### PR TITLE
fix(query): revert {data} envelope double-wrap (#152)

### DIFF
--- a/query/query/routes/query.py
+++ b/query/query/routes/query.py
@@ -144,10 +144,8 @@ async def get_signals(
             return JSONResponse(
                 status_code=200,
                 content={
-                    "data": {
-                        "data": df_dict.to_dict(orient="records"),
-                        "metadata": metadata.to_dict()
-                    }
+                    "data": df_dict.to_dict(orient="records"),
+                    "metadata": metadata.to_dict()
                 }
             )
         elif export == 'csv':

--- a/query/query/routes/signal_definition.py
+++ b/query/query/routes/signal_definition.py
@@ -39,7 +39,7 @@ async def get_signal_definitions(
             definitions = get_all_signal_definitions()
         return JSONResponse(
             status_code=200,
-            content={"data": [definition.to_dict() for definition in definitions]}
+            content=[definition.to_dict() for definition in definitions]
         )
     
     except Exception as e:
@@ -82,7 +82,7 @@ async def get_signal_definition(
             )
         return JSONResponse(
             status_code=200,
-            content={"data": definition.to_dict()}
+            content=definition.to_dict()
         )
     
     except Exception as e:


### PR DESCRIPTION
## Revert of #152

#152 was based on a wrong diagnosis and is causing `data.data.sort is not a function` on the query page. This reverts the two route changes.

### What went wrong
#152 wrapped `/query/definitions` and `/query/signals` responses in `{"data": ...}`. But the **Kerbecs gateway already wraps every proxied response** in its own envelope:

```json
{"status":"SUCCESS","gateway":"Kerbecs v2.2.0","service":"...","data": <raw service body>}
```

Services are supposed to return **bare bodies** — e.g. the Vehicle service returns a bare array and Kerbecs adds the `data` wrapper, which is what the dashboard's `response.data.data` reads.

The extra wrapper produced `{"data":{"data":[...]}}` after the gateway, so `response.data.data` became an **object instead of an array** → `data.data.sort is not a function`.

The #152 verification ran the service directly on `localhost:7700`, **bypassing Kerbecs**, so the double-wrap wasn't visible.

### Why the dropdown was empty originally
The real cause was the DB-credential escaping bug fixed in `f852d33` (`/definitions` was 500ing) — already merged, not an envelope problem.

### This PR
Restores both routes to bare bodies. The Python 3.12 pin from #152 is correct and stays on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)