### PR TITLE
feat(gr26): foreman worker pool, NUM_WORKERS knob

### DIFF
--- a/gr26/config/config.go
+++ b/gr26/config/config.go
@@ -49,19 +49,23 @@ var KerbecsPassword = os.Getenv("KERBECS_PASSWORD")
 var ForemanEndpoint = os.Getenv("FOREMAN_ENDPOINT")
 var ForemanToken = os.Getenv("FOREMAN_TOKEN")
 
+// NumWorkers is the size of the worker pool that claims foreman jobs.
+// Each worker runs its own claim loop; goroutine cost is negligible
+// (mostly idle on HTTP) but more workers = more concurrent jobs.
+var NumWorkersRaw = os.Getenv("NUM_WORKERS")
+var NumWorkers int
+
 var MQTTHost = os.Getenv("MQTT_HOST")
 var MQTTPort = os.Getenv("MQTT_PORT")
 var MQTTUser = os.Getenv("MQTT_USER")
 var MQTTPassword = os.Getenv("MQTT_PASSWORD")
 
-// Epic Shelter cold-storage ingest. SHELTER_S3_BUCKET unset means the
-// feature is off entirely — the on-vehicle gr26 deployment should keep
-// it unset and only the cloud gr26 deployment turns it on.
+// Epic Shelter cold-storage ingest. Driven by foreman jobs now, not by
+// polling — SHELTER_S3_BUCKET unset means the IngestLatestBatchHandler
+// rejects any job claimed for it. The on-vehicle gr26 leaves this unset.
 var ShelterS3Bucket = os.Getenv("SHELTER_S3_BUCKET")
 var ShelterS3Region = os.Getenv("SHELTER_S3_REGION")
 var ShelterS3Prefix = os.Getenv("SHELTER_S3_PREFIX")
