### PR TITLE
refactor(gr26): split HandleMessage into live + replay paths

### DIFF
--- a/gr26/service/message.go
+++ b/gr26/service/message.go
@@ -57,6 +57,12 @@ func SubscribeTopics() {
 	})
 }
 
+// HandleMessage is the live MQTT entry point. Strips the upload-key
+// envelope, validates the key, persists the frame via persistFrame,
+// then publishes signals to the dash WS and fires side-channel hooks.
+//
+// Use replayFrame for cold-storage ingest paths — same persist, no WS,
+// no hooks.
 func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 	if len(message) < 11 {
 		logger.SugarLogger.Infof("[MQ] Message too short, ignoring %d bytes", len(message))
@@ -73,6 +79,39 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 	}
 
 	ts := int(binary.BigEndian.Uint64(timestamp))
+	signals := persistFrame(vehicleID, nodeID, canID, ts, uploadKeyInt, data)
+
+	if config.EnableSignalWS {
+		for _, s := range signals {
+			Hub.Publish(s)
+		}
+	}
+
+	// Side-channel: when shelter announces a successful upload, kick off
+	// a job for the downstream ingest worker. The raw `data` payload
+	// carries the parquet file's ULID in its trailing 16 bytes.
+	if canID == model.MsgIDShelterBatch {
+		go onShelterBatchReceived(vehicleID, ts, data)
+	}
+}
+
+// replayFrame is the cold-storage entry point used by the shelter
+// ingest worker. Same persist as live, but skips WS publish (the data
+// is historical so dashboards shouldn't see it streaming) and skips
+// the side-channel hooks (would recursively re-enqueue ingest jobs).
+//
+// Caller is expected to have already authenticated the source (S3
+// bucket access serves as the trust boundary), so no upload-key
+// validation here.
+func replayFrame(vehicleID, nodeID string, canID, ts int, data []byte) {
+	persistFrame(vehicleID, nodeID, canID, ts, 0, data)
+}
+
+// persistFrame is the decode + persist core shared by the live MQTT
+// (HandleMessage) and cold-storage (replayFrame) paths. Returns the
+// decoded signals so the live path can broadcast them to the WS hub;
+// the replay path discards.
+func persistFrame(vehicleID, nodeID string, canID, ts, uploadKey int, data []byte) []mapache.Signal {
 	producedAt := time.UnixMicro(int64(ts))
 
 	// Attempt to decode first. If anything goes wrong, capture why in
@@ -109,17 +148,17 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 		Timestamp:  ts,
 		CANID:      canID,
 		Bytes:      data,
-		UploadKey:  uploadKeyInt,
+		UploadKey:  uploadKey,
 		Metadata:   meta,
 		ProducedAt: producedAt,
 	})
 	if err != nil {
 		logger.SugarLogger.Infof("Error creating CAN record: %s", err)
-		return
+		return nil
 	}
 
 	if len(signals) == 0 {
-		return
+		return nil
 	}
 	now := time.Now().Truncate(time.Microsecond)
 	for i := range signals {
@@ -131,21 +170,9 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 	}
 	if err := CreateSignals(signals); err != nil {
 		logger.SugarLogger.Infof("Error creating signals: %s", err)
-		return
+		return nil
 	}
-
-	if config.EnableSignalWS {
-		for _, s := range signals {
-			Hub.Publish(s)
-		}
-	}
-
-	// Side-channel: when shelter announces a successful upload, kick off
-	// a job for the downstream ingest worker. The raw `data` payload
-	// carries the parquet file's ULID in its trailing 16 bytes.
-	if canID == model.MsgIDShelterBatch {
-		go onShelterBatchReceived(vehicleID, ts, data)
-	}
+	return signals
 }
 
 func mustJSON(v any) []byte {

--- a/gr26/service/shelter_ingest.go
+++ b/gr26/service/shelter_ingest.go
@@ -3,7 +3,6 @@ package service
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -123,12 +122,11 @@ func processFile(ctx context.Context, client *s3.Client, key, fileULID string) e
 	return nil
 }
 
-// dispatchRow runs one Parquet row through the same decode/persist path
-// the live MQTT subscriber uses. We rebuild the message envelope
-// HandleMessage expects (timestamp u64 BE || upload_key u16 BE || data)
-// with upload_key zeroed — shelter-sourced frames bypass key validation
-// since they came from our own S3 bucket. The cloud gr26 deployment is
-// expected to run with SKIP_AUTH_CHECK=true.
+// dispatchRow runs one Parquet row through the cold-storage decode path
+// (replayFrame). Same persist as live MQTT but skips the WS broadcast
+// (data is historical, dash shouldn't see it streaming) and the
+// shelter-batch side-channel hook (which would recursively enqueue
+// ingest jobs).
 func dispatchRow(r shelterRow) {
 	// Topic format: gr26/{vehicle}/{node}/0x{can_id_hex}
 	parts := strings.Split(r.Topic, "/")
@@ -141,11 +139,5 @@ func dispatchRow(r shelterRow) {
 	if err != nil {
 		return
 	}
-
-	envelope := make([]byte, 10+len(r.Data))
-	binary.BigEndian.PutUint64(envelope[0:8], uint64(r.Timestamp))
-	// envelope[8:10] = upload_key (left zero)
-	copy(envelope[10:], r.Data)
-
-	HandleMessage(r.VehicleID, nodeID, int(canIDInt), envelope)
+	replayFrame(r.VehicleID, nodeID, int(canIDInt), int(r.Timestamp), r.Data)
 }


### PR DESCRIPTION
## What
Extracts the decode+persist core into \`persistFrame\` and gives the cold-storage ingest path a separate entry point (\`replayFrame\`) that skips WS broadcast and the shelter-batch side-channel hook.

## Three functions where there was one
- \`persistFrame(vehicleID, nodeID, canID, ts, uploadKey, data)\` — does the messageStruct.FillFromBytes / CreateCAN / CreateSignals work, returns decoded signals for the caller to optionally broadcast
- \`HandleMessage\` — live MQTT entry. Parses envelope, validates upload key, calls persistFrame, broadcasts to Hub, fires side-channel hook
- \`replayFrame\` — cold-storage entry from the shelter ingest worker. No envelope, no upload-key validation, no WS, no hook

## Behavior changes
- **Live MQTT path:** none. HandleMessage is identical logic, just refactored.
- **Replay path:**
  - WS clients no longer see hours-old "live" signals streaming in when shelter backfills
  - The TCMShelterBatch hook is now correctly a no-op when a shelter-ingested frame happens to be a TCMShelterBatch itself (rare, but would have created an infinite enqueue loop in the previous design)

## dispatchRow simplification
shelter_ingest.go's \`dispatchRow\` calls \`replayFrame\` directly. The synthetic envelope construction (timestamp u64 BE || zero u16 upload_key || data) goes away, along with the encoding/binary import.

## Stacking
Based on Mapache#174 (drop gr26_shelter_ingested). Last in the series; closes out the structural cleanups (1-4 of the 5 we sketched, COPY-FROM perf still open).