### PR TITLE
feat(gr26): virtual CAN UDP listeners for on-tcm software producers

### DIFF
--- a/gr26/config/config.go
+++ b/gr26/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strings"
 
 	"github.com/bk1031/rincon-go/v2"
 )
@@ -27,6 +28,28 @@ var EnableSignalWS = os.Getenv("ENABLE_SIGNAL_WS") != "false"
 
 var Env = os.Getenv("ENV")
 var Port = os.Getenv("PORT")
+var VehicleID = os.Getenv("VEHICLE_ID")
+
+// VirtualCANPorts is a comma-separated list of UDP ports where on-vehicle
+// software services (e.g. shelter) emit synthetic CAN frames. gr26 listens
+// on each port and dispatches through the same decoder as the MQTT path —
+// no relay, no postgres persistence on the mqtt side, no cloud publish.
+var VirtualCANPorts = parsePortList(os.Getenv("VIRTUAL_CAN_PORTS"))
+
+func parsePortList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
 
 var DatabaseHost = os.Getenv("DATABASE_HOST")
 var DatabasePort = os.Getenv("DATABASE_PORT")

--- a/gr26/main.go
+++ b/gr26/main.go
@@ -21,6 +21,7 @@ func main() {
 	rincon.Init(&config.Service, &config.Routes)
 	database.Init()
 	mqtt.Init(service.SubscribeTopics)
+	service.StartVirtualCANListeners()
 
 	api.Run()
 }

--- a/gr26/service/virtual_can.go
+++ b/gr26/service/virtual_can.go
@@ -1,0 +1,113 @@
+package service
+
+import (
+	"encoding/binary"
+	"net"
+	"strconv"
+
+	"github.com/gaucho-racing/mapache/gr26/config"
+	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
+)
+
+// nodeIDMap mirrors the table in tcm-mqtt; canID byte -> node name string,
+// which feeds the gr26 topic/path convention. Kept in sync manually for now;
+// if it drifts, virtual CAN frames will land under "unknown".
+var nodeIDMap = map[byte]string{
+	0x00: "all",
+	0x01: "debugger",
+	0x02: "ecu",
+	0x03: "bcu",
+	0x04: "tcm",
+	0x05: "dash_panel",
+	0x08: "gr_inverter",
+	0x0C: "charging_sdc",
+	0x0D: "fan_controller_1",
+	0x0E: "fan_controller_2",
+	0x0F: "fan_controller_3",
+	0x10: "tire_temp_fl",
+	0x11: "tire_temp_fr",
+	0x12: "tire_temp_rl",
+	0x13: "tire_temp_rr",
+	0x14: "suspension_fl",
+	0x15: "suspension_fr",
+	0x16: "suspension_rl",
+	0x17: "suspension_rr",
+	0x18: "inboard_floor_fl",
+	0x19: "inboard_floor_fr",
+	0x1A: "inboard_floor_rl",
+	0x1B: "inboard_floor_rr",
+	0x1C: "brake_temp_fl",
+	0x1D: "brake_temp_fr",
+	0x1E: "brake_temp_rl",
+	0x1F: "brake_temp_rr",
+	0x30: "dgps",
+	0x67: "dti",
+}
+
+// StartVirtualCANListeners spawns one goroutine per configured port. Each
+// listener accepts UDP packets in the virtual CAN wire format and dispatches
+// them through the same HandleMessage path as MQTT-delivered frames.
+func StartVirtualCANListeners() {
+	if len(config.VirtualCANPorts) == 0 {
+		logger.SugarLogger.Infoln("[VCAN] no virtual CAN ports configured")
+		return
+	}
+	for _, port := range config.VirtualCANPorts {
+		go listenVirtualCAN(port)
+	}
+}
+
+// listenVirtualCAN reads from one UDP port forever, parsing the virtual CAN
+// wire format:
+//
+//	[0:4]    canID         u32 LE
+//	[4]      bus           u8   (unused, 0xFF for virtual)
+//	[5]      length        u8   (payload byte count)
+//	[6:14]   timestamp     u64 BE (μs since epoch)
+//	[14:16]  upload_key    u16 BE
+//	[16:16+length] payload
+//
+// The slice [6:16+length] is exactly the shape HandleMessage already consumes
+// from MQTT (timestamp || key || data), so we hand it through directly.
+func listenVirtualCAN(port string) {
+	portInt, err := strconv.Atoi(port)
+	if err != nil {
+		logger.SugarLogger.Fatalf("[VCAN] invalid port %q: %v", port, err)
+	}
+	addr := net.UDPAddr{Port: portInt, IP: net.ParseIP("0.0.0.0")}
+	conn, err := net.ListenUDP("udp", &addr)
+	if err != nil {
+		logger.SugarLogger.Fatalf("[VCAN] failed to bind UDP port %s: %v", port, err)
+	}
+	defer conn.Close()
+	logger.SugarLogger.Infof("[VCAN] listening on udp/%s", port)
+
+	buffer := make([]byte, 1024)
+	for {
+		n, _, err := conn.ReadFromUDP(buffer)
+		if err != nil {
+			logger.SugarLogger.Errorf("[VCAN:%s] read error: %v", port, err)
+			continue
+		}
+		if n < 16 {
+			logger.SugarLogger.Infof("[VCAN:%s] packet too short (%d bytes, need >= 16)", port, n)
+			continue
+		}
+
+		canID := binary.LittleEndian.Uint32(buffer[0:4])
+		length := int(buffer[5])
+		if 16+length > n {
+			logger.SugarLogger.Infof("[VCAN:%s] payload length %d exceeds packet size %d", port, length, n)
+			continue
+		}
+
+		nodeID := byte((canID >> 20) & 0xFF)
+		nodeName, ok := nodeIDMap[nodeID]
+		if !ok {
+			nodeName = "unknown"
+		}
+
+		message := buffer[6 : 16+length]
+		go HandleMessage(config.VehicleID, nodeName, int(canID), message)
+	}
+}


### PR DESCRIPTION
- Add VIRTUAL_CAN_PORTS env var (comma-separated list of UDP ports)
- gr26 spawns one goroutine per port; each accepts virtual CAN packets and dispatches through the same HandleMessage path as MQTT-delivered frames
- Wire format: canID(4 LE) | bus(1) | length(1) | timestamp(8 BE) | upload_key(2 BE) | payload — bytes [6:] is exactly what HandleMessage already consumes from MQTT
- Add VEHICLE_ID env var since virtual frames don't carry a topic to derive vehicle from
- nodeIDMap copied from tcm-mqtt for now — sync manually until moved into mapache-go

## Notes
- Virtual frames bypass the tcm-mqtt relay, so they don't land in gr26_message or get cloud-MQTT dual-published. Intended for dash-WS-only telemetry (e.g. shelter heartbeat)
- Compose wiring (VIRTUAL_CAN_PORTS in dev + prod stacks) lands separately once shelter has its sender ready