### PR TITLE
feat(gr26): add env vars to toggle signal DB writes and WS publishing

### DIFF
--- a/gr26/config/config.go
+++ b/gr26/config/config.go
@@ -22,6 +22,8 @@ var Routes = []rincon.Route{
 
 var SkipAuthCheck = os.Getenv("SKIP_AUTH_CHECK") == "true"
 var VehicleUploadKeyCacheTTL = os.Getenv("VEHICLE_UPLOAD_KEY_CACHE_TTL")
+var EnableSignalDB = os.Getenv("ENABLE_SIGNAL_DB") != "false"
+var EnableSignalWS = os.Getenv("ENABLE_SIGNAL_WS") != "false"
 
 var Env = os.Getenv("ENV")
 var Port = os.Getenv("PORT")

--- a/gr26/service/signal.go
+++ b/gr26/service/signal.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 
+	"github.com/gaucho-racing/mapache/gr26/config"
 	"github.com/gaucho-racing/mapache/gr26/database"
 	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
 
@@ -28,22 +29,26 @@ func CreateSignal(signal mapache.Signal) error {
 		return fmt.Errorf("signal name cannot be empty")
 	}
 	signal.ID = ulid.Make().Prefixed("sgnl")
-	Hub.Publish(signal)
-	if database.DB.Where("timestamp = ?", signal.Timestamp).Where("vehicle_id = ?", signal.VehicleID).Where("name = ?", signal.Name).Updates(&signal).RowsAffected == 0 {
-		logger.SugarLogger.Infow("[DB] New signal created",
-			"timestamp", signal.Timestamp,
-			"vehicle_id", signal.VehicleID,
-			"name", signal.Name,
-		)
-		if result := database.DB.Create(&signal); result.Error != nil {
-			return result.Error
+	if config.EnableSignalWS {
+		Hub.Publish(signal)
+	}
+	if config.EnableSignalDB {
+		if database.DB.Where("timestamp = ?", signal.Timestamp).Where("vehicle_id = ?", signal.VehicleID).Where("name = ?", signal.Name).Updates(&signal).RowsAffected == 0 {
+			logger.SugarLogger.Infow("[DB] New signal created",
+				"timestamp", signal.Timestamp,
+				"vehicle_id", signal.VehicleID,
+				"name", signal.Name,
+			)
+			if result := database.DB.Create(&signal); result.Error != nil {
+				return result.Error
+			}
+		} else {
+			logger.SugarLogger.Infow("[DB] Existing signal updated",
+				"timestamp", signal.Timestamp,
+				"vehicle_id", signal.VehicleID,
+				"name", signal.Name,
+			)
 		}
-	} else {
-		logger.SugarLogger.Infow("[DB] Existing signal updated",
-			"timestamp", signal.Timestamp,
-			"vehicle_id", signal.VehicleID,
-			"name", signal.Name,
-		)
 	}
 	return nil
 }
@@ -61,15 +66,19 @@ func CreateSignals(signals []mapache.Signal) error {
 		}
 		signals[i].ID = ulid.Make().Prefixed("sgnl")
 	}
-	for _, signal := range signals {
-		Hub.Publish(signal)
+	if config.EnableSignalWS {
+		for _, signal := range signals {
+			Hub.Publish(signal)
+		}
 	}
-	result := database.DB.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "timestamp"}, {Name: "vehicle_id"}, {Name: "name"}},
-		DoUpdates: clause.AssignmentColumns([]string{"id", "value", "raw_value", "produced_at"}),
-	}).Create(&signals)
-	if result.Error != nil {
-		return result.Error
+	if config.EnableSignalDB {
+		result := database.DB.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "timestamp"}, {Name: "vehicle_id"}, {Name: "name"}},
+			DoUpdates: clause.AssignmentColumns([]string{"id", "value", "raw_value", "produced_at"}),
+		}).Create(&signals)
+		if result.Error != nil {
+			return result.Error
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
- Add `ENABLE_SIGNAL_DB` env var (default: true, set to "false" to disable) — gates PostgreSQL signal persistence
- Add `ENABLE_SIGNAL_WS` env var (default: true, set to "false" to disable) — gates WebSocket signal publishing to subscribers
- Applied to both `CreateSignal` and `CreateSignals` code paths