### PR TITLE
feat(gr26): enqueue foreman job on TCMShelterBatch arrival

### DIFF
--- a/gr26/config/config.go
+++ b/gr26/config/config.go
@@ -42,6 +42,13 @@ var KerbecsEndpoint = os.Getenv("KERBECS_ENDPOINT")
 var KerbecsUser = os.Getenv("KERBECS_USER")
 var KerbecsPassword = os.Getenv("KERBECS_PASSWORD")
 
+// Foreman is the job queue gr26 enqueues into when it sees events that
+// should trigger downstream work (e.g. TCMShelterBatch arriving means
+// "go ingest the latest shelter parquet"). Empty endpoint disables the
+// enqueue calls entirely so the on-vehicle gr26 stays out of it.
+var ForemanEndpoint = os.Getenv("FOREMAN_ENDPOINT")
+var ForemanToken = os.Getenv("FOREMAN_TOKEN")
+
 var MQTTHost = os.Getenv("MQTT_HOST")
 var MQTTPort = os.Getenv("MQTT_PORT")
 var MQTTUser = os.Getenv("MQTT_USER")

--- a/gr26/go.sum
+++ b/gr26/go.sum
@@ -42,8 +42,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.43.1 h1:r/vUkpLilfCA3sxbRnkHbJejaoVH
 github.com/aws/aws-sdk-go-v2/service/sts v1.43.1/go.mod h1:t01JURC8Fe5M+7R1K0vzIZ2NT04HqvZR+FjlHrHDT2A=
 github.com/aws/smithy-go v1.27.0 h1:ZoFioDKJxkSIW2otF9T0aPtNlUwhdVCcuZh/rzH9Hus=
 github.com/aws/smithy-go v1.27.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
-github.com/bk1031/rincon-go/v2 v2.0.0 h1:nmDHQNZI/AFfW+ZGTGoxpNPrv3OYXQ09anX+fCoiQsQ=
-github.com/bk1031/rincon-go/v2 v2.0.0/go.mod h1:287Zc8PvUNnJuAwpt9XVuYUL8k4wrXg3Fa3L0KEmAB4=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=

--- a/gr26/model/tcm.go
+++ b/gr26/model/tcm.go
@@ -52,6 +52,11 @@ var TCMShelterHeartbeat = mp.Message{
 	}),
 }
 
+// MsgIDShelterBatch is the canonical name for 0x211 — used by gr26
+// service code that needs to recognize TCMShelterBatch as a side-channel
+// trigger (e.g. enqueueing a downstream ingest job).
+const MsgIDShelterBatch = 0x211
+
 // TCMShelterBatch is a 16-byte CAN-FD frame emitted by shelter after each
 // successful Parquet upload — combines what landed (rows, compressed size)
 // with how it went (claim/upload timing, compression ratio, trigger).

--- a/gr26/pkg/foreman/client.go
+++ b/gr26/pkg/foreman/client.go
@@ -1,0 +1,84 @@
+// Package foreman is a thin HTTP client for gr26 to enqueue jobs into
+// the central Foreman queue. Mirrors foreman's POST /foreman/jobs body
+// shape; not a full client (no claim/heartbeat/complete here — gr26 is
+// a job producer, not a worker, in this direction).
+package foreman
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gaucho-racing/mapache/gr26/config"
+	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
+)
+
+// EnqueueRequest is the body POSTed to foreman /jobs. Fields mirror
+// foreman/api/job.go's enqueueRequest exactly.
+type EnqueueRequest struct {
+	Kind           string          `json:"kind"`
+	Queue          string          `json:"queue,omitempty"`
+	Service        string          `json:"service,omitempty"`
+	IdempotencyKey *string         `json:"idempotency_key,omitempty"`
+	Params         json.RawMessage `json:"params,omitempty"`
+	Priority       int             `json:"priority,omitempty"`
+	MaxAttempts    int             `json:"max_attempts,omitempty"`
+	ScheduledAt    *time.Time      `json:"scheduled_at,omitempty"`
+}
+
+var httpClient = &http.Client{Timeout: 5 * time.Second}
+
+// Enqueue POSTs the request to foreman. Returns nil on success (201) or
+// conflict (409 — idempotency key collision, treated as "already
+// enqueued"). Logs and returns the error for everything else. No-op when
+// FOREMAN_ENDPOINT is unset so a misconfigured-but-running gr26 doesn't
+// crash on every TCMShelterBatch.
+func Enqueue(ctx context.Context, req EnqueueRequest) error {
+	if config.ForemanEndpoint == "" {
+		return nil
+	}
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	url := strings.TrimRight(config.ForemanEndpoint, "/") + "/foreman/jobs"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if config.ForemanToken != "" {
+		httpReq.Header.Set("X-Foreman-Token", config.ForemanToken)
+	}
+
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("post: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		return nil
+	case http.StatusConflict:
+		// Idempotency key matched an existing job — treat as success.
+		// Foreman returned the existing job in the body; we don't care.
+		logger.SugarLogger.Debugf("[FOREMAN] job already enqueued (kind=%s, idem=%v)", req.Kind, deref(req.IdempotencyKey))
+		return nil
+	default:
+		return fmt.Errorf("foreman responded %d", resp.StatusCode)
+	}
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/gr26/service/message.go
+++ b/gr26/service/message.go
@@ -139,6 +139,12 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 			Hub.Publish(s)
 		}
 	}
