### PR TITLE
refactor(gr26): drop gr26_can_signal link table, join on natural keys

### DIFF
--- a/gr26/database/db.go
+++ b/gr26/database/db.go
@@ -31,7 +31,7 @@ func Init() {
 		}
 	} else {
 		logger.SugarLogger.Infoln("Connected to database")
-		db.AutoMigrate(&mapache.Signal{}, &mapache.Ping{}, &model.CAN{}, &model.CANSignal{})
+		db.AutoMigrate(&mapache.Signal{}, &mapache.Ping{}, &model.CAN{})
 		logger.SugarLogger.Infoln("AutoMigration complete")
 		DB = db
 	}

--- a/gr26/model/can.go
+++ b/gr26/model/can.go
@@ -4,8 +4,9 @@ import "time"
 
 // CAN is a stored record of a single decoded CAN frame received from a
 // gr26 vehicle. The composite (vehicle_id, node_id, timestamp) tuple
-// uniquely identifies a frame; ulid is the surrogate key used by the
-// gr26_can_signal join table.
+// uniquely identifies a frame. The signal table joins back to this row
+// via that same tuple (node_id is recovered from the signal name's
+// prefix) — no separate link table required.
 type CAN struct {
 	ID         string    `json:"id" gorm:"primaryKey"`
 	VehicleID  string    `json:"vehicle_id" gorm:"uniqueIndex:idx_gr26_can_unique"`
@@ -24,18 +25,4 @@ type CAN struct {
 
 func (CAN) TableName() string {
 	return "gr26_can"
-}
-
-// CANSignal joins each persisted signal back to the CAN frame it was
-// decoded from. SignalID is the primary key because the relationship is
-// one-to-many (one frame, many signals; each signal traces to exactly
-// one frame).
-type CANSignal struct {
-	SignalID     string    `json:"signal_id" gorm:"primaryKey"`
-	CANMessageID string    `json:"can_message_id" gorm:"index"`
-	CreatedAt    time.Time `json:"created_at" gorm:"autoCreateTime;precision:6"`
-}
-
-func (CANSignal) TableName() string {
-	return "gr26_can_signal"
 }

--- a/gr26/service/can.go
+++ b/gr26/service/can.go
@@ -21,15 +21,20 @@ func GetCAN(id string) (model.CAN, error) {
 	return can, nil
 }
 
-// GetCANForSignal looks up the CAN frame that produced a given signal,
-// joining via gr26_can_signal. Returns gorm.ErrRecordNotFound if the
-// signal isn't linked to any frame (e.g., signal predates the trace
-// feature or belongs to a different service).
+// GetCANForSignal looks up the CAN frame that produced a given signal by
+// joining on the natural keys (vehicle_id, timestamp, node_id) — node_id
+// is recovered from the signal name's prefix, since CreateSignals stamps
+// each signal with the node it was decoded from as `<node>_<short>`.
+// Returns gorm.ErrRecordNotFound if no frame matches (e.g., the source
+// frame was never persisted, or the signal name doesn't follow the
+// node-prefix convention).
 func GetCANForSignal(signalID string) (model.CAN, error) {
 	var can model.CAN
 	err := database.DB.
-		Joins("JOIN gr26_can_signal ON gr26_can_signal.can_message_id = gr26_can.id").
-		Where("gr26_can_signal.signal_id = ?", signalID).
+		Joins("JOIN signal ON gr26_can.vehicle_id = signal.vehicle_id"+
+			" AND gr26_can.timestamp = signal.timestamp"+
+			" AND gr26_can.node_id = split_part(signal.name, '_', 1)").
+		Where("signal.id = ?", signalID).
 		First(&can).Error
 	if err != nil {
 		return model.CAN{}, err
@@ -37,14 +42,16 @@ func GetCANForSignal(signalID string) (model.CAN, error) {
 	return can, nil
 }
 
-// GetSignalsForCAN returns every signal currently linked to the given
-// CAN message via the gr26_can_signal join table. The query orders by
-// signal name so the response is stable and easy to scan.
+// GetSignalsForCAN returns every signal that was decoded from the given
+// CAN frame, joining on the natural keys (vehicle_id, timestamp, node_id).
+// Ordered by signal name so the response is stable and easy to scan.
 func GetSignalsForCAN(canMessageID string) ([]mapache.Signal, error) {
 	var signals []mapache.Signal
 	err := database.DB.
-		Joins("JOIN gr26_can_signal ON gr26_can_signal.signal_id = signal.id").
-		Where("gr26_can_signal.can_message_id = ?", canMessageID).
+		Joins("JOIN gr26_can ON signal.vehicle_id = gr26_can.vehicle_id"+
+			" AND signal.timestamp = gr26_can.timestamp"+
+			" AND gr26_can.node_id = split_part(signal.name, '_', 1)").
+		Where("gr26_can.id = ?", canMessageID).
 		Order("signal.name ASC").
 		Find(&signals).Error
 	if err != nil {
@@ -73,25 +80,4 @@ func CreateCAN(can model.CAN) (model.CAN, error) {
 		return model.CAN{}, result.Error
 	}
 	return can, nil
-}
-
-// CreateCANSignals links each signal id to the CAN frame it was decoded
-// from. Conflicts on signal_id update the can_message_id so the link
-// always points at the most recent frame that produced the signal.
-func CreateCANSignals(canMessageID string, signalIDs []string) error {
-	if !config.EnableSignalDB || len(signalIDs) == 0 {
-		return nil
-	}
-	rows := make([]model.CANSignal, len(signalIDs))
-	for i, sid := range signalIDs {
-		rows[i] = model.CANSignal{
-			SignalID:     sid,
-			CANMessageID: canMessageID,
-		}
-	}
-	result := database.DB.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "signal_id"}},
-		DoUpdates: clause.AssignmentColumns([]string{"can_message_id"}),
-	}).Create(&rows)
-	return result.Error
 }

--- a/gr26/service/message.go
+++ b/gr26/service/message.go
@@ -103,7 +103,7 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 		}
 	}
 
