### PR TITLE
feat(mapache-go): add Session.Analysis jsonb field for Lapache

### DIFF
--- a/mapache-go/json.go
+++ b/mapache-go/json.go
@@ -36,7 +36,7 @@ func (j *JSON) Scan(value any) error {
 
 func (j JSON) MarshalJSON() ([]byte, error) {
 	if len(j) == 0 {
-		return []byte("null"), nil
+		return []byte("{}"), nil
 	}
 	return j, nil
 }

--- a/mapache-go/json.go
+++ b/mapache-go/json.go
@@ -1,0 +1,50 @@
+package mapache
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// JSON is a raw JSON value stored in a Postgres jsonb column. It marshals to and
+// from JSON as-is (so it nests transparently inside a struct's JSON), and its
+// Valuer returns a string so the database driver sends it as text for an
+// implicit cast to jsonb rather than encoding the bytes as bytea.
+type JSON []byte
+
+func (j JSON) Value() (driver.Value, error) {
+	if len(j) == 0 {
+		return nil, nil
+	}
+	return string(j), nil
+}
+
+func (j *JSON) Scan(value any) error {
+	if value == nil {
+		*j = nil
+		return nil
+	}
+	switch v := value.(type) {
+	case []byte:
+		*j = append((*j)[0:0], v...)
+	case string:
+		*j = append((*j)[0:0], v...)
+	default:
+		return fmt.Errorf("unsupported type for JSON: %T", value)
+	}
+	return nil
+}
+
+func (j JSON) MarshalJSON() ([]byte, error) {
+	if len(j) == 0 {
+		return []byte("null"), nil
+	}
+	return j, nil
+}
+
+func (j *JSON) UnmarshalJSON(data []byte) error {
+	if j == nil {
+		return fmt.Errorf("JSON: UnmarshalJSON on nil pointer")
+	}
+	*j = append((*j)[0:0], data...)
+	return nil
+}

--- a/mapache-go/json_test.go
+++ b/mapache-go/json_test.go
@@ -1,0 +1,64 @@
+package mapache
+
+import "testing"
+
+func TestJSON_ValueReturnsStringForJSONB(t *testing.T) {
+	j := JSON(`{"a":1}`)
+	v, err := j.Value()
+	if err != nil {
+		t.Fatalf("Value failed: %v", err)
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("expected string driver value (for implicit jsonb cast), got %T", v)
+	}
+	if s != `{"a":1}` {
+		t.Errorf("got %q, want %q", s, `{"a":1}`)
+	}
+}
+
+func TestJSON_ValueNilWhenEmpty(t *testing.T) {
+	var j JSON
+	v, err := j.Value()
+	if err != nil {
+		t.Fatalf("Value failed: %v", err)
+	}
+	if v != nil {
+		t.Errorf("expected nil driver value for empty JSON, got %v", v)
+	}
+}
+
+func TestJSON_ScanFromBytesAndString(t *testing.T) {
+	var fromBytes JSON
+	if err := fromBytes.Scan([]byte(`{"b":2}`)); err != nil {
+		t.Fatalf("Scan([]byte) failed: %v", err)
+	}
+	if string(fromBytes) != `{"b":2}` {
+		t.Errorf("got %q", fromBytes)
+	}
+
+	var fromString JSON
+	if err := fromString.Scan(`{"c":3}`); err != nil {
+		t.Fatalf("Scan(string) failed: %v", err)
+	}
+	if string(fromString) != `{"c":3}` {
+		t.Errorf("got %q", fromString)
+	}
+}
+
+func TestJSON_ScanNil(t *testing.T) {
+	j := JSON(`{"old":1}`)
+	if err := j.Scan(nil); err != nil {
+		t.Fatalf("Scan(nil) failed: %v", err)
+	}
+	if j != nil {
+		t.Errorf("expected nil after scanning nil, got %q", j)
+	}
+}
+
+func TestJSON_ScanUnsupportedType(t *testing.T) {
+	var j JSON
+	if err := j.Scan(42); err == nil {
+		t.Error("expected error scanning unsupported type, got nil")
+	}
+}

--- a/mapache-go/vehicle.go
+++ b/mapache-go/vehicle.go
@@ -26,8 +26,12 @@ type Session struct {
 	Description string    `json:"description"`
 	StartTime   time.Time `json:"start_time" gorm:"precision:6"`
 	EndTime     time.Time `json:"end_time" gorm:"precision:6"`
-	Markers     []Marker  `json:"markers" gorm:"-"`
-	Segments    []Segment `json:"segments" gorm:"-"`
+	// Analysis holds the Lapache lap-analysis result as a JSON blob: chosen
+	// lat/lon signal fields, normalization mode, crop window, geometric S/F and
+	// sector lines, computed laps, and summary. Null until a result is pushed.
+	Analysis JSON      `json:"analysis" gorm:"type:jsonb"`
+	Markers  []Marker  `json:"markers" gorm:"-"`
+	Segments []Segment `json:"segments" gorm:"-"`
 }
 
 func (Session) TableName() string {

--- a/mapache-go/vehicle.go
+++ b/mapache-go/vehicle.go
@@ -26,10 +26,8 @@ type Session struct {
 	Description string    `json:"description"`
 	StartTime   time.Time `json:"start_time" gorm:"precision:6"`
 	EndTime     time.Time `json:"end_time" gorm:"precision:6"`
-	// Analysis holds the Lapache lap-analysis result as a JSON blob: chosen
-	// lat/lon signal fields, normalization mode, crop window, geometric S/F and
-	// sector lines, computed laps, and summary. Null until a result is pushed.
-	Analysis JSON      `json:"analysis" gorm:"type:jsonb"`
+	// Analysis holds the Lapache lap-analysis result as a jsonb blob.
+	Analysis JSON      `json:"analysis" gorm:"type:jsonb;default:'{}'"`
 	Markers  []Marker  `json:"markers" gorm:"-"`
 	Segments []Segment `json:"segments" gorm:"-"`
 }

--- a/mapache-go/vehicle_test.go
+++ b/mapache-go/vehicle_test.go
@@ -1,9 +1,58 @@
 package mapache
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
+
+func TestSession_AnalysisRoundTrip(t *testing.T) {
+	analysis := JSON(`{"lat_field":"gps_lat","lon_field":"gps_lon","norm_mode":"WGS84","laps":[{"lap":1,"total":42.5}]}`)
+	in := Session{
+		ID:        "ssn_123",
+		VehicleID: "gr26",
+		Name:      "Autocross Run 1",
+		Analysis:  analysis,
+	}
+
+	encoded, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		t.Fatalf("unmarshal to map failed: %v", err)
+	}
+	if _, ok := raw["analysis"]; !ok {
+		t.Fatal("expected 'analysis' key in serialized session")
+	}
+
+	var out Session
+	if err := json.Unmarshal(encoded, &out); err != nil {
+		t.Fatalf("unmarshal to session failed: %v", err)
+	}
+	if string(out.Analysis) != string(analysis) {
+		t.Errorf("analysis round-trip mismatch: got %s, want %s", out.Analysis, analysis)
+	}
+}
+
+func TestSession_AnalysisOmittedWhenNil(t *testing.T) {
+	in := Session{ID: "ssn_456", VehicleID: "gr26"}
+	encoded, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &raw); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	// A nil RawMessage marshals to JSON null; ensure that's what we get
+	// (so an un-analyzed session reports analysis: null, not garbage).
+	if string(raw["analysis"]) != "null" {
+		t.Errorf("expected analysis to be null when unset, got %s", raw["analysis"])
+	}
+}
 
 func TestVehicle_TableName(t *testing.T) {
 	v := Vehicle{}

--- a/mapache-go/vehicle_test.go
+++ b/mapache-go/vehicle_test.go
@@ -37,7 +37,7 @@ func TestSession_AnalysisRoundTrip(t *testing.T) {
 	}
 }
 
