### PR TITLE
fix(query): DB URL escaping + expanding bindparam for signal IN clause

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 *.env
 tmp/
 
+# Local docker compose overrides (e.g. pointing a service at a remote DB
+# for testing). Kept out of git so they don't affect others' local stacks.
+docker-compose.override.yml
+docker-compose.override.yaml
+
 # === K8S ===
 k8s/db-config.yaml
 k8s/sentinel-config.yaml

--- a/query/query/config/config.py
+++ b/query/query/config/config.py
@@ -1,5 +1,7 @@
 import os
 
+from sqlalchemy import URL
+
 class Config:
     """Configuration settings for the application"""
     
@@ -28,6 +30,17 @@ class Config:
     SENTINEL_CLIENT_ID: str = os.getenv('SENTINEL_CLIENT_ID')
 
     @staticmethod
-    def get_database_url() -> str:
-        return f"postgresql+psycopg2://{Config.DATABASE_USER}:{Config.DATABASE_PASSWORD}@{Config.DATABASE_HOST}:{Config.DATABASE_PORT}/{Config.DATABASE_NAME}"
+    def get_database_url() -> URL:
+        # Build via URL.create rather than an f-string so credentials with
+        # special characters (e.g. '@', '%', or non-ASCII bytes in the
+        # password) are escaped instead of corrupting the DSN — an unescaped
+        # '@' in the password otherwise bleeds into the host portion.
+        return URL.create(
+            "postgresql+psycopg2",
+            username=Config.DATABASE_USER,
+            password=Config.DATABASE_PASSWORD,
+            host=Config.DATABASE_HOST,
+            port=Config.DATABASE_PORT,
+            database=Config.DATABASE_NAME,
+        )
 

--- a/query/query/service/query.py
+++ b/query/query/service/query.py
@@ -1,7 +1,7 @@
 from loguru import logger
 from query.database.connection import get_db
 import pandas as pd
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 from query.model.query import Metadata
 
 
@@ -9,7 +9,7 @@ def query_signals(vehicle_id: str, signals: list[str], start: str | None = None,
     if not vehicle_id:
         raise ValueError("Vehicle ID is required")
 
-    params = {"vehicle_id": vehicle_id, "signals": tuple(signals)}
+    params = {"vehicle_id": vehicle_id, "signals": list(signals)}
     query_str = """
     SELECT produced_at, name, value
     FROM signal
@@ -25,8 +25,13 @@ def query_signals(vehicle_id: str, signals: list[str], start: str | None = None,
     query_str += " ORDER BY produced_at ASC"
     logger.info(f"Query: {query_str} | Params: {params}")
 
+    # `expanding=True` makes SQLAlchemy render the IN list as individual
+    # placeholders (... IN (:s_1, :s_2)) on every backend, instead of binding
+    # a single tuple param (which only works by accident on psycopg2).
+    stmt = text(query_str).bindparams(bindparam("signals", expanding=True))
+
     with get_db() as db:
-        result = pd.read_sql(text(query_str).bindparams(**params), db.bind)
+        result = pd.read_sql(stmt.bindparams(**params), db.bind)
 
     result["produced_at"] = pd.to_datetime(result["produced_at"], utc=True)
 


### PR DESCRIPTION
## Summary

Pulls the standalone query/infra fixes out of `jake/lapache` so they can land on `main` as a clean foundation, independent of the in-progress Lapache work.

These three commits touch only `service/query.py`, `config/config.py`, and `.gitignore` — no overlap with Lapache files.

## Changes
- **fix(query): use expanding bindparam for signal IN clause** — correctly bind a variable-length list of signal names instead of a single param.
- **fix(query): build DB URL with `URL.create` to escape credentials** — avoid breakage when DB username/password contain URL-special characters.
- **chore: gitignore local docker-compose overrides**

## Notes
Lapache feature work (dashboard pages, `service/cluster.py`, backend endpoints) intentionally stays on `jake/lapache` and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)