+
+	// Side-channel: when shelter announces a successful upload, kick off
+	// a job for the downstream ingest worker.
+	if canID == model.MsgIDShelterBatch {
+		go onShelterBatchReceived(vehicleID, ts)
+	}
 }
 
 func mustJSON(v any) []byte {

--- a/gr26/service/shelter_batch_hook.go
+++ b/gr26/service/shelter_batch_hook.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/gaucho-racing/mapache/gr26/pkg/foreman"
+	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
+)
+
+// onShelterBatchReceived fires when a TCMShelterBatch frame lands in
+// HandleMessage. We don't do anything with the batch payload directly —
+// instead we enqueue a `gr26.ingest_latest_batch` job for a downstream
+// worker to claim, which is the trigger that replaces our standalone
+// S3 polling loop.
+//
+// idempotency_key is (vehicleID, batch-frame-timestamp). The timestamp
+// is unique per frame (microsecond precision from tcm-mqtt), so MQTT
+// retains / replays don't double-enqueue.
+func onShelterBatchReceived(vehicleID string, ts int) {
+	idem := fmt.Sprintf("gr26.ingest_latest_batch:%s:%d", vehicleID, ts)
+	params, _ := json.Marshal(map[string]any{
+		"vehicle_id":      vehicleID,
+		"trigger_ts_us":   ts,
+	})
+	req := foreman.EnqueueRequest{
+		Kind:           "gr26.ingest_latest_batch",
+		Service:        "gr26",
+		IdempotencyKey: &idem,
+		Params:         params,
+		MaxAttempts:    3,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := foreman.Enqueue(ctx, req); err != nil {
+		logger.SugarLogger.Errorf("[SHELTER] failed to enqueue ingest job for %s: %v", vehicleID, err)
+		return
+	}
+	logger.SugarLogger.Debugf("[SHELTER] enqueued gr26.ingest_latest_batch (vehicle=%s, ts=%d)", vehicleID, ts)
+}


### PR DESCRIPTION
## What
Side-channel hook in HandleMessage: when a TCMShelterBatch frame (canID 0x211) finishes processing, enqueue a \`gr26.ingest_latest_batch\` job in foreman. Push-from-producer trigger instead of polling S3 on a timer.

## Pieces
- \`pkg/foreman/client.go\` — thin POST /foreman/jobs client. Empty \`FOREMAN_ENDPOINT\` = no-op. Treats 409 (idem conflict) as success so MQTT replays / dup-deliveries don't error.
- \`service/shelter_batch_hook.go\` — builds the enqueue with idempotency key \`gr26.ingest_latest_batch:{vehicle}:{ts}\` so each unique batch frame yields at most one job.
- \`service/message.go\` — fires the hook in a goroutine (don't block MQTT dispatch on HTTP) when \`canID == model.MsgIDShelterBatch\`.
- \`model/tcm.go\` — named constant for 0x211.
- \`config/config.go\` — \`FOREMAN_ENDPOINT\`, \`FOREMAN_TOKEN\` env vars.
- \`go.sum\` — drops stale \`rincon-go\` entries.

## What's NOT in this PR
- The worker that claims and processes \`gr26.ingest_latest_batch\` jobs — that's the next step. Until then, jobs accumulate in foreman as unclaimed notifications.
- Removing the existing S3 polling loop — stays in place so ingest doesn't break. Will be ripped out once the worker exists.

## Config
- \`FOREMAN_ENDPOINT\` empty → hook is a no-op (on-vehicle gr26 stays out of foreman)
- Cloud gr26 sets \`FOREMAN_ENDPOINT=http://foreman:port\` and \`FOREMAN_TOKEN=<shared secret>\`