### PR TITLE
chore: use UTC timezone in all service Docker images

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -24,6 +24,6 @@ WORKDIR /
 COPY --from=builder /app /app
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-ENV TZ=America/Los_Angeles
+ENV TZ=UTC
 
 ENTRYPOINT ["/app"]

--- a/gr24/Dockerfile
+++ b/gr24/Dockerfile
@@ -24,6 +24,6 @@ WORKDIR /
 COPY --from=builder /gr24 /gr24
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-ENV TZ=America/Los_Angeles
+ENV TZ=UTC
 
 ENTRYPOINT ["/gr24"]

--- a/gr25/Dockerfile
+++ b/gr25/Dockerfile
@@ -24,6 +24,6 @@ WORKDIR /
 COPY --from=builder /gr25 /gr25
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-ENV TZ=America/Los_Angeles
+ENV TZ=UTC
 
 ENTRYPOINT ["/gr25"]

--- a/gr26/Dockerfile
+++ b/gr26/Dockerfile
@@ -24,6 +24,6 @@ WORKDIR /
 COPY --from=builder /gr26 /gr26
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-ENV TZ=America/Los_Angeles
+ENV TZ=UTC
 
 ENTRYPOINT ["/gr26"]

--- a/vehicle/Dockerfile
+++ b/vehicle/Dockerfile
@@ -24,6 +24,6 @@ WORKDIR /
 COPY --from=builder /app /app
 
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-ENV TZ=America/Los_Angeles
+ENV TZ=UTC
 
 ENTRYPOINT ["/app"]


### PR DESCRIPTION
Standardize on UTC across all backend service Docker images.

- auth, gr24, gr25, gr26, vehicle: `ENV TZ=America/Los_Angeles` → `ENV TZ=UTC`

UTC is the conventional choice for backend services — easier log correlation across services and regions, no twice-yearly DST jumps in log timelines, and Postgres stores timestamps in UTC anyway.