### PR TITLE
feat(gr26): add BCU CAN message signal definitions

### DIFF
--- a/gr26/model/bcu.go
+++ b/gr26/model/bcu.go
@@ -1,0 +1,156 @@
+package model
+
+import (
+	"fmt"
+
+	mp "github.com/gaucho-racing/mapache/mapache-go/v3"
+)
+
+var BCUStatus1 = mp.Message{
+	mp.NewField("accumulator_voltage", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "accumulator_voltage", Value: float64(f.Value) * 0.01, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("ts_voltage", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "ts_voltage", Value: float64(f.Value) * 0.01, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("accumulator_current", 2, mp.Signed, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "accumulator_current", Value: float64(f.Value) * 0.01, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("accumulator_soc", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "accumulator_soc", Value: float64(f.Value) * 20.0 / 51.0, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("glv_soc", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "glv_soc", Value: float64(f.Value) * 20.0 / 51.0, RawValue: f.Value},
+		}
+	}),
+}
+
+var BCUStatus2 = mp.Message{
+	mp.NewField("20v_voltage", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "20v_voltage", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("12v_voltage", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "12v_voltage", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("sdc_voltage", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "sdc_voltage", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("min_cell_voltage", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "min_cell_voltage", Value: float64(f.Value)*0.01 + 2.0, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("max_cell_temp", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "max_cell_temp", Value: float64(f.Value) * 0.25, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("status_flags", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "status_flags", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("precharge_latch_flags", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "precharge_latch_flags", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+}
+
+var BCUStatus3 = mp.Message{
+	mp.NewField("hv_input_voltage", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "hv_input_voltage", Value: float64(f.Value) * 0.01, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("hv_output_voltage", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "hv_output_voltage", Value: float64(f.Value) * 0.01, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("hv_input_current", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "hv_input_current", Value: float64(f.Value) * 0.001, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("hv_output_current", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "hv_output_current", Value: float64(f.Value) * 0.001, RawValue: f.Value},
+		}
+	}),
+}
+
+var BCUPrecharge = mp.Message{
+	mp.NewField("set_ts_active", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "set_ts_active", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+}
+
+var BCUConfigChargeParameters = mp.Message{
+	mp.NewField("charge_voltage", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "charge_voltage", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("charge_current", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "charge_current", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+}
+
+var BCUConfigOperationalParameters = mp.Message{
+	mp.NewField("min_cell_voltage", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "min_cell_voltage", Value: float64(f.Value)*0.01 + 2.0, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("max_cell_temp", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "max_cell_temp", Value: float64(f.Value) * 0.25, RawValue: f.Value},
+		}
+	}),
+}
+
+func cellDataMessage(startCell int) mp.Message {
+	msg := mp.Message{}
+	for i := 0; i < 32; i++ {
+		cell := startCell + i
+		voltageName := fmt.Sprintf("cell_%d_voltage", cell)
+		tempName := fmt.Sprintf("cell_%d_temp", cell)
+		msg = append(msg, mp.NewField(voltageName, 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+			return []mp.Signal{
+				{Name: f.Name, Value: float64(f.Value)*0.01 + 2.0, RawValue: f.Value},
+			}
+		}))
+		msg = append(msg, mp.NewField(tempName, 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+			return []mp.Signal{
+				{Name: f.Name, Value: float64(f.Value) * 0.25, RawValue: f.Value},
+			}
+		}))
+	}
+	return msg
+}
+
+var BCUCellData1 = cellDataMessage(0)
+var BCUCellData2 = cellDataMessage(32)
+var BCUCellData3 = cellDataMessage(64)
+var BCUCellData4 = cellDataMessage(96)
+var BCUCellData5 = cellDataMessage(128)

--- a/gr26/model/message.go
+++ b/gr26/model/message.go
@@ -3,6 +3,17 @@ package model
 import mp "github.com/gaucho-racing/mapache/mapache-go/v3"
 
 var messageMap = map[int]mp.Message{
+	0x007: BCUStatus1,
+	0x008: BCUStatus2,
+	0x009: BCUStatus3,
+	0x00A: BCUPrecharge,
+	0x00B: BCUConfigChargeParameters,
+	0x00C: BCUConfigOperationalParameters,
+	0x00D: BCUCellData1,
+	0x00E: BCUCellData2,
+	0x00F: BCUCellData3,
+	0x010: BCUCellData4,
+	0x011: BCUCellData5,
 	0x02A: TCMResourceUtil,
 	0x030: DGPS_UVW,
 	0x031: GPSLatitude,


### PR DESCRIPTION
- Add BCU Status 1 signals: accumulator/TS voltage, accumulator current (signed), accumulator/GLV SoC
- Add BCU Status 2 signals: 20v/12v/SDC voltages, min cell voltage, max cell temp, status flags, precharge latch flags
- Add BCU Status 3 signals: HV input/output voltage and current
- Add BCU Precharge signal: set_ts_active
- Add BCU Config Charge Parameters: charge voltage/current
- Add BCU Config Operational Parameters: min cell voltage, max cell temp thresholds
- Add BCU Cell Data 1-5: 160 cells total (32 per message), each with voltage (0.01x+2 scaling) and temperature (0.25x scaling)
- Uses `cellDataMessage()` helper to generate the repetitive cell data field definitions