-	can, err := CreateCAN(model.CAN{
+	_, err := CreateCAN(model.CAN{
 		VehicleID:  vehicleID,
 		NodeID:     nodeID,
 		Timestamp:  ts,
@@ -132,14 +132,6 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 	if err := CreateSignals(signals); err != nil {
 		logger.SugarLogger.Infof("Error creating signals: %s", err)
 		return
-	}
-
-	signalIDs := make([]string, len(signals))
-	for i, s := range signals {
-		signalIDs[i] = s.ID
-	}
-	if err := CreateCANSignals(can.ID, signalIDs); err != nil {
-		logger.SugarLogger.Infof("Error creating CAN-signal links: %s", err)
 	}
 
 	if config.EnableSignalWS {

--- a/gr26/service/signal.go
+++ b/gr26/service/signal.go
@@ -68,10 +68,10 @@ func CreateSignals(signals []mapache.Signal) error {
 		signals[i].ID = ulid.Make().Prefixed("sgnl")
 	}
 	if config.EnableSignalDB {
-		// Preserve the existing id on conflict so the join table in
-		// gr26_can_signal stays valid across retransmits. Returning id
-		// rewrites our locally-generated ULID with the actually-stored
-		// one when a row already existed.
+		// Refresh value/raw_value/produced_at on conflict so a retransmit
+		// (or a corrected decode landed later) wins over the older row.
+		// Returning id rewrites our locally-generated ULID with the
+		// actually-stored one when the row already existed.
 		result := database.DB.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "timestamp"}, {Name: "vehicle_id"}, {Name: "name"}},
 			DoUpdates: clause.AssignmentColumns([]string{"value", "raw_value", "produced_at"}),


### PR DESCRIPTION
- Remove the gr26_can_signal model + AutoMigrate + all calls to CreateCANSignals
- Rewrite GetCANForSignal / GetSignalsForCAN to JOIN gr26_can ↔ signal on natural keys: \`vehicle_id\`, \`timestamp\`, and \`split_part(signal.name, '_', 1) = gr26_can.node_id\`
- HandleMessage stops collecting signalIDs and writing to the link table
- CreateSignals on-conflict comment updated (no longer about preserving IDs for a join table)

## Why
The link table was a denormalized cache of an unambiguous natural-key relationship. gr26_can already has a unique constraint on (vehicle_id, node_id, timestamp), and CreateSignals stamps each signal's name as \`<node>_<short>\` — so the join is fully recoverable without the cache. Less plumbing, one fewer write per CAN frame, lighter shelter-ingest path going forward.

## After deploy
Drop the legacy table to reclaim space:
\`\`\`sql
DROP TABLE gr26_can_signal;
\`\`\`

## Latent assumption
This assumes signal short-names don't collide across messages from the same node at the same timestamp. In practice today none of the message defs do — but the schema doesn't enforce it.