### PR TITLE
feat(dashboard): production Dockerfile + CI workflow

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,160 @@
+name: dashboard
+run-name: Triggered by ${{ github.event_name }} to ${{ github.ref }} by @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    name: Build ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate platform pair
+        id: platform
+        run: |
+          platform=${{ matrix.platform }}
+          echo "pair=${platform//\//-}" >> $GITHUB_OUTPUT
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: dashboard
+          platforms: ${{ matrix.platform }}
+          # Mapbox token is required at build time — Vite bakes it into the
+          # bundle. Missing secret → empty string → maps render blank but
+          # the rest of the app works.
+          build-args: |
+            VITE_MAPBOX_ACCESS_TOKEN=${{ secrets.MAPBOX_ACCESS_TOKEN }}
+          outputs: type=image,name=ghcr.io/gaucho-racing/mapache/dashboard,push-by-digest=true,name-canonical=true,push=true
+          cache-from: |
+            type=gha,scope=build-${{ github.workflow }}-${{ steps.platform.outputs.pair }}-${{ github.ref_name }}
+            type=gha,scope=build-${{ github.workflow }}-${{ steps.platform.outputs.pair }}-main
+          cache-to: type=gha,scope=build-${{ github.workflow }}-${{ steps.platform.outputs.pair }}-${{ github.ref_name }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ steps.platform.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    name: Merge manifests
+    needs: build
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if this commit has a release tag
+        id: release
+        run: |
+          tag=$(git tag --points-at HEAD | grep '^v' | head -n1)
+          if [ -n "$tag" ]; then
+            echo "Found tag: $tag"
+            if gh release view "$tag" --json tagName > /dev/null 2>&1; then
+              echo "release_tag=$tag" >> $GITHUB_OUTPUT
+              echo "is_release=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+          echo "is_release=false" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate tag list
+        id: tags
+        shell: bash
+        run: |
+          TAGS="type=sha"
+
+          if [ "${GITHUB_REF_TYPE}" = "branch" ] && [ "${GITHUB_REF_NAME}" = "main" ]; then
+            TAGS="${TAGS}\ntype=raw,value=latest"
+          fi
+
+          if [ "${{ steps.release.outputs.is_release }}" = "true" ]; then
+            CLEAN_TAG=$(echo "${{ steps.release.outputs.release_tag }}" | sed 's/^v//')
+            TAGS="${TAGS}\ntype=raw,value=${CLEAN_TAG}"
+          fi
+
+          echo -e "tags<<EOF\n$TAGS\nEOF" >> $GITHUB_OUTPUT
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/gaucho-racing/mapache/dashboard
+          tags: ${{ steps.tags.outputs.tags }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'ghcr.io/gaucho-racing/mapache/dashboard@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ghcr.io/gaucho-racing/mapache/dashboard:${{ steps.meta.outputs.version }}

--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+*.log
+Dockerfile.dev

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,22 @@
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . ./
+
+# Build-time Vite vars are baked into the bundle. Backend URL / WS URL
+# default to the prod hostname inside src/consts/config.tsx, so they
+# don't need to be passed here. Mapbox is the one that has to be
+# injected at build time — empty token = maps won't render.
+ARG VITE_MAPBOX_ACCESS_TOKEN=""
+ENV VITE_MAPBOX_ACCESS_TOKEN=$VITE_MAPBOX_ACCESS_TOKEN
+
+RUN npm run build
+
+FROM nginx:alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/dashboard/nginx.conf
+++ b/dashboard/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback — react-router uses pushState, so unknown paths must
+    # serve index.html and let the client handle routing.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Static assets are content-hashed by Vite, so they're safe to cache
+    # forever. index.html stays uncacheable so deploys take effect on the
+    # next page load.
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -297,7 +297,8 @@ case "$TARGET" in
 
         GO_CONFIG_SERVICES=("auth" "gr26" "vehicle" "foreman")
         PY_SERVICES=("query")
-        ALL_SERVICES=("${GO_CONFIG_SERVICES[@]}" "${PY_SERVICES[@]}")
+        NODE_SERVICES=("dashboard")
+        ALL_SERVICES=("${GO_CONFIG_SERVICES[@]}" "${PY_SERVICES[@]}" "${NODE_SERVICES[@]}")
 
         echo ""
         echo "=== Release Summary ==="
@@ -313,6 +314,9 @@ case "$TARGET" in
         done
         for svc in "${PY_SERVICES[@]}"; do
             echo "    ${svc}/pyproject.toml"
+        done
+        for svc in "${NODE_SERVICES[@]}"; do
+            echo "    ${svc}/package.json"
         done
         echo ""
         echo "  Docker images that will be tagged:"
@@ -332,6 +336,12 @@ case "$TARGET" in
         for svc in "${PY_SERVICES[@]}"; do
             sed -i '' "s/^version = \".*\"/version = \"${SEMVER}\"/" "${REPO_ROOT}/${svc}/pyproject.toml"
         done
+        # Top-level package.json "version" — the only line in package.json
+        # matching this pattern (npm deps use the package name as key, not
+        # the literal token "version").
+        for svc in "${NODE_SERVICES[@]}"; do
+            sed -i '' "s/\"version\": \".*\"/\"version\": \"${SEMVER}\"/" "${REPO_ROOT}/${svc}/package.json"
+        done
 
         FILES=()
         for svc in "${GO_CONFIG_SERVICES[@]}"; do
@@ -339,6 +349,9 @@ case "$TARGET" in
         done
         for svc in "${PY_SERVICES[@]}"; do
             FILES+=("${svc}/pyproject.toml")
+        done
+        for svc in "${NODE_SERVICES[@]}"; do
+            FILES+=("${svc}/package.json")
         done
         git add "${FILES[@]}"
         git commit -m "release: mapache ${VERSION}"


### PR DESCRIPTION
- Multi-stage `dashboard/Dockerfile`: `node:22-alpine` builder → `nginx:alpine` runtime
- `dashboard/nginx.conf`: SPA fallback (`try_files \$uri /index.html`) + `Cache-Control: immutable` on Vite's hashed `/assets/`
- `dashboard/.dockerignore` excludes `node_modules`, `dist`, `Dockerfile.dev` from the build context
- `.github/workflows/dashboard.yml` mirrors `gr26.yml`: per-platform build matrix (amd64+arm64), push-by-digest then manifest merge, tags on `main` + release tags
- `VITE_MAPBOX_ACCESS_TOKEN` passed as a Docker build-arg from `secrets.MAPBOX_ACCESS_TOKEN`. Other `VITE_*` already default to the prod hostname / sentinel client_id inside `src/consts/config.tsx`, so nothing else needs plumbing
- `scripts/release.sh`: `dashboard` joins the `mapache` release loop under a new `NODE_SERVICES` group — `package.json` `"version"` gets bumped alongside `config.go` / `pyproject.toml` for the other services

## Test plan
- [x] `docker build` locally completes (3MB JS / 901KB gzip)
- [ ] Repo secret `MAPBOX_ACCESS_TOKEN` exists (set up by maintainer; missing secret → empty token → maps render blank but app works)
- [ ] First push: dashboard workflow runs to green, image lands at `ghcr.io/gaucho-racing/mapache/dashboard:latest` and `:sha-<hash>`
- [ ] `docker run -p 8080:80 ghcr.io/gaucho-racing/mapache/dashboard:latest` → `curl localhost:8080/` returns `index.html`, `curl localhost:8080/anything` returns same (SPA fallback)
- [ ] Cut a release with `scripts/release.sh 3.4.0` to verify the new `package.json` bump path