### PR TITLE
feat(dashboard): jobs tab

### DIFF
--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   useVehicleList,
 } from "@/lib/store";
 import {
+  Briefcase,
   Bug,
   CarFront,
   ChevronsUpDown,
@@ -280,6 +281,13 @@ const Sidebar = (props: SidebarProps) => {
             text="Vehicles"
             link={`/vehicles?vid=${currentVehicle.id}`}
             isSelected={props.selectedPage === "vehicles"}
+            isSidebarExpanded={props.isSidebarExpanded}
+          />
+          <SidebarItem
+            icon={Briefcase}
+            text="Jobs"
+            link={`/jobs`}
+            isSelected={props.selectedPage === "jobs"}
             isSidebarExpanded={props.isSidebarExpanded}
           />
           <div className="px-4 py-2">

--- a/dashboard/src/components/jobs/JobStatusBadge.tsx
+++ b/dashboard/src/components/jobs/JobStatusBadge.tsx
@@ -1,0 +1,14 @@
+import { Badge } from "@/components/ui/badge";
+
+const STATUS_STYLES: Record<string, string> = {
+  pending: "bg-neutral-700 text-neutral-200 hover:bg-neutral-700",
+  running: "bg-blue-600 text-white hover:bg-blue-600",
+  succeeded: "bg-green-600 text-white hover:bg-green-600",
+  failed: "bg-red-600 text-white hover:bg-red-600",
+  cancelled: "bg-amber-600 text-white hover:bg-amber-600",
+};
+
+export function JobStatusBadge({ status }: { status: string }) {
+  const style = STATUS_STYLES[status] ?? "bg-neutral-700 text-neutral-200";
+  return <Badge className={style}>{status}</Badge>;
+}

--- a/dashboard/src/components/jobs/RunningJobCard.tsx
+++ b/dashboard/src/components/jobs/RunningJobCard.tsx
@@ -4,7 +4,9 @@ import { Separator } from "@/components/ui/separator";
 import { JobStatusBadge } from "@/components/jobs/JobStatusBadge";
 import {
   elapsedMs,
+  formatCount,
   formatDurationMs,
+  PROGRESS_GRADIENT_CLASS,
   useJobStream,
   useTickingNow,
 } from "@/lib/job-stream";
@@ -33,11 +35,15 @@ export function RunningJobCard({ job: initial }: { job: Job }) {
           <div className="truncate text-sm font-semibold">{job.kind}</div>
           <JobStatusBadge status={job.status} />
         </div>
-        <Progress value={pct} className="h-2" />
-        <div className="flex justify-between text-xs text-muted-foreground">
+        <Progress
+          value={pct}
+          className="h-2"
+          indicatorClassName={PROGRESS_GRADIENT_CLASS}
+        />
+        <div className="flex justify-between font-mono text-xs text-muted-foreground">
           <span>
-            {job.progress_current.toLocaleString()} /{" "}
-            {job.progress_total.toLocaleString()}
+            {formatCount(job.progress_current)} /{" "}
+            {formatCount(job.progress_total)}
           </span>
           <span>{pct.toFixed(1)}%</span>
         </div>

--- a/dashboard/src/components/jobs/RunningJobCard.tsx
+++ b/dashboard/src/components/jobs/RunningJobCard.tsx
@@ -1,0 +1,67 @@
+import { Card } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Separator } from "@/components/ui/separator";
+import { JobStatusBadge } from "@/components/jobs/JobStatusBadge";
+import {
+  elapsedMs,
+  formatDurationMs,
+  useJobStream,
+  useTickingNow,
+} from "@/lib/job-stream";
+import { Job, isTerminalStatus } from "@/models/job";
+import { useNavigate } from "react-router-dom";
+
+export function RunningJobCard({ job: initial }: { job: Job }) {
+  const navigate = useNavigate();
+  const { job: streamed } = useJobStream(initial.id, initial);
+  const job = streamed ?? initial;
+  const active = !isTerminalStatus(job.status);
+  const now = useTickingNow(500, active);
+  const elapsed = elapsedMs(job, now);
+  const pct =
+    job.progress_total > 0
+      ? (job.progress_current / job.progress_total) * 100
+      : 0;
+
+  return (
+    <Card
+      className="cursor-pointer p-4 transition-all duration-150 hover:bg-card"
+      onClick={() => navigate(`/jobs/${job.id}`)}
+    >
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <div className="truncate text-sm font-semibold">{job.kind}</div>
+          <JobStatusBadge status={job.status} />
+        </div>
+        <Progress value={pct} className="h-2" />
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>
+            {job.progress_current.toLocaleString()} /{" "}
+            {job.progress_total.toLocaleString()}
+          </span>
+          <span>{pct.toFixed(1)}%</span>
+        </div>
+        {job.progress_message && (
+          <div className="truncate text-xs text-muted-foreground">
+            {job.progress_message}
+          </div>
+        )}
+        <Separator className="my-1" />
+        <div className="grid grid-cols-[80px_1fr] gap-y-1 text-xs">
+          <span className="text-muted-foreground">elapsed</span>
+          <span className="text-right font-mono">
+            {formatDurationMs(elapsed)}
+          </span>
+          <span className="text-muted-foreground">attempt</span>
+          <span className="text-right font-mono">
+            {job.attempt}/{job.max_attempts}
+          </span>
+          <span className="text-muted-foreground">worker</span>
+          <span className="truncate text-right font-mono">
+            {job.worker_id || "—"}
+          </span>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/dashboard/src/lib/job-stream.ts
+++ b/dashboard/src/lib/job-stream.ts
@@ -70,6 +70,27 @@ export function useTickingNow(intervalMs: number, active: boolean): number {
   return now;
 }
 
+// formatCount abbreviates large integers for dense table / card display
+// (e.g. 1234 -> "1.2k", 991232 -> "991k", 4_200_000 -> "4.2M"). Drops the
+// decimal once the result would have 3+ leading digits to avoid noise.
+export function formatCount(n: number): string {
+  if (!Number.isFinite(n)) return "—";
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) {
+    return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  }
+  if (n < 1_000_000_000) {
+    return `${(n / 1_000_000).toFixed(n < 10_000_000 ? 1 : 0)}M`;
+  }
+  return `${(n / 1_000_000_000).toFixed(1)}B`;
+}
+
+// PROGRESS_GRADIENT_CLASS styles a Progress indicator with the GR brand
+// gradient. Exported so list / card / detail progress bars share one
+// source of truth — change here, all job views update together.
+export const PROGRESS_GRADIENT_CLASS =
+  "bg-gradient-to-r from-gr-pink to-gr-purple";
+
 export function formatDurationMs(ms: number): string {
   if (ms < 0) return "—";
   if (ms < 1000) return `${ms}ms`;

--- a/dashboard/src/lib/job-stream.ts
+++ b/dashboard/src/lib/job-stream.ts
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from "react";
+import { BACKEND_URL } from "@/consts/config";
+import { Job, isTerminalStatus } from "@/models/job";
+
+// useJobStream opens an SSE connection to foreman's /events/:id endpoint
+// and keeps the returned job in sync as the server pushes updates. The
+// stream auto-closes once the job reaches a terminal status, mirroring
+// the server-side behaviour in foreman/api/sse.go.
+//
+// `initial` (optional) seeds state before the first event lands so cards
+// rendered from a list fetch don't flash empty. Passing it does not
+// re-open the stream if it doesn't change — only jobId is a dep.
+export function useJobStream(
+  jobId: string | undefined,
+  initial?: Job,
+): { job: Job | null; error: string | null } {
+  const [job, setJob] = useState<Job | null>(initial ?? null);
+  const [error, setError] = useState<string | null>(null);
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!jobId) return;
+    setError(null);
+
+    const es = new EventSource(`${BACKEND_URL}/foreman/events/${jobId}`);
+    esRef.current = es;
+
+    const onJob = (e: MessageEvent) => {
+      try {
+        const data = JSON.parse(e.data) as Job;
+        setJob(data);
+        if (isTerminalStatus(data.status)) {
+          es.close();
+          esRef.current = null;
+        }
+      } catch {
+        setError("malformed event");
+      }
+    };
+    es.addEventListener("job", onJob);
+
+    es.onerror = () => {
+      if (es.readyState === EventSource.CLOSED) {
+        setError("stream closed");
+      }
+      // Otherwise EventSource is auto-reconnecting; let it do its thing.
+    };
+
+    return () => {
+      es.removeEventListener("job", onJob);
+      es.close();
+      esRef.current = null;
+    };
+  }, [jobId]);
+
+  return { job, error };
+}
+
+// useTickingNow returns a Date.now() value that refreshes on the given
+// interval while `active` is true. Use it to drive live elapsed-time
+// displays without coupling to the SSE cadence.
+export function useTickingNow(intervalMs: number, active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    setNow(Date.now());
+    const t = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(t);
+  }, [intervalMs, active]);
+  return now;
+}
+
+export function formatDurationMs(ms: number): string {
+  if (ms < 0) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  const s = ((ms % 60_000) / 1000).toFixed(1);
+  return `${m}m ${s}s`;
+}
+
+// elapsedMs computes the time the job has been running. Falls back to
+// `now` when the job hasn't reported a finished_at yet, so the display
+// keeps ticking while the job is live.
+export function elapsedMs(job: Job, now: number): number {
+  if (!job.started_at) return 0;
+  const start = new Date(job.started_at).getTime();
+  const end = job.finished_at ? new Date(job.finished_at).getTime() : now;
+  return end - start;
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -16,6 +16,8 @@ import SettingsPage from "@/pages/settings/SettingsPage.tsx";
 import VehiclesPage from "@/pages/vehicles/VehiclesPage.tsx";
 import TripsPage from "@/pages/trips/TripsPage.tsx";
 import TripDetailsPage from "@/pages/trips/TripDetailsPage.tsx";
+import JobsPage from "@/pages/jobs/JobsPage.tsx";
+import JobDetailsPage from "@/pages/jobs/JobDetailsPage.tsx";
 import DebugPage from "@/pages/debug/DebugPage.tsx";
 import { useRoseMode } from "@/lib/store";
 import { useEffect } from "react";
@@ -52,6 +54,14 @@ const router = createBrowserRouter([
   {
     path: "/vehicles",
     element: <VehiclesPage />,
+  },
+  {
+    path: "/jobs",
+    element: <JobsPage />,
+  },
+  {
+    path: "/jobs/:id",
+    element: <JobDetailsPage />,
   },
   {
     path: "/debug",

--- a/dashboard/src/models/job.tsx
+++ b/dashboard/src/models/job.tsx
@@ -1,0 +1,59 @@
+export type JobStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled";
+
+export interface Job {
+  id: string;
+  kind: string;
+  queue: string;
+  service: string;
+  status: JobStatus;
+  idempotency_key?: string;
+  params?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+  error?: string;
+  priority: number;
+  progress_current: number;
+  progress_total: number;
+  progress_message?: string;
+  attempt: number;
+  max_attempts: number;
+  worker_id?: string;
+  lease_expires_at?: string;
+  cancel_requested: boolean;
+  scheduled_at?: string;
+  started_at?: string;
+  finished_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export const initJob: Job = {
+  id: "",
+  kind: "",
+  queue: "",
+  service: "",
+  status: "pending",
+  priority: 0,
+  progress_current: 0,
+  progress_total: 0,
+  attempt: 0,
+  max_attempts: 0,
+  cancel_requested: false,
+  created_at: "",
+  updated_at: "",
+};
+
+export const JOB_STATUSES: JobStatus[] = [
+  "pending",
+  "running",
+  "succeeded",
+  "failed",
+  "cancelled",
+];
+
+export const isTerminalStatus = (s: string): boolean =>
+  s === "succeeded" || s === "failed" || s === "cancelled";

--- a/dashboard/src/pages/jobs/JobDetailsPage.tsx
+++ b/dashboard/src/pages/jobs/JobDetailsPage.tsx
@@ -1,0 +1,218 @@
+import Layout from "@/components/Layout";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Progress } from "@/components/ui/progress";
+import { JobStatusBadge } from "@/components/jobs/JobStatusBadge";
+import { LoadingComponent } from "@/components/Loading";
+import { BACKEND_URL } from "@/consts/config";
+import { notify } from "@/lib/notify";
+import { getAxiosErrorMessage } from "@/lib/axios-error-handler";
+import { Job, initJob, isTerminalStatus } from "@/models/job";
+import axios from "axios";
+import { ArrowLeft, RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+const POLL_INTERVAL_MS = 2000;
+
+function JobDetailsPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [job, setJob] = useState<Job>(initJob);
+  const [loaded, setLoaded] = useState(false);
+
+  const fetchJob = async (silent = false) => {
+    if (!id) return;
+    try {
+      const r = await axios.get(`${BACKEND_URL}/foreman/jobs/${id}`, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("sentinel_access_token")}`,
+        },
+      });
+      setJob(r.data.data as Job);
+      setLoaded(true);
+    } catch (e) {
+      if (!silent) {
+        notify.error(getAxiosErrorMessage(e));
+        navigate("/jobs");
+      }
+    }
+  };
+
+  useEffect(() => {
+    fetchJob();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  // Live-refresh while the job is still moving. Stops the moment status
+  // flips to a terminal state.
+  useEffect(() => {
+    if (!loaded || isTerminalStatus(job.status)) return;
+    const t = setInterval(() => fetchJob(true), POLL_INTERVAL_MS);
+    return () => clearInterval(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded, job.status, id]);
+
+  if (!loaded) {
+    return (
+      <Layout activeTab="jobs" headerTitle="Job">
+        <LoadingComponent />
+      </Layout>
+    );
+  }
+
+  const pct =
+    job.progress_total > 0
+      ? (job.progress_current / job.progress_total) * 100
+      : 0;
+
+  return (
+    <Layout activeTab="jobs" headerTitle="Job Details">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <Button variant="outline" onClick={() => navigate("/jobs")}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Jobs
+          </Button>
+          <Button variant="outline" onClick={() => fetchJob()}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Refresh
+          </Button>
+        </div>
+
+        <Card className="p-4">
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap items-center gap-3">
+              <h2 className="text-xl font-semibold">{job.kind}</h2>
+              <JobStatusBadge status={job.status} />
+              {!isTerminalStatus(job.status) && (
+                <span className="text-xs text-muted-foreground">
+                  live • refreshing every {POLL_INTERVAL_MS / 1000}s
+                </span>
+              )}
+            </div>
+            <div className="font-mono text-xs text-muted-foreground">
+              {job.id}
+            </div>
+          </div>
+        </Card>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <Card className="p-4">
+            <h4 className="mb-2">Overview</h4>
+            <Separator className="mb-3" />
+            <DefList
+              items={[
+                ["Queue", job.queue],
+                ["Service", job.service || "—"],
+                ["Priority", String(job.priority)],
+                ["Attempt", `${job.attempt} / ${job.max_attempts}`],
+                ["Worker", job.worker_id || "—"],
+                ["Idempotency key", job.idempotency_key || "—"],
+                ["Scheduled", fmtTime(job.scheduled_at)],
+                ["Created", fmtTime(job.created_at)],
+                ["Started", fmtTime(job.started_at)],
+                ["Finished", fmtTime(job.finished_at)],
+                ["Lease expires", fmtTime(job.lease_expires_at)],
+                ["Duration", formatDuration(job)],
+              ]}
+            />
+          </Card>
+
+          <Card className="p-4">
+            <h4 className="mb-2">Progress</h4>
+            <Separator className="mb-3" />
+            {job.progress_total > 0 ? (
+              <div className="flex flex-col gap-2">
+                <Progress value={pct} />
+                <div className="flex justify-between text-sm text-muted-foreground">
+                  <span>
+                    {job.progress_current.toLocaleString()} /{" "}
+                    {job.progress_total.toLocaleString()}
+                  </span>
+                  <span>{pct.toFixed(1)}%</span>
+                </div>
+                {job.progress_message && (
+                  <div className="text-sm text-muted-foreground">
+                    {job.progress_message}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="text-sm text-muted-foreground">
+                No progress reported.
+              </div>
+            )}
+          </Card>
+        </div>
+
+        {job.params && Object.keys(job.params).length > 0 && (
+          <JsonCard title="Params" data={job.params} />
+        )}
+
+        {job.result && Object.keys(job.result).length > 0 && (
+          <JsonCard title="Result" data={job.result} />
+        )}
+
+        {job.error && (
+          <Card className="border border-red-700 p-4">
+            <h4 className="mb-2 text-red-400">Error</h4>
+            <Separator className="mb-3" />
+            <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-xs text-red-200">
+              {job.error}
+            </pre>
+          </Card>
+        )}
+      </div>
+    </Layout>
+  );
+}
+
+function DefList({ items }: { items: [string, string][] }) {
+  return (
+    <dl className="grid grid-cols-[140px_1fr] gap-y-1.5 text-sm">
+      {items.map(([k, v]) => (
+        <div key={k} className="contents">
+          <dt className="text-muted-foreground">{k}</dt>
+          <dd className="break-all font-mono text-xs">{v}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function JsonCard({ title, data }: { title: string; data: unknown }) {
+  return (
+    <Card className="p-4">
+      <h4 className="mb-2">{title}</h4>
+      <Separator className="mb-3" />
+      <pre className="overflow-x-auto rounded bg-neutral-950 p-3 font-mono text-xs">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </Card>
+  );
+}
+
+function fmtTime(s?: string): string {
+  if (!s) return "—";
+  const d = new Date(s);
+  if (isNaN(d.getTime())) return "—";
+  return d.toLocaleString();
+}
+
+function formatDuration(job: Job): string {
+  if (!job.started_at) return "—";
+  const end = job.finished_at
+    ? new Date(job.finished_at).getTime()
+    : Date.now();
+  const start = new Date(job.started_at).getTime();
+  const ms = end - start;
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(2)}s`;
+  const m = Math.floor(ms / 60_000);
+  const s = ((ms % 60_000) / 1000).toFixed(1);
+  return `${m}m ${s}s`;
+}
+
+export default JobDetailsPage;

--- a/dashboard/src/pages/jobs/JobDetailsPage.tsx
+++ b/dashboard/src/pages/jobs/JobDetailsPage.tsx
@@ -5,68 +5,36 @@ import { Separator } from "@/components/ui/separator";
 import { Progress } from "@/components/ui/progress";
 import { JobStatusBadge } from "@/components/jobs/JobStatusBadge";
 import { LoadingComponent } from "@/components/Loading";
-import { BACKEND_URL } from "@/consts/config";
-import { notify } from "@/lib/notify";
-import { getAxiosErrorMessage } from "@/lib/axios-error-handler";
-import { Job, initJob, isTerminalStatus } from "@/models/job";
-import axios from "axios";
-import { ArrowLeft, RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import {
+  elapsedMs,
+  formatDurationMs,
+  useJobStream,
+  useTickingNow,
+} from "@/lib/job-stream";
+import { Job, isTerminalStatus } from "@/models/job";
+import { ArrowLeft } from "lucide-react";
 import { useNavigate, useParams } from "react-router-dom";
-
-const POLL_INTERVAL_MS = 2000;
 
 function JobDetailsPage() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const [job, setJob] = useState<Job>(initJob);
-  const [loaded, setLoaded] = useState(false);
+  const { job, error } = useJobStream(id);
 
-  const fetchJob = async (silent = false) => {
-    if (!id) return;
-    try {
-      const r = await axios.get(`${BACKEND_URL}/foreman/jobs/${id}`, {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem("sentinel_access_token")}`,
-        },
-      });
-      setJob(r.data.data as Job);
-      setLoaded(true);
-    } catch (e) {
-      if (!silent) {
-        notify.error(getAxiosErrorMessage(e));
-        navigate("/jobs");
-      }
-    }
-  };
-
-  useEffect(() => {
-    fetchJob();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
-
-  // Live-refresh while the job is still moving. Stops the moment status
-  // flips to a terminal state.
-  useEffect(() => {
-    if (!loaded || isTerminalStatus(job.status)) return;
-    const t = setInterval(() => fetchJob(true), POLL_INTERVAL_MS);
-    return () => clearInterval(t);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loaded, job.status, id]);
-
-  if (!loaded) {
+  if (!job) {
     return (
       <Layout activeTab="jobs" headerTitle="Job">
-        <LoadingComponent />
+        {error ? (
+          <Card className="border border-red-700 p-4">
+            <div className="text-sm text-red-200">{error}</div>
+          </Card>
+        ) : (
+          <LoadingComponent />
+        )}
       </Layout>
     );
   }
 
-  const pct =
-    job.progress_total > 0
-      ? (job.progress_current / job.progress_total) * 100
-      : 0;
-
+  const active = !isTerminalStatus(job.status);
   return (
     <Layout activeTab="jobs" headerTitle="Job Details">
       <div className="flex flex-col gap-4">
@@ -75,76 +43,13 @@ function JobDetailsPage() {
             <ArrowLeft className="mr-2 h-4 w-4" />
             Back to Jobs
           </Button>
-          <Button variant="outline" onClick={() => fetchJob()}>
-            <RefreshCw className="mr-2 h-4 w-4" />
-            Refresh
-          </Button>
         </div>
 
-        <Card className="p-4">
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-wrap items-center gap-3">
-              <h2 className="text-xl font-semibold">{job.kind}</h2>
-              <JobStatusBadge status={job.status} />
-              {!isTerminalStatus(job.status) && (
-                <span className="text-xs text-muted-foreground">
-                  live • refreshing every {POLL_INTERVAL_MS / 1000}s
-                </span>
-              )}
-            </div>
-            <div className="font-mono text-xs text-muted-foreground">
-              {job.id}
-            </div>
-          </div>
-        </Card>
+        <JobHeader job={job} active={active} />
 
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <Card className="p-4">
-            <h4 className="mb-2">Overview</h4>
-            <Separator className="mb-3" />
-            <DefList
-              items={[
-                ["Queue", job.queue],
-                ["Service", job.service || "—"],
-                ["Priority", String(job.priority)],
-                ["Attempt", `${job.attempt} / ${job.max_attempts}`],
-                ["Worker", job.worker_id || "—"],
-                ["Idempotency key", job.idempotency_key || "—"],
-                ["Scheduled", fmtTime(job.scheduled_at)],
-                ["Created", fmtTime(job.created_at)],
-                ["Started", fmtTime(job.started_at)],
-                ["Finished", fmtTime(job.finished_at)],
-                ["Lease expires", fmtTime(job.lease_expires_at)],
-                ["Duration", formatDuration(job)],
-              ]}
-            />
-          </Card>
-
-          <Card className="p-4">
-            <h4 className="mb-2">Progress</h4>
-            <Separator className="mb-3" />
-            {job.progress_total > 0 ? (
-              <div className="flex flex-col gap-2">
-                <Progress value={pct} />
-                <div className="flex justify-between text-sm text-muted-foreground">
-                  <span>
-                    {job.progress_current.toLocaleString()} /{" "}
-                    {job.progress_total.toLocaleString()}
-                  </span>
-                  <span>{pct.toFixed(1)}%</span>
-                </div>
-                {job.progress_message && (
-                  <div className="text-sm text-muted-foreground">
-                    {job.progress_message}
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div className="text-sm text-muted-foreground">
-                No progress reported.
-              </div>
-            )}
-          </Card>
+          <OverviewCard job={job} active={active} />
+          <ProgressCard job={job} />
         </div>
 
         {job.params && Object.keys(job.params).length > 0 && (
@@ -166,6 +71,108 @@ function JobDetailsPage() {
         )}
       </div>
     </Layout>
+  );
+}
+
+function JobHeader({ job, active }: { job: Job; active: boolean }) {
+  const now = useTickingNow(500, active);
+  const elapsed = elapsedMs(job, now);
+  return (
+    <Card className="p-4">
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-3">
+          <h2 className="text-xl font-semibold">{job.kind}</h2>
+          <JobStatusBadge status={job.status} />
+          {active ? (
+            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className="relative flex h-2 w-2">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-500 opacity-75" />
+                <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
+              </span>
+              live
+            </span>
+          ) : null}
+        </div>
+        <div className="flex items-baseline gap-4">
+          <div className="font-mono text-xs text-muted-foreground">
+            {job.id}
+          </div>
+          {job.started_at && (
+            <div className="ml-auto flex items-baseline gap-2">
+              <span className="text-xs text-muted-foreground">
+                {active ? "elapsed" : "duration"}
+              </span>
+              <span className="font-mono text-lg">
+                {formatDurationMs(elapsed)}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function OverviewCard({ job, active }: { job: Job; active: boolean }) {
+  const now = useTickingNow(500, active);
+  return (
+    <Card className="p-4">
+      <h4 className="mb-2">Overview</h4>
+      <Separator className="mb-3" />
+      <DefList
+        items={[
+          ["Queue", job.queue],
+          ["Service", job.service || "—"],
+          ["Priority", String(job.priority)],
+          ["Attempt", `${job.attempt} / ${job.max_attempts}`],
+          ["Worker", job.worker_id || "—"],
+          ["Idempotency key", job.idempotency_key || "—"],
+          ["Scheduled", fmtTime(job.scheduled_at)],
+          ["Created", fmtTime(job.created_at)],
+          ["Started", fmtTime(job.started_at)],
+          ["Finished", fmtTime(job.finished_at)],
+          ["Lease expires", fmtTime(job.lease_expires_at)],
+          [
+            active ? "Elapsed" : "Duration",
+            job.started_at ? formatDurationMs(elapsedMs(job, now)) : "—",
+          ],
+        ]}
+      />
+    </Card>
+  );
+}
+
+function ProgressCard({ job }: { job: Job }) {
+  const pct =
+    job.progress_total > 0
+      ? (job.progress_current / job.progress_total) * 100
+      : 0;
+  return (
+    <Card className="p-4">
+      <h4 className="mb-2">Progress</h4>
+      <Separator className="mb-3" />
+      {job.progress_total > 0 ? (
+        <div className="flex flex-col gap-2">
+          <Progress value={pct} />
+          <div className="flex justify-between text-sm text-muted-foreground">
+            <span>
+              {job.progress_current.toLocaleString()} /{" "}
+              {job.progress_total.toLocaleString()}
+            </span>
+            <span>{pct.toFixed(1)}%</span>
+          </div>
+          {job.progress_message && (
+            <div className="text-sm text-muted-foreground">
+              {job.progress_message}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="text-sm text-muted-foreground">
+          No progress reported.
+        </div>
+      )}
+    </Card>
   );
 }
 
@@ -199,20 +206,6 @@ function fmtTime(s?: string): string {
   const d = new Date(s);
   if (isNaN(d.getTime())) return "—";
   return d.toLocaleString();
-}
-
-function formatDuration(job: Job): string {
-  if (!job.started_at) return "—";
-  const end = job.finished_at
-    ? new Date(job.finished_at).getTime()
-    : Date.now();
-  const start = new Date(job.started_at).getTime();
-  const ms = end - start;
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60_000) return `${(ms / 1000).toFixed(2)}s`;
-  const m = Math.floor(ms / 60_000);
-  const s = ((ms % 60_000) / 1000).toFixed(1);
-  return `${m}m ${s}s`;
 }
 
 export default JobDetailsPage;

--- a/dashboard/src/pages/jobs/JobDetailsPage.tsx
+++ b/dashboard/src/pages/jobs/JobDetailsPage.tsx
@@ -8,6 +8,7 @@ import { LoadingComponent } from "@/components/Loading";
 import {
   elapsedMs,
   formatDurationMs,
+  PROGRESS_GRADIENT_CLASS,
   useJobStream,
   useTickingNow,
 } from "@/lib/job-stream";
@@ -153,7 +154,7 @@ function ProgressCard({ job }: { job: Job }) {
       <Separator className="mb-3" />
       {job.progress_total > 0 ? (
         <div className="flex flex-col gap-2">
-          <Progress value={pct} />
+          <Progress value={pct} indicatorClassName={PROGRESS_GRADIENT_CLASS} />
           <div className="flex justify-between text-sm text-muted-foreground">
             <span>
               {job.progress_current.toLocaleString()} /{" "}

--- a/dashboard/src/pages/jobs/JobsPage.tsx
+++ b/dashboard/src/pages/jobs/JobsPage.tsx
@@ -1,0 +1,279 @@
+import Layout from "@/components/Layout";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { BACKEND_URL } from "@/consts/config";
+import { notify } from "@/lib/notify";
+import { getAxiosErrorMessage } from "@/lib/axios-error-handler";
+import { Job, JOB_STATUSES, isTerminalStatus } from "@/models/job";
+import { JobStatusBadge } from "@/components/jobs/JobStatusBadge";
+import axios from "axios";
+import { RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const PAGE_SIZE = 50;
+const POLL_INTERVAL_MS = 5000;
+
+function JobsPage() {
+  const navigate = useNavigate();
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState("");
+  const [kind, setKind] = useState("");
+  const [serviceName, setServiceName] = useState("");
+  const [hasMore, setHasMore] = useState(false);
+  const [paginated, setPaginated] = useState(false);
+
+  const fetchJobs = useCallback(
+    async (cursor?: string) => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams();
+        params.set("limit", String(PAGE_SIZE));
+        if (status) params.set("status", status);
+        if (kind.trim()) params.set("kind", kind.trim());
+        if (serviceName.trim()) params.set("service", serviceName.trim());
+        if (cursor) params.set("cursor", cursor);
+        const r = await axios.get(
+          `${BACKEND_URL}/foreman/jobs?${params.toString()}`,
+          {
+            headers: {
+              Authorization: `Bearer ${localStorage.getItem("sentinel_access_token")}`,
+            },
+          },
+        );
+        const newJobs = (r.data.data as Job[]) ?? [];
+        setJobs((prev) => (cursor ? [...prev, ...newJobs] : newJobs));
+        setHasMore(newJobs.length === PAGE_SIZE);
+      } catch (e) {
+        notify.error(getAxiosErrorMessage(e));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [status, kind, serviceName],
+  );
+
+  // Filter changes reset pagination + reload from the top.
+  useEffect(() => {
+    setPaginated(false);
+    fetchJobs();
+  }, [fetchJobs]);
+
+  // Poll the first page while any visible job is still moving. Skip if the
+  // user has clicked "Load more" — refreshing would blow away the appended
+  // pages, which is more annoying than a stale list.
+  useEffect(() => {
+    if (paginated) return;
+    if (!jobs.some((j) => !isTerminalStatus(j.status))) return;
+    const t = setInterval(() => fetchJobs(), POLL_INTERVAL_MS);
+    return () => clearInterval(t);
+  }, [jobs, paginated, fetchJobs]);
+
+  const handleLoadMore = () => {
+    const last = jobs[jobs.length - 1];
+    if (!last) return;
+    setPaginated(true);
+    fetchJobs(last.id);
+  };
+
+  return (
+    <Layout activeTab="jobs" headerTitle="Jobs">
+      <div className="flex flex-col gap-4">
+        <FilterBar
+          status={status}
+          setStatus={setStatus}
+          kind={kind}
+          setKind={setKind}
+          serviceName={serviceName}
+          setServiceName={setServiceName}
+          loading={loading}
+          onRefresh={() => {
+            setPaginated(false);
+            fetchJobs();
+          }}
+        />
+
+        <Card>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ID</TableHead>
+                <TableHead>Kind</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Attempt</TableHead>
+                <TableHead>Progress</TableHead>
+                <TableHead>Duration</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {jobs.length === 0 && !loading && (
+                <TableRow>
+                  <TableCell
+                    colSpan={7}
+                    className="py-8 text-center text-muted-foreground"
+                  >
+                    No jobs found
+                  </TableCell>
+                </TableRow>
+              )}
+              {jobs.map((j) => (
+                <JobRow
+                  key={j.id}
+                  job={j}
+                  onClick={() => navigate(`/jobs/${j.id}`)}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </Card>
+
+        {hasMore && (
+          <div className="flex justify-center">
+            <Button
+              variant="outline"
+              onClick={handleLoadMore}
+              disabled={loading}
+            >
+              Load more
+            </Button>
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}
+
+interface FilterBarProps {
+  status: string;
+  setStatus: (s: string) => void;
+  kind: string;
+  setKind: (s: string) => void;
+  serviceName: string;
+  setServiceName: (s: string) => void;
+  loading: boolean;
+  onRefresh: () => void;
+}
+
+function FilterBar(props: FilterBarProps) {
+  return (
+    <div className="flex flex-wrap items-end gap-4">
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Status</label>
+        <Select
+          value={props.status || "all"}
+          onValueChange={(v) => props.setStatus(v === "all" ? "" : v)}
+        >
+          <SelectTrigger className="w-[160px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            {JOB_STATUSES.map((s) => (
+              <SelectItem key={s} value={s}>
+                {s}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Kind</label>
+        <Input
+          value={props.kind}
+          onChange={(e) => props.setKind(e.target.value)}
+          placeholder="e.g. gr26.ingest_batch"
+          className="w-[260px]"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">Service</label>
+        <Input
+          value={props.serviceName}
+          onChange={(e) => props.setServiceName(e.target.value)}
+          placeholder="e.g. gr26"
+          className="w-[160px]"
+        />
+      </div>
+      <Button
+        variant="outline"
+        onClick={props.onRefresh}
+        disabled={props.loading}
+      >
+        <RefreshCw
+          className={`h-4 w-4 ${props.loading ? "animate-spin" : ""}`}
+        />
+      </Button>
+    </div>
+  );
+}
+
+function JobRow({ job, onClick }: { job: Job; onClick: () => void }) {
+  const pct =
+    job.progress_total > 0
+      ? (job.progress_current / job.progress_total) * 100
+      : 0;
+  return (
+    <TableRow className="cursor-pointer" onClick={onClick}>
+      <TableCell className="font-mono text-xs">{job.id.slice(-12)}</TableCell>
+      <TableCell>{job.kind}</TableCell>
+      <TableCell>
+        <JobStatusBadge status={job.status} />
+      </TableCell>
+      <TableCell>
+        {job.attempt}/{job.max_attempts}
+      </TableCell>
+      <TableCell className="w-[220px]">
+        {job.progress_total > 0 ? (
+          <div className="flex items-center gap-2">
+            <Progress value={pct} className="h-1.5 w-24" />
+            <span className="whitespace-nowrap text-xs text-muted-foreground">
+              {job.progress_current.toLocaleString()}/
+              {job.progress_total.toLocaleString()}
+            </span>
+          </div>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )}
+      </TableCell>
+      <TableCell className="text-xs">{formatDuration(job)}</TableCell>
+      <TableCell className="text-xs text-muted-foreground">
+        {new Date(job.created_at).toLocaleString()}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function formatDuration(job: Job): string {
+  if (!job.started_at) return "—";
+  const end = job.finished_at
+    ? new Date(job.finished_at).getTime()
+    : Date.now();
+  const start = new Date(job.started_at).getTime();
+  const ms = end - start;
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  const s = Math.floor((ms % 60_000) / 1000);
+  return `${m}m ${s}s`;
+}
+
+export default JobsPage;

--- a/dashboard/src/pages/jobs/JobsPage.tsx
+++ b/dashboard/src/pages/jobs/JobsPage.tsx
@@ -21,7 +21,12 @@ import {
 import { BACKEND_URL } from "@/consts/config";
 import { notify } from "@/lib/notify";
 import { getAxiosErrorMessage } from "@/lib/axios-error-handler";
-import { formatDurationMs, elapsedMs } from "@/lib/job-stream";
+import {
+  formatDurationMs,
+  formatCount,
+  elapsedMs,
+  PROGRESS_GRADIENT_CLASS,
+} from "@/lib/job-stream";
 import { Job, JOB_STATUSES, isTerminalStatus } from "@/models/job";
 import { JobStatusBadge } from "@/components/jobs/JobStatusBadge";
 import { RunningJobCard } from "@/components/jobs/RunningJobCard";
@@ -266,10 +271,14 @@ function JobRow({ job, onClick }: { job: Job; onClick: () => void }) {
       <TableCell className="w-[220px]">
         {job.progress_total > 0 ? (
           <div className="flex items-center gap-2">
-            <Progress value={pct} className="h-1.5 w-24" />
-            <span className="whitespace-nowrap text-xs text-muted-foreground">
-              {job.progress_current.toLocaleString()}/
-              {job.progress_total.toLocaleString()}
+            <Progress
+              value={pct}
+              className="h-1.5 w-24"
+              indicatorClassName={PROGRESS_GRADIENT_CLASS}
+            />
+            <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+              {formatCount(job.progress_current)}/
+              {formatCount(job.progress_total)}
             </span>
           </div>
         ) : (

--- a/dashboard/src/pages/jobs/JobsPage.tsx
+++ b/dashboard/src/pages/jobs/JobsPage.tsx
@@ -21,11 +21,13 @@ import {
 import { BACKEND_URL } from "@/consts/config";
 import { notify } from "@/lib/notify";
 import { getAxiosErrorMessage } from "@/lib/axios-error-handler";
+import { formatDurationMs, elapsedMs } from "@/lib/job-stream";
 import { Job, JOB_STATUSES, isTerminalStatus } from "@/models/job";
 import { JobStatusBadge } from "@/components/jobs/JobStatusBadge";
+import { RunningJobCard } from "@/components/jobs/RunningJobCard";
 import axios from "axios";
 import { RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 const PAGE_SIZE = 50;
@@ -77,9 +79,11 @@ function JobsPage() {
     fetchJobs();
   }, [fetchJobs]);
 
-  // Poll the first page while any visible job is still moving. Skip if the
-  // user has clicked "Load more" — refreshing would blow away the appended
-  // pages, which is more annoying than a stale list.
+  // Per-card SSE streams (RunningJobCard) keep in-progress data fresh in
+  // real-time, so we only poll the list to *discover* newly enqueued or
+  // newly-running jobs. Skip while the user has paginated — refreshing
+  // would blow away the appended pages, which is more annoying than a
+  // stale list.
   useEffect(() => {
     if (paginated) return;
     if (!jobs.some((j) => !isTerminalStatus(j.status))) return;
@@ -93,6 +97,11 @@ function JobsPage() {
     setPaginated(true);
     fetchJobs(last.id);
   };
+
+  const runningJobs = useMemo(
+    () => jobs.filter((j) => !isTerminalStatus(j.status)),
+    [jobs],
+  );
 
   return (
     <Layout activeTab="jobs" headerTitle="Jobs">
@@ -110,6 +119,19 @@ function JobsPage() {
             fetchJobs();
           }}
         />
+
+        {runningJobs.length > 0 && (
+          <div className="flex flex-col gap-2">
+            <h3 className="text-sm font-semibold text-muted-foreground">
+              Running ({runningJobs.length})
+            </h3>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+              {runningJobs.map((j) => (
+                <RunningJobCard key={j.id} job={j} />
+              ))}
+            </div>
+          </div>
+        )}
 
         <Card>
           <Table>
@@ -254,26 +276,14 @@ function JobRow({ job, onClick }: { job: Job; onClick: () => void }) {
           <span className="text-muted-foreground">—</span>
         )}
       </TableCell>
-      <TableCell className="text-xs">{formatDuration(job)}</TableCell>
+      <TableCell className="text-xs">
+        {job.started_at ? formatDurationMs(elapsedMs(job, Date.now())) : "—"}
+      </TableCell>
       <TableCell className="text-xs text-muted-foreground">
         {new Date(job.created_at).toLocaleString()}
       </TableCell>
     </TableRow>
   );
-}
-
-function formatDuration(job: Job): string {
-  if (!job.started_at) return "—";
-  const end = job.finished_at
-    ? new Date(job.finished_at).getTime()
-    : Date.now();
-  const start = new Date(job.started_at).getTime();
-  const ms = end - start;
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
-  const m = Math.floor(ms / 60_000);
-  const s = Math.floor((ms % 60_000) / 1000);
-  return `${m}m ${s}s`;
 }
 
 export default JobsPage;

--- a/dashboard/src/pages/jobs/JobsPage.tsx
+++ b/dashboard/src/pages/jobs/JobsPage.tsx
@@ -274,7 +274,11 @@ function JobRow({ job, onClick }: { job: Job; onClick: () => void }) {
             <Progress
               value={pct}
               className="h-1.5 w-24"
-              indicatorClassName={PROGRESS_GRADIENT_CLASS}
+              indicatorClassName={
+                isTerminalStatus(job.status)
+                  ? "bg-white"
+                  : PROGRESS_GRADIENT_CLASS
+              }
             />
             <span className="whitespace-nowrap font-mono text-xs text-muted-foreground">
               {formatCount(job.progress_current)}/

--- a/gr26/job/ingest_batch.go
+++ b/gr26/job/ingest_batch.go
@@ -174,6 +174,10 @@ func processFile(ctx context.Context, client *s3.Client, key string, progress *w
 	}
 
 	duration := time.Since(start)
+	// Pin progress to (total, total) so the worker's final heartbeat
+	// flush stores a clean 100% reading instead of whatever the last
+	// in-flight tick caught.
+	progress.Set(totalRows, totalRows, "complete")
 	logger.SugarLogger.Infof("[SHELTER] %s: %d rows in %s (decoded=%d unknown=%d errors=%d)",
 		key, total, duration, stats.decoded, stats.unknown, stats.decodeError)
 

--- a/gr26/worker/worker.go
+++ b/gr26/worker/worker.go
@@ -123,6 +123,25 @@ func (w *Worker) runJob(ctx context.Context, job *foreman.Job) {
 		return
 	}
 
+	// Flush the handler's final progress before Complete so the DB row
+	// reflects the terminal state, not whatever the last 10s ticker
+	// happened to catch. Handlers that ended mid-tick would otherwise
+	// freeze at the last snapshot (e.g. 991k/1M instead of 1M/1M).
+	if cur, tot, msg, set := progress.snapshot(); set {
+		req := foreman.HeartbeatRequest{
+			WorkerID:        w.ID,
+			LeaseSec:        claimLeaseSec,
+			ProgressCurrent: &cur,
+			ProgressTotal:   &tot,
+		}
+		if msg != "" {
+			req.ProgressMessage = &msg
+		}
+		if err := foreman.Heartbeat(ctx, job.ID, req); err != nil {
+			logger.SugarLogger.Warnf("[WORKER %s] final heartbeat %s failed: %v", w.ID, job.ID, err)
+		}
+	}
+
 	if err := foreman.Complete(ctx, job.ID, foreman.CompleteRequest{
 		WorkerID: w.ID,
 		Result:   result,


### PR DESCRIPTION
- new /jobs route with paginated list view (status / kind / service filters, cursor-based load more)
- /jobs/:id detail page showing overview, progress, params, result, error
- inline progress bar on list rows
- list auto-refreshes every 5s while non-terminal jobs are visible; detail auto-refreshes every 2s while non-terminal — polling stops once the job settles
- status badges colour-coded by state (pending / running / succeeded / failed / cancelled)
- sidebar entry under Vehicles