### PR TITLE
fix: pg volume mount layout for pg18+

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -173,7 +173,9 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      # Mount the parent dir, not /var/lib/postgresql/data — pg18+ writes to
+      # a version-specific subdir (e.g. /var/lib/postgresql/18/docker).
+      - pgdata:/var/lib/postgresql
 
 volumes:
   pgdata:


### PR DESCRIPTION
Mount the volume at `/var/lib/postgresql` instead of `/var/lib/postgresql/data` so pg18+ can write to its version-specific subdirectory (`/var/lib/postgresql/18/docker`). Required because pg18 changed the data layout — pre-existing volumes worked by accident, but fresh inits on pg18 fail.

Hit this on the Jetson when running tcm-26 (same fix already pushed there). Mapache hasn't hit it yet but would on any fresh local clone — applying preemptively.

⚠️ Existing local volumes need to be wiped: `docker compose down -v && docker compose up`. No production impact (production DBs aren't managed via this compose).