-func TestSession_AnalysisOmittedWhenNil(t *testing.T) {
+func TestSession_AnalysisDefaultsToEmptyObject(t *testing.T) {
 	in := Session{ID: "ssn_456", VehicleID: "gr26"}
 	encoded, err := json.Marshal(in)
 	if err != nil {
@@ -47,10 +47,9 @@ func TestSession_AnalysisOmittedWhenNil(t *testing.T) {
 	if err := json.Unmarshal(encoded, &raw); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
-	// A nil RawMessage marshals to JSON null; ensure that's what we get
-	// (so an un-analyzed session reports analysis: null, not garbage).
-	if string(raw["analysis"]) != "null" {
-		t.Errorf("expected analysis to be null when unset, got %s", raw["analysis"])
+	// An un-analyzed session reports analysis: {} rather than null.
+	if string(raw["analysis"]) != "{}" {
+		t.Errorf("expected analysis to default to {} when unset, got %s", raw["analysis"])
 	}
 }
 

--- a/vehicle/go.mod
+++ b/vehicle/go.mod
@@ -2,6 +2,8 @@ module github.com/gaucho-racing/mapache/vehicle
 
 go 1.26
 
+replace github.com/gaucho-racing/mapache/mapache-go/v3 => ../mapache-go
+
 require (
 	github.com/bk1031/rincon-go/v2 v2.0.0
 	github.com/fatih/color v1.18.0

--- a/vehicle/go.mod
+++ b/vehicle/go.mod
@@ -2,8 +2,6 @@ module github.com/gaucho-racing/mapache/vehicle
 
 go 1.26
 
-replace github.com/gaucho-racing/mapache/mapache-go/v3 => ../mapache-go
-
 require (
 	github.com/bk1031/rincon-go/v2 v2.0.0
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
Adds a JSON helper type backing a jsonb column and an Analysis field on Session to hold Lapache lap-analysis results. Points the vehicle service at the local mapache-go via a replace directive so it builds against the unpublished schema. AutoMigrate adds the column on boot.