### PR TITLE
feat(dashboard): add gr26 Pedals widget

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -8,6 +8,7 @@ import Gr26EcuDebugWidget from "./components/widgets/gr26/live/EcuDebugWidget";
 import Gr26BcuDebugWidget from "./components/widgets/gr26/live/BcuDebugWidget";
 import Gr26DtiDebugWidget from "./components/widgets/gr26/live/DtiDebugWidget";
 import Gr26InverterDebugWidget from "./components/widgets/gr26/live/InverterDebugWidget";
+import Gr26PedalsWidget from "./components/widgets/gr26/live/PedalsWidget";
 import { TimeProvider } from "./context/time-context";
 import { useVehicle } from "./lib/store";
 
@@ -38,6 +39,7 @@ function DashboardContent() {
             />
             <TcmCpuWidget vehicle_id={vehicle.id} showDeltaBanner />
             <TcmCpuGraphWidget vehicle_id={vehicle.id} showDeltaBanner />
+            <Gr26PedalsWidget vehicle_id={vehicle.id} showDeltaBanner />
             <Gr26EcuDebugWidget vehicle_id={vehicle.id} showDeltaBanner />
             <Gr26BcuDebugWidget vehicle_id={vehicle.id} showDeltaBanner />
             <Gr26DtiDebugWidget vehicle_id={vehicle.id} showDeltaBanner />

--- a/dashboard/src/components/widgets/gr26/live/PedalsWidget.tsx
+++ b/dashboard/src/components/widgets/gr26/live/PedalsWidget.tsx
@@ -1,0 +1,67 @@
+import { Progress } from "@/components/ui/progress";
+import { Separator } from "@/components/ui/separator";
+import LiveWidget from "@/components/widgets/LiveWidget";
+
+interface PedalsWidgetProps {
+  vehicle_id: string;
+  showDeltaBanner?: boolean;
+}
+
+export default function PedalsWidget({
+  vehicle_id,
+  showDeltaBanner = false,
+}: PedalsWidgetProps) {
+  const signals = ["ecu_apps1_signal", "ecu_apps2_signal"];
+
+  return (
+    <LiveWidget
+      vehicle_id={vehicle_id}
+      signals={signals}
+      showDeltaBanner={showDeltaBanner}
+      alwaysShowData={true}
+      width={400}
+      height={300}
+    >
+      {(_, currentSignals) => {
+        const apps1 = currentSignals.get("ecu_apps1_signal");
+        const apps2 = currentSignals.get("ecu_apps2_signal");
+        return (
+          <div className="h-full w-full p-4">
+            <h1 className="mb-2 text-2xl font-bold">Pedals</h1>
+            <div className="flex items-center justify-center">
+              <div className="w-1/3 text-start">
+                <p>APPS 1:</p>
+                <h3>{(apps1?.value ?? 0).toFixed(2)}</h3>
+              </div>
+              <div className="w-2/3">
+                <Progress value={Math.floor(apps1?.value ?? 0)} />
+              </div>
+            </div>
+            <div className="flex items-center justify-center">
+              <div className="w-1/3 text-start">
+                <p>APPS 2:</p>
+                <h3>{(apps2?.value ?? 0).toFixed(2)}</h3>
+              </div>
+              <div className="w-2/3">
+                <Progress value={Math.floor(apps2?.value ?? 0)} />
+              </div>
+            </div>
+            <Separator className="my-2" />
+            <div className="flex items-center justify-between">
+              <div className="w-1/2 text-start">
+                <p>APPS 1 RAW:</p>
+              </div>
+              <h3>{apps1?.raw_value ?? 0}</h3>
+            </div>
+            <div className="flex items-center justify-between">
+              <div className="w-1/2 text-start">
+                <p>APPS 2 RAW:</p>
+              </div>
+              <h3>{apps2?.raw_value ?? 0}</h3>
+            </div>
+          </div>
+        );
+      }}
+    </LiveWidget>
+  );
+}

--- a/dashboard/src/components/widgets/registry.tsx
+++ b/dashboard/src/components/widgets/registry.tsx
@@ -4,9 +4,11 @@ import {
   BatteryFull,
   Bug,
   CirclePlus,
+  Gauge,
   LucideIcon,
   MapIcon,
 } from "lucide-react";
+import Gr26PedalsWidget from "@/components/widgets/gr26/live/PedalsWidget";
 import MobileDebugWidget from "@/components/widgets/gr24/MobileDebugWidget";
 import AcuDebugWidget from "@/components/widgets/gr24/AcuDebugWidget";
 import PedalsDebugWidget from "@/components/widgets/gr24/PedalsDebugWidget";
@@ -29,6 +31,20 @@ export const getWidgetRegistry = (vehicle_type: string) => {
     return gr24_registry;
   }
   return {};
+};
+
+export const gr26_registry = {
+  Pedal: [
+    {
+      id: "pedals-full",
+      name: "Pedals",
+      description:
+        "Shows both raw and scaled APPS pedal positions from both position sensors.",
+      component: Gr26PedalsWidget,
+      icon: Gauge,
+      preview: "/widgets/gr24/pedals-full.png",
+    },
+  ],
 };
 
 export const gr24_registry = {

--- a/dashboard/src/pages/widgets/WidgetsPage.tsx
+++ b/dashboard/src/pages/widgets/WidgetsPage.tsx
@@ -1,6 +1,6 @@
 import Layout from "@/components/Layout";
 import { Card } from "@/components/ui/card";
-import { gr24_registry } from "@/components/widgets/registry";
+import { gr24_registry, gr26_registry } from "@/components/widgets/registry";
 import { useVehicle } from "@/lib/store";
 import { WidgetEntry } from "@/components/widgets/registry";
 
@@ -10,6 +10,9 @@ function WidgetsPage() {
   const getRegistry = () => {
     if (vehicle.type === "gr24") {
       return gr24_registry;
+    }
+    if (vehicle.type === "gr26") {
+      return gr26_registry;
     }
     return {};
   };


### PR DESCRIPTION
Recreate the gr24 APPS pedals widget for gr26 on the live WebSocket data path. Reads ecu_apps1_signal/ecu_apps2_signal from the ECU analog data message and shows scaled progress bars plus raw values. Wires it into the gr26 dashboard (App.tsx) and registers it in the gr26 widgets catalog (registry.tsx, WidgetsPage.tsx).