### PR TITLE
feat(gr26): add inverter, fan, dash, TCM status, and DTI signal definitions

### DIFF
--- a/gr26/model/dash.go
+++ b/gr26/model/dash.go
@@ -1,0 +1,19 @@
+package model
+
+import mp "github.com/gaucho-racing/mapache/mapache-go/v3"
+
+var DashStatus = mp.Message{
+	mp.NewField("button_led_flags", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "button_led_flags", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+}
+
+var DashConfig = mp.Message{
+	mp.NewField("led_latch_flags", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "led_latch_flags", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+}

--- a/gr26/model/dti.go
+++ b/gr26/model/dti.go
@@ -1,0 +1,107 @@
+package model
+
+import mp "github.com/gaucho-racing/mapache/mapache-go/v3"
+
+var DTIData1 = mp.Message{
+	mp.NewField("erpm", 4, mp.Signed, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "erpm", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("duty_cycle", 2, mp.Signed, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "duty_cycle", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("input_voltage", 2, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "input_voltage", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+}
+
+var DTIData2 = mp.Message{
+	mp.NewField("ac_current", 2, mp.Signed, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "ac_current", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("dc_current", 2, mp.Signed, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "dc_current", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("_reserved", 4, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return nil
+	}),
+}
+
+var DTIData3 = mp.Message{
+	mp.NewField("controller_temp", 2, mp.Signed, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "controller_temp", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("motor_temp", 2, mp.Signed, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "motor_temp", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("fault_codes", 1, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "fault_codes", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("_reserved", 3, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return nil
+	}),
+}
+
+var DTIData4 = mp.Message{
+	mp.NewField("foc_id", 4, mp.Signed, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "foc_id", Value: float64(f.Value) * 0.01, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("foc_iq", 4, mp.Signed, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "foc_iq", Value: float64(f.Value) * 0.01, RawValue: f.Value},
+		}
+	}),
+}
+
+var DTIData5 = mp.Message{
+	mp.NewField("throttle", 1, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "throttle", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("brake", 1, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "brake", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("digital_io", 1, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "digital_io", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("drive_enable", 1, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "drive_enable", Value: float64(f.Value & 0x01), RawValue: f.Value & 0x01},
+		}
+	}),
+	mp.NewField("limit_flags", 2, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "limit_flags", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("_reserved", 1, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return nil
+	}),
+	mp.NewField("can_version", 1, mp.Unsigned, mp.BigEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "can_version", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+}

--- a/gr26/model/fan.go
+++ b/gr26/model/fan.go
@@ -1,0 +1,29 @@
+package model
+
+import mp "github.com/gaucho-racing/mapache/mapache-go/v3"
+
+var FanStatus = mp.Message{
+	mp.NewField("fan_speed", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "fan_speed", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("input_voltage", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "input_voltage", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("input_current", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "input_current", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+}
+
+var FanCommand = mp.Message{
+	mp.NewField("fan_command", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "fan_command", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+}

--- a/gr26/model/inverter.go
+++ b/gr26/model/inverter.go
@@ -1,0 +1,106 @@
+package model
+
+import mp "github.com/gaucho-racing/mapache/mapache-go/v3"
+
+var InverterStatus1 = mp.Message{
+	mp.NewField("ac_current", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "ac_current", Value: float64(f.Value)*0.01 - 327.68, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("dc_current", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "dc_current", Value: float64(f.Value) * 0.01, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("motor_rpm", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "motor_rpm", Value: float64(f.Value) - 32768, RawValue: f.Value},
+		}
+	}),
+}
+
+var InverterStatus2 = mp.Message{
+	mp.NewField("u_mosfet_temp", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "u_mosfet_temp", Value: float64(f.Value&0xFF) - 40, RawValue: f.Value & 0xFF},
+		}
+	}),
+	mp.NewField("v_mosfet_temp", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "v_mosfet_temp", Value: float64(f.Value&0xFF) - 40, RawValue: f.Value & 0xFF},
+		}
+	}),
+	mp.NewField("w_mosfet_temp", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "w_mosfet_temp", Value: float64(f.Value&0xFF) - 40, RawValue: f.Value & 0xFF},
+		}
+	}),
+}
+
+var InverterStatus3 = mp.Message{
+	mp.NewField("motor_temp", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "motor_temp", Value: float64(f.Value) - 40, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("_padding", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return nil
+	}),
+	mp.NewField("fault_bits", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "fault_bits", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+}
+
+var InverterConfig = mp.Message{
+	mp.NewField("max_ac_current", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "max_ac_current", Value: float64(f.Value)*0.01 - 327.68, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("max_dc_current", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "max_dc_current", Value: float64(f.Value)*0.01 - 327.68, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("absolute_max_rpm", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "absolute_max_rpm", Value: float64(f.Value) - 32768, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("motor_direction", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "motor_direction", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+}
+
+var InverterCommand = mp.Message{
+	mp.NewField("set_ac_current", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "set_ac_current", Value: float64(f.Value)*0.01 - 327.68, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("set_dc_current", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "set_dc_current", Value: float64(f.Value)*0.01 - 327.68, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("rpm_limit", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "rpm_limit", Value: float64(f.Value) - 32768, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("field_weakening", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "field_weakening", Value: float64(f.Value) * 0.1, RawValue: f.Value},
+		}
+	}),
+	mp.NewField("drive_enable", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "drive_enable", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+}

--- a/gr26/model/message.go
+++ b/gr26/model/message.go
@@ -3,7 +3,22 @@ package model
 import mp "github.com/gaucho-racing/mapache/mapache-go/v3"
 
 var messageMap = map[int]mp.Message{
+	// GR Inverter
+	0x013: InverterStatus1,
+	0x014: InverterStatus2,
+	0x015: InverterStatus3,
+	0x016: InverterConfig,
+	0x017: InverterCommand,
+	// Fan
+	0x018: FanStatus,
+	0x019: FanCommand,
+	// Dash
+	0x01A: DashStatus,
+	0x01B: DashConfig,
+	// TCM
+	0x029: TCMStatus,
 	0x02A: TCMResourceUtil,
+	// GPS
 	0x030: DGPS_UVW,
 	0x031: GPSLatitude,
 	0x032: GPSLongitude,
@@ -11,6 +26,12 @@ var messageMap = map[int]mp.Message{
 	0x034: GPSPx,
 	0x035: GPSQy,
 	0x036: GPSRz,
+	// DTI Inverter (custom CAN IDs)
+	0x2016: DTIData1,
+	0x2116: DTIData2,
+	0x2216: DTIData3,
+	0x2316: DTIData4,
+	0x2416: DTIData5,
 }
 
 func GetMessage(id int) mp.Message {

--- a/gr26/model/tcm.go
+++ b/gr26/model/tcm.go
@@ -2,6 +2,27 @@ package model
 
 import mp "github.com/gaucho-racing/mapache/mapache-go/v3"
 
+var TCMStatus = mp.Message{
+	mp.NewField("status_bits", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "status_bits", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("mapache_ping", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "mapache_ping", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("cache_size", 4, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return []mp.Signal{
+			{Name: "cache_size", Value: float64(f.Value), RawValue: f.Value},
+		}
+	}),
+	mp.NewField("_reserved", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return nil
+	}),
+}
+
 var TCMResourceUtil = mp.Message{
 	mp.NewField("cpu0_freq", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
 		signals := []mp.Signal{}


### PR DESCRIPTION
- Add Inverter Status 1 signals: AC/DC current, motor RPM (with offset scaling)
- Add Inverter Status 2 signals: U/V/W MOSFET temps (handles byte padding between fields)
- Add Inverter Status 3 signals: motor temp, fault bits
- Add Inverter Config signals: max AC/DC current, absolute max RPM, motor direction
- Add Inverter Command signals: set AC/DC current, RPM limit, field weakening, drive enable
- Add Fan Status signals: fan speed, input voltage/current
- Add Fan Command signal: fan command percentage
- Add Dash Status/Config signals: button/LED flag bitfields
- Add TCM Status signals: status bits, mapache ping latency, cache size
- Add DTI Data 1-5 signals (big-endian VESC protocol): ERPM, duty cycle, input voltage, AC/DC current, controller/motor temp, fault codes, FOC Id/Iq, throttle/brake, digital I/O, limit flags, CAN version