### PR TITLE
fix: call /sessions instead of /trips after Trip->Session rename

### DIFF
--- a/dashboard/src/components/trips/TripDetailsDialog.tsx
+++ b/dashboard/src/components/trips/TripDetailsDialog.tsx
@@ -41,7 +41,7 @@ export function TripDetailsDialog({
   const updateTrip = async () => {
     try {
       const response = await axios.post(
-        `${BACKEND_URL}/trips/${trip.id}`,
+        `${BACKEND_URL}/sessions/${trip.id}`,
         editedTrip,
         {
           headers: {

--- a/dashboard/src/pages/query/QueryPage.tsx
+++ b/dashboard/src/pages/query/QueryPage.tsx
@@ -215,7 +215,7 @@ function QueryPage() {
   const getAvailableTrips = async () => {
     try {
       const response = await axios.get(
-        `${BACKEND_URL}/trips?vehicle_type=${vehicle.type}`,
+        `${BACKEND_URL}/sessions?vehicle_type=${vehicle.type}`,
         {
           headers: {
             Authorization: `Bearer ${localStorage.getItem("sentinel_access_token")}`,

--- a/dashboard/src/pages/trips/TripDetailsPage.tsx
+++ b/dashboard/src/pages/trips/TripDetailsPage.tsx
@@ -172,7 +172,7 @@ function TripDetailsPage() {
 
   const getTrip = async (id: string) => {
     try {
-      const response = await axios.get(`${BACKEND_URL}/trips/${id}`, {
+      const response = await axios.get(`${BACKEND_URL}/sessions/${id}`, {
         headers: {
           Authorization: `Bearer ${localStorage.getItem("sentinel_access_token")}`,
         },

--- a/dashboard/src/pages/trips/TripsPage.tsx
+++ b/dashboard/src/pages/trips/TripsPage.tsx
@@ -22,7 +22,7 @@ function TripsPage() {
   const getTrips = async () => {
     try {
       const response = await axios.get(
-        `${BACKEND_URL}/trips?vehicle_id=${vehicle.id}`,
+        `${BACKEND_URL}/sessions?vehicle_id=${vehicle.id}`,
         {
           headers: {
             Authorization: `Bearer ${localStorage.getItem("sentinel_access_token")}`,

--- a/query/query/service/trip.py
+++ b/query/query/service/trip.py
@@ -8,7 +8,7 @@ from query.service.rincon import match_route
 
 def get_all_trips() -> list[dict[str, Any]]:
     try:
-        route = "/trips"
+        route = "/sessions"
         service = match_route(route, "GET")
         r = requests.get(f"{service.endpoint}{route}")
         return r.json()
@@ -19,7 +19,7 @@ def get_all_trips() -> list[dict[str, Any]]:
 
 def get_trip_by_id(trip_id: str) -> dict[str, Any]:
     try:
-        route = f"/trips/{trip_id}"
+        route = f"/sessions/{trip_id}"
         service = match_route(route, "GET")
         r = requests.get(f"{service.endpoint}{route}")
         return r.json()


### PR DESCRIPTION
The vehicle service was refactored to expose /sessions (Trip/Lap -> Session/Marker), but the frontend trips/query pages and the query service's trip lookup still called the unregistered /trips route, producing network errors. Repoint those API calls at /sessions. Client-side router paths are unchanged.