-var ShelterPollIntervalRaw = os.Getenv("SHELTER_POLL_INTERVAL_SEC")
-var ShelterPollIntervalSec int
 
 func IsProduction() bool {
 	return Env == "PROD"

--- a/gr26/config/verify.go
+++ b/gr26/config/verify.go
@@ -47,13 +47,13 @@ func Verify() {
 		VehicleUploadKeyCacheTTL = "600"
 		logger.SugarLogger.Infof("VEHICLE_UPLOAD_KEY_CACHE_TTL is not set, defaulting to %s", VehicleUploadKeyCacheTTL)
 	}
-	if ShelterPollIntervalRaw == "" {
-		ShelterPollIntervalRaw = "60"
+	if NumWorkersRaw == "" {
+		NumWorkersRaw = "1"
 	}
-	if n, err := strconv.Atoi(ShelterPollIntervalRaw); err != nil {
-		logger.SugarLogger.Errorf("SHELTER_POLL_INTERVAL_SEC=%q is not an int, defaulting to 60", ShelterPollIntervalRaw)
-		ShelterPollIntervalSec = 60
+	if n, err := strconv.Atoi(NumWorkersRaw); err != nil || n < 1 {
+		logger.SugarLogger.Errorf("NUM_WORKERS=%q is not a positive int, defaulting to 1", NumWorkersRaw)
+		NumWorkers = 1
 	} else {
-		ShelterPollIntervalSec = n
+		NumWorkers = n
 	}
 }

--- a/gr26/main.go
+++ b/gr26/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+
 	"github.com/gaucho-racing/mapache/gr26/api"
 	"github.com/gaucho-racing/mapache/gr26/config"
 	"github.com/gaucho-racing/mapache/gr26/database"
@@ -8,6 +10,7 @@ import (
 	"github.com/gaucho-racing/mapache/gr26/pkg/kerbecs"
 	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
 	"github.com/gaucho-racing/mapache/gr26/service"
+	"github.com/gaucho-racing/mapache/gr26/worker"
 )
 
 func main() {
@@ -19,7 +22,12 @@ func main() {
 	kerbecs.Init(config.KerbecsEndpoint, config.KerbecsUser, config.KerbecsPassword)
 	database.Init()
 	mqtt.Init(service.SubscribeTopics)
-	service.StartShelterIngest()
+
+	// Worker pool: foreman gives us jobs, we run them. Currently just
+	// gr26.ingest_latest_batch but adding more is a Register call.
+	reg := worker.NewRegistry()
+	reg.Register("gr26.ingest_latest_batch", service.IngestLatestBatchHandler)
+	worker.StartPool(context.Background(), reg)
 
 	api.Run()
 }

--- a/gr26/pkg/foreman/client.go
+++ b/gr26/pkg/foreman/client.go
@@ -1,7 +1,8 @@
-// Package foreman is a thin HTTP client for gr26 to enqueue jobs into
-// the central Foreman queue. Mirrors foreman's POST /foreman/jobs body
-// shape; not a full client (no claim/heartbeat/complete here — gr26 is
-// a job producer, not a worker, in this direction).
+// Package foreman is gr26's HTTP client for the central foreman job
+// queue. Covers both the producer side (Enqueue) and the worker side
+// (Claim, Heartbeat, Complete, Fail) — gr26 plays both roles depending
+// on the message: TCMShelterBatch arrival enqueues a job; the worker
+// pool claims and runs them.
 package foreman
 
 import (
@@ -17,6 +18,19 @@ import (
 	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
 )
 
+// Job is the subset of foreman's Job record a worker needs to act on
+// a claim. Other fields (priority, lease, worker_id, etc.) are tracked
+// foreman-side; we don't echo them back to the handler.
+type Job struct {
+	ID          string          `json:"id"`
+	Kind        string          `json:"kind"`
+	Queue       string          `json:"queue"`
+	Service     string          `json:"service"`
+	Params      json.RawMessage `json:"params"`
+	Attempt     int             `json:"attempt"`
+	MaxAttempts int             `json:"max_attempts"`
+}
+
 // EnqueueRequest is the body POSTed to foreman /jobs. Fields mirror
 // foreman/api/job.go's enqueueRequest exactly.
 type EnqueueRequest struct {
@@ -30,50 +44,147 @@ type EnqueueRequest struct {
 	ScheduledAt    *time.Time      `json:"scheduled_at,omitempty"`
 }
 
-var httpClient = &http.Client{Timeout: 5 * time.Second}
+type ClaimRequest struct {
+	Kinds    []string `json:"kinds"`
+	Queues   []string `json:"queues,omitempty"`
+	WorkerID string   `json:"worker_id"`
+	LeaseSec int      `json:"lease_seconds,omitempty"`
+}
+
+type HeartbeatRequest struct {
+	WorkerID        string  `json:"worker_id"`
+	ProgressCurrent *int64  `json:"progress_current,omitempty"`
+	ProgressTotal   *int64  `json:"progress_total,omitempty"`
+	ProgressMessage *string `json:"progress_message,omitempty"`
+	LeaseSec        int     `json:"lease_seconds,omitempty"`
+}
+
+type CompleteRequest struct {
+	WorkerID string          `json:"worker_id"`
+	Result   json.RawMessage `json:"result,omitempty"`
+}
+
+type FailRequest struct {
+	WorkerID   string `json:"worker_id"`
+	Error      string `json:"error,omitempty"`
+	Retryable  bool   `json:"retryable"`
+	BackoffSec int    `json:"backoff_seconds,omitempty"`
+}
+
+var httpClient = &http.Client{Timeout: 30 * time.Second}
 
 // Enqueue POSTs the request to foreman. Returns nil on success (201) or
 // conflict (409 — idempotency key collision, treated as "already
-// enqueued"). Logs and returns the error for everything else. No-op when
-// FOREMAN_ENDPOINT is unset so a misconfigured-but-running gr26 doesn't
-// crash on every TCMShelterBatch.
+// enqueued"). No-op when FOREMAN_ENDPOINT is unset.
 func Enqueue(ctx context.Context, req EnqueueRequest) error {
 	if config.ForemanEndpoint == "" {
 		return nil
 	}
-
-	body, err := json.Marshal(req)
+	resp, err := doJSON(ctx, http.MethodPost, "/foreman/jobs", req)
 	if err != nil {
-		return fmt.Errorf("marshal: %w", err)
-	}
-
-	url := strings.TrimRight(config.ForemanEndpoint, "/") + "/foreman/jobs"
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("new request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	if config.ForemanToken != "" {
-		httpReq.Header.Set("X-Foreman-Token", config.ForemanToken)
-	}
-
-	resp, err := httpClient.Do(httpReq)
-	if err != nil {
-		return fmt.Errorf("post: %w", err)
+		return err
 	}
 	defer resp.Body.Close()
-
 	switch resp.StatusCode {
 	case http.StatusCreated:
 		return nil
 	case http.StatusConflict:
-		// Idempotency key matched an existing job — treat as success.
-		// Foreman returned the existing job in the body; we don't care.
 		logger.SugarLogger.Debugf("[FOREMAN] job already enqueued (kind=%s, idem=%v)", req.Kind, deref(req.IdempotencyKey))
 		return nil
 	default:
-		return fmt.Errorf("foreman responded %d", resp.StatusCode)
+		return fmt.Errorf("enqueue: foreman responded %d", resp.StatusCode)
 	}
+}
+
+// Claim asks foreman for one job matching any of req.Kinds. Returns
+// (nil, nil) when nothing is available (foreman 204) — that's the
+// expected "queue empty" signal, not an error.
+func Claim(ctx context.Context, req ClaimRequest) (*Job, error) {
+	if config.ForemanEndpoint == "" {
+		return nil, nil
+	}
+	resp, err := doJSON(ctx, http.MethodPost, "/foreman/claim", req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var job Job
+		if err := json.NewDecoder(resp.Body).Decode(&job); err != nil {
+			return nil, fmt.Errorf("claim decode: %w", err)
+		}
+		return &job, nil
+	case http.StatusNoContent:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("claim: foreman responded %d", resp.StatusCode)
+	}
+}
+
+// Heartbeat extends the lease on an in-flight job. Workers should call
+// this periodically for long-running jobs so foreman's reaper doesn't
+// take the lease back.
+func Heartbeat(ctx context.Context, jobID string, req HeartbeatRequest) error {
+	if config.ForemanEndpoint == "" {
+		return nil
+	}
+	resp, err := doJSON(ctx, http.MethodPost, "/foreman/jobs/"+jobID+"/heartbeat", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("heartbeat: foreman responded %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func Complete(ctx context.Context, jobID string, req CompleteRequest) error {
+	if config.ForemanEndpoint == "" {
+		return nil
+	}
+	resp, err := doJSON(ctx, http.MethodPost, "/foreman/jobs/"+jobID+"/complete", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("complete: foreman responded %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func Fail(ctx context.Context, jobID string, req FailRequest) error {
+	if config.ForemanEndpoint == "" {
+		return nil
+	}
+	resp, err := doJSON(ctx, http.MethodPost, "/foreman/jobs/"+jobID+"/fail", req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("fail: foreman responded %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func doJSON(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	url := strings.TrimRight(config.ForemanEndpoint, "/") + path
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(buf))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if config.ForemanToken != "" {
+		req.Header.Set("X-Foreman-Token", config.ForemanToken)
+	}
+	return httpClient.Do(req)
 }
 
 func deref(s *string) string {

--- a/gr26/service/shelter_ingest.go
+++ b/gr26/service/shelter_ingest.go
@@ -19,6 +19,7 @@ import (
 	gr26config "github.com/gaucho-racing/mapache/gr26/config"
 	"github.com/gaucho-racing/mapache/gr26/database"
 	"github.com/gaucho-racing/mapache/gr26/model"
+	"github.com/gaucho-racing/mapache/gr26/pkg/foreman"
 	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
 )
 
@@ -33,52 +34,51 @@ type shelterRow struct {
 	TargetNode string `parquet:"target_node"`
 }
 
-// StartShelterIngest spins up the S3 polling loop in the background.
-// No-op when SHELTER_S3_BUCKET is unset, so the on-car gr26 deployment
-// stays out of S3.
-func StartShelterIngest() {
+// IngestLatestBatchHandler is the worker entrypoint registered for
+// "gr26.ingest_latest_batch" jobs. Each invocation finds the oldest
+// unprocessed shelter parquet in S3 (ULID lexical order = chronological)
+// and runs it through the same HandleMessage decode path as live MQTT.
+//
+// If no unprocessed file exists, the handler returns nil — that's a
+// successful no-op, not an error (we can race with another worker that
+// claimed first).
+func IngestLatestBatchHandler(ctx context.Context, job *foreman.Job) error {
 	if gr26config.ShelterS3Bucket == "" {
-		logger.SugarLogger.Infoln("[SHELTER] ingest disabled (SHELTER_S3_BUCKET unset)")
-		return
+		return errors.New("shelter ingest configured at foreman but SHELTER_S3_BUCKET is unset")
 	}
-	go runShelterIngest()
-}
-
-func runShelterIngest() {
-	ctx := context.Background()
 	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithRegion(gr26config.ShelterS3Region),
 	)
 	if err != nil {
-		logger.SugarLogger.Errorf("[SHELTER] AWS config load failed: %v", err)
-		return
+		return fmt.Errorf("aws config: %w", err)
 	}
 	client := s3.NewFromConfig(awsCfg)
 
-	logger.SugarLogger.Infof("[SHELTER] starting (bucket=%s prefix=%q interval=%ds)",
-		gr26config.ShelterS3Bucket, gr26config.ShelterS3Prefix, gr26config.ShelterPollIntervalSec)
-
-	for {
-		if err := pollOnce(ctx, client); err != nil {
-			logger.SugarLogger.Errorf("[SHELTER] poll iteration failed: %v", err)
-		}
-		time.Sleep(time.Duration(gr26config.ShelterPollIntervalSec) * time.Second)
+	key, fileULID, err := findOldestUnprocessed(ctx, client)
+	if err != nil {
+		return fmt.Errorf("scan s3: %w", err)
 	}
+	if key == "" {
+		logger.SugarLogger.Debugf("[SHELTER] job %s: nothing to ingest", job.ID)
+		return nil
+	}
+	return processFile(ctx, client, key, fileULID)
 }
 
-func pollOnce(ctx context.Context, client *s3.Client) error {
-	var continuationToken *string
-	for {
-		out, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
-			Bucket:            aws.String(gr26config.ShelterS3Bucket),
-			Prefix:            aws.String(gr26config.ShelterS3Prefix),
-			ContinuationToken: continuationToken,
-		})
+// findOldestUnprocessed walks the S3 prefix in lexical (= chronological,
+// because ULID) order and returns the first parquet whose ULID isn't in
+// gr26_shelter_ingested. Returns ("", "", nil) when nothing pending.
+func findOldestUnprocessed(ctx context.Context, client *s3.Client) (string, string, error) {
+	paginator := s3.NewListObjectsV2Paginator(client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(gr26config.ShelterS3Bucket),
+		Prefix: aws.String(gr26config.ShelterS3Prefix),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return fmt.Errorf("list: %w", err)
+			return "", "", err
 		}
-
-		for _, obj := range out.Contents {
+		for _, obj := range page.Contents {
 			key := aws.ToString(obj.Key)
 			if !strings.HasSuffix(key, ".parquet") {
 				continue
@@ -87,20 +87,12 @@ func pollOnce(ctx context.Context, client *s3.Client) error {
 			if fileULID == "" {
 				continue
 			}
-			if alreadyIngested(fileULID) {
-				continue
-			}
-			if err := processFile(ctx, client, key, fileULID); err != nil {
-				logger.SugarLogger.Errorf("[SHELTER] %s failed: %v", key, err)
-				continue
+			if !alreadyIngested(fileULID) {
+				return key, fileULID, nil
 			}
 		}
-
-		if !aws.ToBool(out.IsTruncated) {
-			return nil
-		}
-		continuationToken = out.NextContinuationToken
 	}
+	return "", "", nil
 }
 
 // extractULID pulls the file ULID out of an S3 key like

--- a/gr26/worker/pool.go
+++ b/gr26/worker/pool.go
@@ -1,0 +1,41 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gaucho-racing/mapache/gr26/config"
+	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
+)
+
+// StartPool spawns config.NumWorkers goroutines, each running its own
+// claim loop against the supplied registry. Worker IDs are hostname-N
+// so foreman can tell siblings apart on the same host but ID stays
+// stable across restarts.
+//
+// No-op when FOREMAN_ENDPOINT is unset (the on-vehicle gr26 deployment
+// stays out of foreman entirely) or when the registry has no kinds.
+func StartPool(ctx context.Context, reg *Registry) {
+	if config.ForemanEndpoint == "" {
+		logger.SugarLogger.Infoln("[WORKER] pool disabled (FOREMAN_ENDPOINT unset)")
+		return
+	}
+	if len(reg.Kinds()) == 0 {
+		logger.SugarLogger.Infoln("[WORKER] pool disabled (no handlers registered)")
+		return
+	}
+
+	n := config.NumWorkers
+	if n < 1 {
+		n = 1
+	}
+	host := hostname()
+	logger.SugarLogger.Infof("[WORKER] starting pool of %d workers (kinds=%v)", n, reg.Kinds())
+	for i := 0; i < n; i++ {
+		w := &Worker{
+			ID:       fmt.Sprintf("gr26-%s-%d", host, i),
+			Registry: reg,
+		}
+		go w.Run(ctx)
+	}
+}

--- a/gr26/worker/registry.go
+++ b/gr26/worker/registry.go
@@ -1,0 +1,55 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gaucho-racing/mapache/gr26/pkg/foreman"
+)
+
+// Handler is the contract a job kind's worker code satisfies. The
+// returned error is what foreman gets — nil = Complete, non-nil = Fail
+// (with the error string in the message).
+type Handler func(ctx context.Context, job *foreman.Job) error
+
+// Registry maps job kinds to handlers. A single Registry is shared
+// across all workers in the pool; lookups are read-only at runtime so
+// no locking after construction.
+type Registry struct {
+	handlers map[string]Handler
+}
+
+func NewRegistry() *Registry {
+	return &Registry{handlers: make(map[string]Handler)}
+}
+
+// Register associates a handler with a kind. Panics on duplicate
+// registration — fail loud at startup rather than silently overwriting.
+func (r *Registry) Register(kind string, h Handler) {
+	if _, exists := r.handlers[kind]; exists {
+		panic(fmt.Sprintf("worker: kind %q already registered", kind))
+	}
+	r.handlers[kind] = h
+}
+
+// Kinds returns the kinds the registry knows about. Used by workers to
+// build their claim request.
+func (r *Registry) Kinds() []string {
+	kinds := make([]string, 0, len(r.handlers))
+	for k := range r.handlers {
+		kinds = append(kinds, k)
+	}
+	return kinds
+}
+
+// Handle dispatches a claimed job to the matching handler. Returns an
+// error if no handler is registered for the job's kind — that path
+// shouldn't fire in practice (foreman only claims kinds we asked for)
+// but a clear error helps if registration drifts.
+func (r *Registry) Handle(ctx context.Context, job *foreman.Job) error {
+	h, ok := r.handlers[job.Kind]
+	if !ok {
+		return fmt.Errorf("no handler registered for kind %q", job.Kind)
+	}
+	return h(ctx, job)
+}

--- a/gr26/worker/worker.go
+++ b/gr26/worker/worker.go
@@ -1,0 +1,140 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/gaucho-racing/mapache/gr26/pkg/foreman"
+	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
+)
+
+// Tuning constants. Exposed as variables not consts so tests can poke
+// them, but no env wiring yet — defaults are fine until we have ops
+// data saying otherwise.
+var (
+	// claimLeaseSec is the lease duration we request when claiming.
+	// Foreman's reaper will sweep the job back to pending if our
+	// heartbeat doesn't extend the lease past this window.
+	claimLeaseSec = 60
+
+	// heartbeatInterval is how often a running handler refreshes its
+	// lease. Should be comfortably less than claimLeaseSec.
+	heartbeatInterval = 20 * time.Second
+
+	// claimEmptySleep is how long a worker waits after foreman returns
+	// 204 (no jobs available) before trying again. Tradeoff: shorter
+	// = lower latency on new jobs, more foreman load.
+	claimEmptySleep = 5 * time.Second
+
+	// claimErrorBackoff is how long a worker waits after a transient
+	// HTTP error from foreman before retrying.
+	claimErrorBackoff = 10 * time.Second
+)
+
+type Worker struct {
+	ID       string
+	Registry *Registry
+}
+
+// Run loops forever (or until ctx cancels) — claim → handle → ack —
+// with backoff on empty queue and on transient errors.
+func (w *Worker) Run(ctx context.Context) {
+	kinds := w.Registry.Kinds()
+	logger.SugarLogger.Infof("[WORKER %s] starting, kinds=%v", w.ID, kinds)
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		job, err := foreman.Claim(ctx, foreman.ClaimRequest{
+			Kinds:    kinds,
+			WorkerID: w.ID,
+			LeaseSec: claimLeaseSec,
+		})
+		if err != nil {
+			logger.SugarLogger.Errorf("[WORKER %s] claim failed: %v", w.ID, err)
+			sleep(ctx, claimErrorBackoff)
+			continue
+		}
+		if job == nil {
+			sleep(ctx, claimEmptySleep)
+			continue
+		}
+
+		w.runJob(ctx, job)
+	}
+}
+
+func (w *Worker) runJob(ctx context.Context, job *foreman.Job) {
+	logger.SugarLogger.Infof("[WORKER %s] claimed job %s (kind=%s, attempt=%d/%d)",
+		w.ID, job.ID, job.Kind, job.Attempt, job.MaxAttempts)
+
+	// Heartbeat in the background while the handler runs.
+	hbCtx, cancelHB := context.WithCancel(ctx)
+	hbDone := make(chan struct{})
+	go func() {
+		defer close(hbDone)
+		ticker := time.NewTicker(heartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-hbCtx.Done():
+				return
+			case <-ticker.C:
+				if err := foreman.Heartbeat(ctx, job.ID, foreman.HeartbeatRequest{
+					WorkerID: w.ID,
+					LeaseSec: claimLeaseSec,
+				}); err != nil {
+					logger.SugarLogger.Warnf("[WORKER %s] heartbeat %s failed: %v", w.ID, job.ID, err)
+				}
+			}
+		}
+	}()
+
+	start := time.Now()
+	handlerErr := w.Registry.Handle(ctx, job)
+	cancelHB()
+	<-hbDone
+
+	if handlerErr != nil {
+		logger.SugarLogger.Errorf("[WORKER %s] job %s failed in %s: %v", w.ID, job.ID, time.Since(start), handlerErr)
+		retryable := job.Attempt < job.MaxAttempts
+		if err := foreman.Fail(ctx, job.ID, foreman.FailRequest{
+			WorkerID:  w.ID,
+			Error:     handlerErr.Error(),
+			Retryable: retryable,
+		}); err != nil {
+			logger.SugarLogger.Errorf("[WORKER %s] couldn't report failure on %s: %v", w.ID, job.ID, err)
+		}
+		return
+	}
+
+	if err := foreman.Complete(ctx, job.ID, foreman.CompleteRequest{
+		WorkerID: w.ID,
+	}); err != nil {
+		logger.SugarLogger.Errorf("[WORKER %s] couldn't report success on %s: %v", w.ID, job.ID, err)
+		return
+	}
+	logger.SugarLogger.Infof("[WORKER %s] job %s done in %s", w.ID, job.ID, time.Since(start))
+}
+
+func sleep(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}
+
+// hostname returns the container hostname, falling back to "gr26" so
+// worker IDs are still stable-ish if Hostname() fails (e.g. in tests).
+func hostname() string {
+	h, err := os.Hostname()
+	if err != nil || h == "" {
+		return "gr26"
+	}
+	return h
+}


### PR DESCRIPTION
## What
Replaces the standalone S3-polling shelter ingest loop with a foreman worker pool. Each worker runs its own claim loop against any registered kind; pool size is \`NUM_WORKERS\` (default 1). Today we register exactly one kind, \`gr26.ingest_latest_batch\`, which finds the oldest unprocessed shelter parquet and runs it through HandleMessage.

## New worker module
- \`pkg/foreman/client.go\` — extended with Claim/Heartbeat/Complete/Fail (was producer-only)
- \`worker/registry.go\` — Registry maps kind -> Handler; panics on dup
- \`worker/worker.go\` — claim → heartbeat-loop → handle → ack/fail cycle. Worker ID is \`gr26-<hostname>-<index>\`
- \`worker/pool.go\` — \`StartPool\` spawns NUM_WORKERS goroutines. No-op when FOREMAN_ENDPOINT is unset

## service/shelter_ingest.go restructured
- \`StartShelterIngest\` / \`runShelterIngest\` / \`pollOnce\` removed
- New \`IngestLatestBatchHandler(ctx, job)\` — the worker entry point
- New \`findOldestUnprocessed\` — picks the next ULID via S3 pagination + dedup
- \`processFile\`, \`dispatchRow\`, \`alreadyIngested\`, \`markIngested\`, \`extractULID\`, \`shelterRow\` unchanged

## Config
- \`NUM_WORKERS\` added (default 1)
- \`SHELTER_POLL_INTERVAL_SEC\` removed (no more polling)
- Tuning constants (\`claimLeaseSec=60\`, \`heartbeatInterval=20s\`, \`claimEmptySleep=5s\`, \`claimErrorBackoff=10s\`) live as package vars in \`worker.go\` — no env wiring yet

## Base
Stacked on top of #171 (\`bk1031/foreman-shelter-enqueue\`). When that merges, base auto-updates to main.