### PR TITLE
feat(gr26): add GPS distance travelled widget

### DIFF
--- a/dashboard/src/components/widgets/gr26/live/DistanceWidget.tsx
+++ b/dashboard/src/components/widgets/gr26/live/DistanceWidget.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from "react";
+import { RotateCcw } from "lucide-react";
+import LiveWidget from "@/components/widgets/LiveWidget";
+import { Button } from "@/components/ui/button";
+import { Signal } from "@/models/signal";
+
+interface DistanceWidgetProps {
+  vehicle_id: string;
+  showDeltaBanner?: boolean;
+}
+
+const EARTH_RADIUS_M = 6371000;
+
+// Great-circle distance between two lat/lon points in meters.
+function haversine(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return EARTH_RADIUS_M * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function DistanceTracker({
+  lat,
+  lon,
+  lastMessageTime,
+}: {
+  lat: number;
+  lon: number;
+  lastMessageTime: number;
+}) {
+  const [distanceM, setDistanceM] = useState(0);
+  const prevPoint = useRef<{ lat: number; lon: number } | null>(null);
+  // Track the timestamp of the sample we last integrated so we only
+  // accumulate on genuinely new GPS fixes.
+  const lastProcessed = useRef(0);
+
+  useEffect(() => {
+    if (lastMessageTime === lastProcessed.current) return;
+    if (lat === 0 && lon === 0) return;
+    lastProcessed.current = lastMessageTime;
+
+    const prev = prevPoint.current;
+    if (prev) {
+      const step = haversine(prev.lat, prev.lon, lat, lon);
+      // Ignore obviously bogus jumps (e.g. dropped fix snapping to 0,0).
+      if (step < 1000) {
+        setDistanceM((d) => d + step);
+      }
+    }
+    prevPoint.current = { lat, lon };
+  }, [lat, lon, lastMessageTime]);
+
+  const reset = () => {
+    setDistanceM(0);
+    prevPoint.current = lat === 0 && lon === 0 ? null : { lat, lon };
+  };
+
+  const km = distanceM / 1000;
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-4">
+      <h1 className="text-2xl font-bold">Distance Travelled</h1>
+      <div className="flex items-baseline gap-2">
+        <span className="font-mono text-5xl font-bold">{km.toFixed(3)}</span>
+        <span className="text-xl text-muted-foreground">km</span>
+      </div>
+      <p className="font-mono text-sm text-muted-foreground">
+        {distanceM.toFixed(1)} m
+      </p>
+      <Button variant="outline" size="sm" onClick={reset} className="mt-2">
+        <RotateCcw className="mr-2 h-4 w-4" />
+        Reset
+      </Button>
+    </div>
+  );
+}
+
+export default function DistanceWidget({
+  vehicle_id,
+  showDeltaBanner = false,
+}: DistanceWidgetProps) {
+  return (
+    <LiveWidget
+      vehicle_id={vehicle_id}
+      signals={["dgps_gps_latitude", "dgps_gps_longitude"]}
+      showDeltaBanner={showDeltaBanner}
+      alwaysShowData={true}
+      width={400}
+      height={300}
+    >
+      {(
+        _: Map<string, Signal[]>,
+        currentSignals: Map<string, Signal>,
+        lastMessageTime: number,
+      ) => {
+        const lat = currentSignals.get("dgps_gps_latitude")?.value ?? 0;
+        const lon = currentSignals.get("dgps_gps_longitude")?.value ?? 0;
+        return (
+          <DistanceTracker
+            lat={lat}
+            lon={lon}
+            lastMessageTime={lastMessageTime}
+          />
+        );
+      }}
+    </LiveWidget>
+  );
+}

--- a/dashboard/src/components/widgets/registry.tsx
+++ b/dashboard/src/components/widgets/registry.tsx
@@ -10,6 +10,7 @@ import {
   Gauge,
   LucideIcon,
   MapIcon,
+  Route,
   TrendingUp,
   Zap,
 } from "lucide-react";
@@ -23,6 +24,7 @@ import DgpsDebugWidget from "@/components/widgets/gr26/live/DgpsDebugWidget";
 import DgpsVelocityWidget from "@/components/widgets/gr26/live/DgpsVelocityWidget";
 import DgpsAccelWidget from "@/components/widgets/gr26/live/DgpsAccelWidget";
 import DgpsPositionWidget from "@/components/widgets/gr26/live/DgpsPositionWidget";
+import Gr26DistanceWidget from "@/components/widgets/gr26/live/DistanceWidget";
 import BmsCellWidget from "@/components/widgets/gr26/live/AcuCellWidget";
 import MobileDebugWidget from "@/components/widgets/gr24/MobileDebugWidget";
 import AcuDebugWidget from "@/components/widgets/gr24/AcuDebugWidget";
@@ -229,6 +231,16 @@ export const gr26_registry = {
       icon: Bug,
       span: 12,
       preview: "/widgets/gr26/dgps-debug.png",
+    },
+    {
+      id: "distance",
+      name: "Distance Travelled",
+      description:
+        "Accumulates total distance driven from GPS position, with a reset button.",
+      component: Gr26DistanceWidget,
+      icon: Route,
+      span: 4,
+      preview: "/widgets/gr26/distance.png",
     },
   ],
 };


### PR DESCRIPTION
## Summary
Adds a **Distance Travelled** widget for gr26 that tracks the total distance the car has driven from live GPS data, with a button to reset the counter to 0.

- New widget: `dashboard/src/components/widgets/gr26/live/DistanceWidget.tsx`
- Registered under the gr26 **DGPS** category in `registry.tsx` (id `distance`, `Route` icon)

## How it works
- Subscribes to the live `dgps_gps_latitude` / `dgps_gps_longitude` signals (same source as the DGPS Position map).
- Accumulates distance using the **haversine formula** between consecutive GPS fixes — measures actual path length around the circuit, not straight-line displacement from the start.
- Displays the running total in km (3 decimals) plus a meters readout.
- **Reset** button zeros the counter and re-anchors to the current position.

## Robustness
- Integrates only when a genuinely new fix arrives (keyed on `lastMessageTime`), so re-renders don't double-count.
- Skips `(0,0)` fixes and discards any single step over 1 km to avoid dropped/reacquired GPS fixes injecting a bogus jump.

## Notes
- No preview image yet at `/widgets/gr26/distance.png` (matching convention; not required to function).
- `tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)