### PR TITLE
fix(gr26): fix wheel speed graph build error breaking cloud deploy

### DIFF
--- a/dashboard/src/components/widgets/gr26/live/WheelSpeedGraphWidget.tsx
+++ b/dashboard/src/components/widgets/gr26/live/WheelSpeedGraphWidget.tsx
@@ -140,8 +140,10 @@ export default function WheelSpeedGraphWidget({
                           }
                           return String(value);
                         }}
-                        formatter={(value: number, name: string) => {
-                          return [`${value.toFixed(2)}`, name];
+                        formatter={(value, name) => {
+                          const num =
+                            typeof value === "number" ? value : Number(value);
+                          return [`${num.toFixed(2)}`, name];
                         }}
                       />
                     }


### PR DESCRIPTION
## Summary
Fixes the TypeScript compile error that broke the dashboard production build in **v3.1.6**, taking down the mapache cloud deploy.

## Root cause
`WheelSpeedGraphWidget.tsx` (added in #160) typed the recharts tooltip `formatter` callback's `value` param as `number`:

```tsx
formatter={(value: number, name: string) => {
  return [`${value.toFixed(2)}`, name];
}}
```

Recharts types `formatter` as `Formatter<ValueType, NameType>`, where `value` is `ValueType` (`string | number | (string | number)[]`). Annotating it as the narrower `number` fails `tsc`:

```
WheelSpeedGraphWidget.tsx(143,25): error TS2322:
Type '(value: number, name: string) => [string, string]' is not assignable to
type 'Formatter<ValueType, NameType>'. ... Type 'string' is not assignable to type 'number'.
```

This was the only type error on main, and it fails the production build that gets deployed.

## Fix
Accept `value` untyped and narrow it to a number — mirroring the `labelFormatter` pattern directly above it in the same component.

## Verification
`npx tsc --noEmit` now passes with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)