### PR TITLE
feat(gr26): extend TCMShelterBatch to 32B, carry batch ULID

### DIFF
--- a/gr26/model/tcm.go
+++ b/gr26/model/tcm.go
@@ -57,16 +57,22 @@ var TCMShelterHeartbeat = mp.Message{
 // trigger (e.g. enqueueing a downstream ingest job).
 const MsgIDShelterBatch = 0x211
 
-// TCMShelterBatch is a 16-byte CAN-FD frame emitted by shelter after each
+// TCMShelterBatch is a 32-byte CAN-FD frame emitted by shelter after each
 // successful Parquet upload — combines what landed (rows, compressed size)
-// with how it went (claim/upload timing, compression ratio, trigger).
+// with how it went (claim/upload timing, compression ratio, trigger), plus
+// the raw ULID of the parquet file so downstream ingest workers can
+// target that file directly without scanning S3.
 //
-//   rows              u32 LE  row count in the uploaded batch
-//   compressed_bytes  u32 LE  size of the parquet file on S3 (after zstd)
-//   upload_ms         u16 LE  parquet write + S3 multipart upload duration
-//   claim_ms          u16 LE  postgres claim CTE duration
-//   ratio_x100        u16 LE  compression ratio × 100 (e.g. 724 → 7.24x)
-//   trigger           u8      0=size 1=age 2=startup
+//   rows              u32 LE   row count in the uploaded batch
+//   compressed_bytes  u32 LE   size of the parquet file on S3 (after zstd)
+//   upload_ms         u16 LE   parquet write + S3 multipart upload duration
+//   claim_ms          u16 LE   postgres claim CTE duration
+//   ratio_x100        u16 LE   compression ratio × 100 (e.g. 724 → 7.24x)
+//   trigger           u8       0=size 1=age 2=startup
+//   _reserved         u8       padding
+//   batch_id          [16]u8   raw ULID of the parquet file. Not exposed
+//                              as a signal; the gr26 batch hook reads it
+//                              directly out of the raw frame bytes.
 var TCMShelterBatch = mp.Message{
 	mp.NewField("rows", 4, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
 		return []mp.Signal{
@@ -99,6 +105,12 @@ var TCMShelterBatch = mp.Message{
 		}
 	}),
 	mp.NewField("_reserved", 1, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
+		return nil
+	}),
+	// 16 raw ULID bytes. The integer Value overflows int64 (silently —
+	// see mapache-go binary.go) but Bytes are preserved, which is all
+	// the gr26 batch hook needs since it reads from the raw frame.
+	mp.NewField("_batch_id", 16, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
 		return nil
 	}),
 }


### PR DESCRIPTION
- Add a 16-byte \`_batch_id\` field at the end of TCMShelterBatch so the parquet ULID rides along with each upload notification
- Payload now 32 bytes (DLC 13 in CAN-FD); existing six signal-producing fields are unchanged
- \`_batch_id\` doesn't export a signal — the gr26 batch hook will read it straight from the raw frame in a follow-up PR
- Int Value silently overflows int64 on a 16-byte unsigned decode, but Bytes are preserved (see mapache-go/binary.go), which is all we need

## Deploy ordering note
After this lands, shelter still sending 16-byte payloads will fail the \`FillFromBytes\` length check. Frame still persists in \`gr26_can\` with \`metadata.status="decode_error"\` and signals are skipped. Brief window — deploy the matching TCM-26 shelter change promptly after.

## Pairs with
- TCM-26 shelter PR (to be opened) — sends 32-byte payload including ULID
- Mapache follow-up — drop \`gr26_shelter_ingested\` once the job carries the ULID directly