### PR TITLE
feat(gr26): add pedal bar widget for acc/brake pedal

### DIFF
--- a/dashboard/src/components/widgets/gr26/live/PedalBarWidget.tsx
+++ b/dashboard/src/components/widgets/gr26/live/PedalBarWidget.tsx
@@ -1,0 +1,57 @@
+import LiveWidget from "@/components/widgets/LiveWidget";
+import { Progress } from "@/components/ui/progress";
+import { Signal } from "@/models/signal";
+
+interface PedalBarWidgetProps {
+  vehicle_id: string;
+  showDeltaBanner?: boolean;
+}
+
+export default function PedalBarWidget({
+  vehicle_id,
+  showDeltaBanner = false,
+}: PedalBarWidgetProps) {
+  const signals = ["ecu_acc_pedal", "ecu_brake_pedal"];
+
+  return (
+    <LiveWidget
+      vehicle_id={vehicle_id}
+      signals={signals}
+      showDeltaBanner={showDeltaBanner}
+      alwaysShowData={true}
+      width={400}
+      height={200}
+    >
+      {(_: Map<string, Signal[]>, currentSignals: Map<string, Signal>) => {
+        const accPedal = currentSignals.get("ecu_acc_pedal")?.value ?? 0;
+        const brakePedal = currentSignals.get("ecu_brake_pedal")?.value ?? 0;
+        const accClamped = Math.min(100, Math.max(0, accPedal));
+        const brakeClamped = Math.min(100, Math.max(0, brakePedal));
+
+        return (
+          <div className="h-full w-full p-4">
+            <h1 className="mb-4 text-2xl font-bold">Pedals</h1>
+            <div className="mb-3 flex items-center justify-center">
+              <div className="w-1/3 text-start">
+                <p>APPS:</p>
+                <h3>{accPedal.toFixed(2)}%</h3>
+              </div>
+              <div className="w-2/3">
+                <Progress value={accClamped} />
+              </div>
+            </div>
+            <div className="flex items-center justify-center">
+              <div className="w-1/3 text-start">
+                <p>Brake:</p>
+                <h3>{brakePedal.toFixed(2)}%</h3>
+              </div>
+              <div className="w-2/3">
+                <Progress value={brakeClamped} />
+              </div>
+            </div>
+          </div>
+        );
+      }}
+    </LiveWidget>
+  );
+}

--- a/dashboard/src/components/widgets/registry.tsx
+++ b/dashboard/src/components/widgets/registry.tsx
@@ -14,6 +14,7 @@ import {
   Zap,
 } from "lucide-react";
 import Gr26PedalsWidget from "@/components/widgets/gr26/live/PedalsWidget";
+import Gr26PedalBarWidget from "@/components/widgets/gr26/live/PedalBarWidget";
 import Gr26EcuDebugWidget from "@/components/widgets/gr26/live/EcuDebugWidget";
 import Gr26BcuDebugWidget from "@/components/widgets/gr26/live/BcuDebugWidget";
 import Gr26DtiDebugWidget from "@/components/widgets/gr26/live/DtiDebugWidget";
@@ -124,6 +125,16 @@ export const gr26_registry = {
       icon: Gauge,
       span: 6,
       preview: "/widgets/gr26/pedals-full.png",
+    },
+    {
+      id: "pedal-bar",
+      name: "Pedal Bar",
+      description:
+        "Shows the accelerator pedal position as a 0–100% progress bar.",
+      component: Gr26PedalBarWidget,
+      icon: Gauge,
+      span: 6,
+      preview: "/widgets/gr26/pedal-bar.png",
     },
   ],
   ECU: [

--- a/gr26/model/ecu.go
+++ b/gr26/model/ecu.go
@@ -129,12 +129,12 @@ var ECUAnalogData = mp.Message{
 	}),
 	mp.NewField("acc_pedal", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
 		return []mp.Signal{
-			{Name: "acc_pedal", Value: float64(f.Value), RawValue: f.Value},
+			{Name: "acc_pedal", Value: float64(f.Value) / 655.35, RawValue: f.Value},
 		}
 	}),
 	mp.NewField("brake_pedal", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
 		return []mp.Signal{
-			{Name: "brake_pedal", Value: float64(f.Value), RawValue: f.Value},
+			{Name: "brake_pedal", Value: float64(f.Value) / 655.35, RawValue: f.Value},
 		}
 	}),
 }


### PR DESCRIPTION
Add a progress-bar pedals widget for gr26 using the percentage-scaled ecu_acc_pedal and ecu_brake_pedal signals. Scale acc_pedal to 0-100% in the ECU model.