### PR TITLE
feat: job fan-out (ingest_latest_batch + ingest_all_batches) + new job dialog

### DIFF
--- a/dashboard/src/components/jobs/EnqueueJobDialog.tsx
+++ b/dashboard/src/components/jobs/EnqueueJobDialog.tsx
@@ -27,18 +27,23 @@ import { useNavigate } from "react-router-dom";
 interface Preset {
   kind: string;
   description: string;
-  service: string;
   params: Record<string, unknown>;
   maxAttempts: number;
 }
 
 const CUSTOM_VALUE = "__custom__";
 
+// `service` on a job is who *requested* it — when the user clicks New
+// Job, that's the dashboard. The kind tells the worker pool what to
+// pick up; service is just the producer tag. Kept distinct from the
+// MQTT-triggered path in gr26's OnShelterBatchReceived which sets
+// service="gr26".
+const REQUESTER_SERVICE = "dashboard";
+
 const PRESETS: Preset[] = [
   {
     kind: "gr26.ingest_batch",
     description: "Ingest a specific parquet by file_ulid.",
-    service: "gr26",
     params: { vehicle_id: "gr26", file_ulid: "" },
     maxAttempts: 3,
   },
@@ -46,7 +51,6 @@ const PRESETS: Preset[] = [
     kind: "gr26.ingest_latest_batch",
     description:
       "Find the most-recently-uploaded parquet for a vehicle and ingest it inline.",
-    service: "gr26",
     params: { vehicle_id: "gr26" },
     maxAttempts: 3,
   },
@@ -54,7 +58,6 @@ const PRESETS: Preset[] = [
     kind: "gr26.ingest_all_batches",
     description:
       "Fan-out: enqueue an ingest_batch for every parquet uploaded in the last N hours.",
-    service: "gr26",
     params: { vehicle_id: "gr26", hours: 24 },
     maxAttempts: 1,
   },
@@ -74,7 +77,7 @@ export function EnqueueJobDialog({
   const navigate = useNavigate();
   const [presetValue, setPresetValue] = useState<string>(PRESETS[0].kind);
   const [kind, setKind] = useState("");
-  const [service, setService] = useState("");
+  const [service, setService] = useState(REQUESTER_SERVICE);
   const [paramsText, setParamsText] = useState("{}");
   const [idempotencyKey, setIdempotencyKey] = useState("");
   const [priority, setPriority] = useState("0");
@@ -94,7 +97,7 @@ export function EnqueueJobDialog({
       return;
     }
     setKind(p.kind);
-    setService(p.service);
+    setService(REQUESTER_SERVICE);
     setParamsText(JSON.stringify(p.params, null, 2));
     setMaxAttempts(String(p.maxAttempts));
     setParamsError(null);

--- a/dashboard/src/components/jobs/EnqueueJobDialog.tsx
+++ b/dashboard/src/components/jobs/EnqueueJobDialog.tsx
@@ -1,0 +1,270 @@
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { BACKEND_URL } from "@/consts/config";
+import { getAxiosErrorMessage } from "@/lib/axios-error-handler";
+import { notify } from "@/lib/notify";
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+interface Preset {
+  kind: string;
+  description: string;
+  service: string;
+  params: Record<string, unknown>;
+  maxAttempts: number;
+}
+
+const CUSTOM_VALUE = "__custom__";
+
+const PRESETS: Preset[] = [
+  {
+    kind: "gr26.ingest_batch",
+    description: "Ingest a specific parquet by file_ulid.",
+    service: "gr26",
+    params: { vehicle_id: "gr26", file_ulid: "" },
+    maxAttempts: 3,
+  },
+  {
+    kind: "gr26.ingest_latest_batch",
+    description:
+      "Find the most-recently-uploaded parquet for a vehicle and ingest it inline.",
+    service: "gr26",
+    params: { vehicle_id: "gr26" },
+    maxAttempts: 3,
+  },
+  {
+    kind: "gr26.ingest_all_batches",
+    description:
+      "Fan-out: enqueue an ingest_batch for every parquet uploaded in the last N hours.",
+    service: "gr26",
+    params: { vehicle_id: "gr26", hours: 24 },
+    maxAttempts: 1,
+  },
+];
+
+interface EnqueueJobDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onEnqueued?: (jobId: string) => void;
+}
+
+export function EnqueueJobDialog({
+  open,
+  onOpenChange,
+  onEnqueued,
+}: EnqueueJobDialogProps) {
+  const navigate = useNavigate();
+  const [presetValue, setPresetValue] = useState<string>(PRESETS[0].kind);
+  const [kind, setKind] = useState("");
+  const [service, setService] = useState("");
+  const [paramsText, setParamsText] = useState("{}");
+  const [idempotencyKey, setIdempotencyKey] = useState("");
+  const [priority, setPriority] = useState("0");
+  const [maxAttempts, setMaxAttempts] = useState("1");
+  const [submitting, setSubmitting] = useState(false);
+  const [paramsError, setParamsError] = useState<string | null>(null);
+
+  // Apply a preset whenever it's picked (or on first open). "Custom"
+  // wipes the kind input but leaves the rest so users can tweak from
+  // a copied-over template.
+  useEffect(() => {
+    if (!open) return;
+    const p = PRESETS.find((x) => x.kind === presetValue);
+    if (!p) {
+      // custom — leave fields, just clear kind so the user notices
+      setKind("");
+      return;
+    }
+    setKind(p.kind);
+    setService(p.service);
+    setParamsText(JSON.stringify(p.params, null, 2));
+    setMaxAttempts(String(p.maxAttempts));
+    setParamsError(null);
+  }, [presetValue, open]);
+
+  const activePreset = PRESETS.find((p) => p.kind === presetValue);
+
+  const submit = async () => {
+    if (!kind.trim()) {
+      notify.error("kind is required");
+      return;
+    }
+    let params: unknown;
+    try {
+      params = paramsText.trim() ? JSON.parse(paramsText) : null;
+      setParamsError(null);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setParamsError(msg);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const body: Record<string, unknown> = {
+        kind: kind.trim(),
+        max_attempts: Number(maxAttempts) || 1,
+        priority: Number(priority) || 0,
+      };
+      if (service.trim()) body.service = service.trim();
+      if (idempotencyKey.trim()) body.idempotency_key = idempotencyKey.trim();
+      if (params !== null) body.params = params;
+
+      const r = await axios.post(`${BACKEND_URL}/foreman/jobs`, body, {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("sentinel_access_token")}`,
+        },
+      });
+      const job = r.data.data;
+      notify.success(`Enqueued ${job.id}`);
+      onOpenChange(false);
+      onEnqueued?.(job.id);
+      navigate(`/jobs/${job.id}`);
+    } catch (e) {
+      // Foreman returns 409 with { conflict: true, job: ... } when the
+      // idempotency key collides. Axios surfaces it as an error.
+      const raw = axios.isAxiosError(e) ? e.response?.data?.data : undefined;
+      if (raw?.conflict && raw?.job?.id) {
+        notify.error(`Already enqueued: ${raw.job.id}`);
+        onOpenChange(false);
+        navigate(`/jobs/${raw.job.id}`);
+        return;
+      }
+      notify.error(getAxiosErrorMessage(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>New Job</DialogTitle>
+          <DialogDescription>
+            Enqueue a job in foreman. Pick a preset for a templated params
+            skeleton, or "Custom" to fill in any kind by hand.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label>Preset</Label>
+            <Select value={presetValue} onValueChange={setPresetValue}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PRESETS.map((p) => (
+                  <SelectItem key={p.kind} value={p.kind}>
+                    {p.kind}
+                  </SelectItem>
+                ))}
+                <SelectItem value={CUSTOM_VALUE}>Custom</SelectItem>
+              </SelectContent>
+            </Select>
+            {activePreset && (
+              <div className="text-xs text-muted-foreground">
+                {activePreset.description}
+              </div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label>Kind</Label>
+              <Input
+                value={kind}
+                onChange={(e) => setKind(e.target.value)}
+                placeholder="e.g. gr26.ingest_batch"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label>Service</Label>
+              <Input
+                value={service}
+                onChange={(e) => setService(e.target.value)}
+                placeholder="e.g. gr26"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label>Params (JSON)</Label>
+            <Textarea
+              value={paramsText}
+              onChange={(e) => {
+                setParamsText(e.target.value);
+                setParamsError(null);
+              }}
+              placeholder='{ "vehicle_id": "gr26" }'
+              rows={6}
+              className="font-mono text-xs"
+            />
+            {paramsError && (
+              <div className="text-xs text-red-400">{paramsError}</div>
+            )}
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label>Priority</Label>
+              <Input
+                type="number"
+                value={priority}
+                onChange={(e) => setPriority(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label>Max attempts</Label>
+              <Input
+                type="number"
+                value={maxAttempts}
+                onChange={(e) => setMaxAttempts(e.target.value)}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label>Idempotency key</Label>
+              <Input
+                value={idempotencyKey}
+                onChange={(e) => setIdempotencyKey(e.target.value)}
+                placeholder="optional"
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={submitting}>
+            {submitting ? "Enqueueing…" : "Enqueue"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/src/pages/jobs/JobsPage.tsx
+++ b/dashboard/src/pages/jobs/JobsPage.tsx
@@ -28,10 +28,11 @@ import {
   PROGRESS_GRADIENT_CLASS,
 } from "@/lib/job-stream";
 import { Job, JOB_STATUSES, isTerminalStatus } from "@/models/job";
+import { EnqueueJobDialog } from "@/components/jobs/EnqueueJobDialog";
 import { JobStatusBadge } from "@/components/jobs/JobStatusBadge";
 import { RunningJobCard } from "@/components/jobs/RunningJobCard";
 import axios from "axios";
-import { RefreshCw } from "lucide-react";
+import { Plus, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -47,6 +48,7 @@ function JobsPage() {
   const [serviceName, setServiceName] = useState("");
   const [hasMore, setHasMore] = useState(false);
   const [paginated, setPaginated] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   const fetchJobs = useCallback(
     async (cursor?: string) => {
@@ -120,6 +122,16 @@ function JobsPage() {
           setServiceName={setServiceName}
           loading={loading}
           onRefresh={() => {
+            setPaginated(false);
+            fetchJobs();
+          }}
+          onNew={() => setDialogOpen(true)}
+        />
+
+        <EnqueueJobDialog
+          open={dialogOpen}
+          onOpenChange={setDialogOpen}
+          onEnqueued={() => {
             setPaginated(false);
             fetchJobs();
           }}
@@ -198,56 +210,63 @@ interface FilterBarProps {
   setServiceName: (s: string) => void;
   loading: boolean;
   onRefresh: () => void;
+  onNew: () => void;
 }
 
 function FilterBar(props: FilterBarProps) {
   return (
-    <div className="flex flex-wrap items-end gap-4">
-      <div className="flex flex-col gap-1">
-        <label className="text-xs text-muted-foreground">Status</label>
-        <Select
-          value={props.status || "all"}
-          onValueChange={(v) => props.setStatus(v === "all" ? "" : v)}
+    <div className="flex flex-wrap items-end justify-between gap-4">
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-muted-foreground">Status</label>
+          <Select
+            value={props.status || "all"}
+            onValueChange={(v) => props.setStatus(v === "all" ? "" : v)}
+          >
+            <SelectTrigger className="w-[160px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              {JOB_STATUSES.map((s) => (
+                <SelectItem key={s} value={s}>
+                  {s}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-muted-foreground">Kind</label>
+          <Input
+            value={props.kind}
+            onChange={(e) => props.setKind(e.target.value)}
+            placeholder="e.g. gr26.ingest_batch"
+            className="w-[260px]"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-muted-foreground">Service</label>
+          <Input
+            value={props.serviceName}
+            onChange={(e) => props.setServiceName(e.target.value)}
+            placeholder="e.g. gr26"
+            className="w-[160px]"
+          />
+        </div>
+        <Button
+          variant="outline"
+          onClick={props.onRefresh}
+          disabled={props.loading}
         >
-          <SelectTrigger className="w-[160px]">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All</SelectItem>
-            {JOB_STATUSES.map((s) => (
-              <SelectItem key={s} value={s}>
-                {s}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          <RefreshCw
+            className={`h-4 w-4 ${props.loading ? "animate-spin" : ""}`}
+          />
+        </Button>
       </div>
-      <div className="flex flex-col gap-1">
-        <label className="text-xs text-muted-foreground">Kind</label>
-        <Input
-          value={props.kind}
-          onChange={(e) => props.setKind(e.target.value)}
-          placeholder="e.g. gr26.ingest_batch"
-          className="w-[260px]"
-        />
-      </div>
-      <div className="flex flex-col gap-1">
-        <label className="text-xs text-muted-foreground">Service</label>
-        <Input
-          value={props.serviceName}
-          onChange={(e) => props.setServiceName(e.target.value)}
-          placeholder="e.g. gr26"
-          className="w-[160px]"
-        />
-      </div>
-      <Button
-        variant="outline"
-        onClick={props.onRefresh}
-        disabled={props.loading}
-      >
-        <RefreshCw
-          className={`h-4 w-4 ${props.loading ? "animate-spin" : ""}`}
-        />
+      <Button onClick={props.onNew}>
+        <Plus className="mr-2 h-4 w-4" />
+        New Job
       </Button>
     </div>
   );

--- a/gr26/job/ingest_all_batches.go
+++ b/gr26/job/ingest_all_batches.go
@@ -1,0 +1,134 @@
+package job
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	gr26config "github.com/gaucho-racing/mapache/gr26/config"
+	"github.com/gaucho-racing/mapache/gr26/pkg/foreman"
+	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
+	"github.com/gaucho-racing/mapache/gr26/worker"
+)
+
+// ingestAllParams is the params shape for gr26.ingest_all_batches jobs.
+// HoursBack is how far back from "now" we look; a 24 means anything
+// uploaded in the last day.
+type ingestAllParams struct {
+	VehicleID string `json:"vehicle_id"`
+	Hours     int    `json:"hours"`
+}
+
+// ingestAllResult is the json shape stored on foreman's job.result. The
+// per-file Entries list reflects every file the handler tried to enqueue
+// — including ones that 409'd because they were already done.
+type ingestAllResult struct {
+	VehicleID   string            `json:"vehicle_id"`
+	HoursBack   int               `json:"hours_back"`
+	Found       int               `json:"found"`
+	Enqueued    int               `json:"enqueued"`
+	AlreadyDone int               `json:"already_done"`
+	Failed      int               `json:"failed,omitempty"`
+	Entries     []ingestAllEntry  `json:"entries"`
+}
+
+type ingestAllEntry struct {
+	FileULID string `json:"file_ulid"`
+	JobID    string `json:"job_id,omitempty"`
+	Status   string `json:"status"` // "enqueued" | "already_done" | "failed"
+	Error    string `json:"error,omitempty"`
+}
+
+// IngestAllBatchesHandler fans out: lists every shelter parquet for the
+// given vehicle, filters to those uploaded in the last `hours` hours,
+// and enqueues one gr26.ingest_batch job per file. Returns immediately
+// once enqueueing is done; the spawned ingests run independently and
+// show up as their own rows in /jobs.
+//
+// Idempotency keys match the live-feed producer
+// (gr26.ingest_batch:<vehicle>:<file_ulid>) so re-running this handler
+// on the same window is safe — already-ingested files come back as
+// "already_done" entries without spawning a duplicate job.
+func IngestAllBatchesHandler(ctx context.Context, j *foreman.Job, progress *worker.ProgressReporter) (json.RawMessage, error) {
+	if gr26config.ShelterS3Bucket == "" {
+		return nil, errors.New("shelter ingest configured at foreman but SHELTER_S3_BUCKET is unset")
+	}
+	var p ingestAllParams
+	if err := json.Unmarshal(j.Params, &p); err != nil {
+		return nil, fmt.Errorf("decode params: %w", err)
+	}
+	if p.VehicleID == "" {
+		return nil, errors.New("missing vehicle_id")
+	}
+	if p.Hours <= 0 {
+		return nil, errors.New("hours must be > 0")
+	}
+
+	client, err := newS3Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	progress.Set(0, 0, "listing shelter bucket")
+	objects, err := listShelterObjects(ctx, client, p.VehicleID)
+	if err != nil {
+		return nil, err
+	}
+
+	since := time.Now().Add(-time.Duration(p.Hours) * time.Hour)
+	inRange := make([]shelterObject, 0, len(objects))
+	for _, o := range objects {
+		if o.LastModified.After(since) {
+			inRange = append(inRange, o)
+		}
+	}
+
+	logger.SugarLogger.Infof("[SHELTER] ingest_all for %s: %d/%d files in last %dh",
+		p.VehicleID, len(inRange), len(objects), p.Hours)
+
+	progress.Set(0, int64(len(inRange)), "enqueueing ingest jobs")
+
+	res := ingestAllResult{
+		VehicleID: p.VehicleID,
+		HoursBack: p.Hours,
+		Found:     len(inRange),
+		Entries:   make([]ingestAllEntry, 0, len(inRange)),
+	}
+	for i, o := range inRange {
+		fileULID := extractFileULID(o.Key)
+		entry := ingestAllEntry{FileULID: fileULID}
+
+		idem := fmt.Sprintf("gr26.ingest_batch:%s:%s", p.VehicleID, fileULID)
+		params, _ := json.Marshal(shelterIngestParams{
+			VehicleID: p.VehicleID,
+			FileULID:  fileULID,
+		})
+		out, err := foreman.Enqueue(ctx, foreman.EnqueueRequest{
+			Kind:           "gr26.ingest_batch",
+			Service:        "gr26",
+			IdempotencyKey: &idem,
+			Params:         params,
+			MaxAttempts:    3,
+		})
+		switch {
+		case err != nil:
+			entry.Status = "failed"
+			entry.Error = err.Error()
+			res.Failed++
+		case out.Created:
+			entry.Status = "enqueued"
+			entry.JobID = out.JobID
+			res.Enqueued++
+		default:
+			entry.Status = "already_done"
+			entry.JobID = out.JobID
+			res.AlreadyDone++
+		}
+		res.Entries = append(res.Entries, entry)
+		progress.Set(int64(i+1), int64(len(inRange)), "enqueueing ingest jobs")
+	}
+
+	return json.Marshal(res)
+}

--- a/gr26/job/ingest_batch.go
+++ b/gr26/job/ingest_batch.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/parquet-go/parquet-go"
 	ulid "github.com/gaucho-racing/ulid-go"
@@ -63,7 +62,7 @@ func OnShelterBatchReceived(vehicleID string, ts int, data []byte) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := foreman.Enqueue(ctx, req); err != nil {
+	if _, err := foreman.Enqueue(ctx, req); err != nil {
 		logger.SugarLogger.Errorf("[SHELTER] failed to enqueue ingest job for %s/%s: %v", vehicleID, fileULID, err)
 		return
 	}
@@ -112,22 +111,20 @@ func IngestBatchHandler(ctx context.Context, job *foreman.Job, progress *worker.
 		return nil, fmt.Errorf("incomplete params: vehicle_id=%q file_ulid=%q", p.VehicleID, p.FileULID)
 	}
 
-	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
-		awsconfig.WithRegion(gr26config.ShelterS3Region),
-	)
+	client, err := newS3Client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("aws config: %w", err)
+		return nil, err
 	}
-	client := s3.NewFromConfig(awsCfg)
 
-	// Path scheme must stay in sync with TCM-26 shelter/service/upload.py.
-	prefix := strings.TrimRight(gr26config.ShelterS3Prefix, "/")
-	key := fmt.Sprintf("%s/%s/batch_%s.parquet", prefix, p.VehicleID, p.FileULID)
-
-	return processFile(ctx, client, key, progress)
+	res, err := processFile(ctx, client, shelterKey(p.VehicleID, p.FileULID), progress)
+	if err != nil {
+		return nil, err
+	}
+	res.FileULID = p.FileULID
+	return json.Marshal(res)
 }
 
-func processFile(ctx context.Context, client *s3.Client, key string, progress *worker.ProgressReporter) (json.RawMessage, error) {
+func processFile(ctx context.Context, client *s3.Client, key string, progress *worker.ProgressReporter) (ingestResult, error) {
 	start := time.Now()
 	logger.SugarLogger.Infof("[SHELTER] processing %s", key)
 	progress.Set(0, 0, "downloading parquet from s3")
@@ -137,7 +134,7 @@ func processFile(ctx context.Context, client *s3.Client, key string, progress *w
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("get: %w", err)
+		return ingestResult{}, fmt.Errorf("get: %w", err)
 	}
 	defer obj.Body.Close()
 
@@ -146,7 +143,7 @@ func processFile(ctx context.Context, client *s3.Client, key string, progress *w
 	// a couple hundred MB we'd switch to a tempfile + io.ReaderAt.
 	body, err := io.ReadAll(obj.Body)
 	if err != nil {
-		return nil, fmt.Errorf("download: %w", err)
+		return ingestResult{}, fmt.Errorf("download: %w", err)
 	}
 
 	pr := parquet.NewGenericReader[shelterRow](bytes.NewReader(body))
@@ -169,7 +166,7 @@ func processFile(ctx context.Context, client *s3.Client, key string, progress *w
 			break
 		}
 		if readErr != nil {
-			return nil, fmt.Errorf("parquet read: %w", readErr)
+			return ingestResult{}, fmt.Errorf("parquet read: %w", readErr)
 		}
 	}
 
@@ -181,7 +178,7 @@ func processFile(ctx context.Context, client *s3.Client, key string, progress *w
 	logger.SugarLogger.Infof("[SHELTER] %s: %d rows in %s (decoded=%d unknown=%d errors=%d)",
 		key, total, duration, stats.decoded, stats.unknown, stats.decodeError)
 
-	return json.Marshal(ingestResult{
+	return ingestResult{
 		TotalRows:            total,
 		Decoded:              stats.decoded,
 		UnknownCanID:         stats.unknown,
@@ -189,7 +186,7 @@ func processFile(ctx context.Context, client *s3.Client, key string, progress *w
 		DurationMs:           duration.Milliseconds(),
 		UnknownBreakdown:     topUnknown(stats.unknownByCanID, 10),
 		DecodeErrorBreakdown: topErrors(stats.errorByCanID, 10),
-	})
+	}, nil
 }
 
 // dispatchRow parses the topic out of one Parquet row and runs it
@@ -298,7 +295,10 @@ type errorBreakdownEntry struct {
 
 // ingestResult is the json shape stored on foreman's job.result column.
 // Top-N caps keep payload size bounded even on pathological batches.
+// FileULID is set by the handler after processFile returns — handy for
+// ingest_latest_batch where the file_ulid isn't in the job params.
 type ingestResult struct {
+	FileULID             string                `json:"file_ulid,omitempty"`
 	TotalRows            int                   `json:"total_rows"`
 	Decoded              int                   `json:"decoded"`
 	UnknownCanID         int                   `json:"unknown_can_id"`

--- a/gr26/job/ingest_latest_batch.go
+++ b/gr26/job/ingest_latest_batch.go
@@ -1,0 +1,70 @@
+package job
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+
+	gr26config "github.com/gaucho-racing/mapache/gr26/config"
+	"github.com/gaucho-racing/mapache/gr26/pkg/foreman"
+	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
+	"github.com/gaucho-racing/mapache/gr26/worker"
+)
+
+// ingestLatestParams is the params shape for gr26.ingest_latest_batch
+// jobs. Just a vehicle_id — the handler resolves the actual file at
+// claim time.
+type ingestLatestParams struct {
+	VehicleID string `json:"vehicle_id"`
+}
+
+// IngestLatestBatchHandler picks the most recently uploaded parquet
+// under the vehicle's shelter prefix and ingests it inline. The
+// resolved file_ulid lands in the job's result so the dashboard makes
+// it obvious which file got processed.
+//
+// Sort order is by S3 LastModified (newest first), matching the dialog
+// preset language ("most recently uploaded").
+func IngestLatestBatchHandler(ctx context.Context, j *foreman.Job, progress *worker.ProgressReporter) (json.RawMessage, error) {
+	if gr26config.ShelterS3Bucket == "" {
+		return nil, errors.New("shelter ingest configured at foreman but SHELTER_S3_BUCKET is unset")
+	}
+	var p ingestLatestParams
+	if err := json.Unmarshal(j.Params, &p); err != nil {
+		return nil, fmt.Errorf("decode params: %w", err)
+	}
+	if p.VehicleID == "" {
+		return nil, errors.New("missing vehicle_id")
+	}
+
+	client, err := newS3Client(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	progress.Set(0, 0, "listing shelter bucket")
+	objects, err := listShelterObjects(ctx, client, p.VehicleID)
+	if err != nil {
+		return nil, err
+	}
+	if len(objects) == 0 {
+		return nil, fmt.Errorf("no batches found for vehicle %s", p.VehicleID)
+	}
+
+	sort.Slice(objects, func(i, k int) bool {
+		return objects[i].LastModified.After(objects[k].LastModified)
+	})
+	latest := objects[0]
+	fileULID := extractFileULID(latest.Key)
+	logger.SugarLogger.Infof("[SHELTER] latest for %s: %s (LastModified=%s)",
+		p.VehicleID, fileULID, latest.LastModified)
+
+	res, err := processFile(ctx, client, latest.Key, progress)
+	if err != nil {
+		return nil, err
+	}
+	res.FileULID = fileULID
+	return json.Marshal(res)
+}

--- a/gr26/job/shelter.go
+++ b/gr26/job/shelter.go
@@ -1,0 +1,92 @@
+package job
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	gr26config "github.com/gaucho-racing/mapache/gr26/config"
+)
+
+// newS3Client builds an S3 client from the default credential chain +
+// configured region. Centralised so every shelter job uses identical
+// auth wiring.
+func newS3Client(ctx context.Context) (*s3.Client, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(gr26config.ShelterS3Region),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("aws config: %w", err)
+	}
+	return s3.NewFromConfig(cfg), nil
+}
+
+// shelterKey returns the canonical S3 key for a given vehicle + file ULID,
+// matching the layout TCM-26's shelter/service/upload.py writes to.
+func shelterKey(vehicleID, fileULID string) string {
+	prefix := strings.TrimRight(gr26config.ShelterS3Prefix, "/")
+	return fmt.Sprintf("%s/%s/batch_%s.parquet", prefix, vehicleID, fileULID)
+}
+
+// extractFileULID parses the ULID out of a shelter S3 key. Returns the
+// empty string if the basename doesn't match the expected
+// "batch_<ulid>.parquet" shape — callers should treat that as a skip.
+func extractFileULID(key string) string {
+	base := key
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	if !strings.HasPrefix(base, "batch_") || !strings.HasSuffix(base, ".parquet") {
+		return ""
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(base, "batch_"), ".parquet")
+}
+
+// shelterObject is the slim subset of an S3 ListObjectsV2 entry the
+// shelter jobs care about.
+type shelterObject struct {
+	Key          string
+	LastModified time.Time
+	SizeBytes    int64
+}
+
+// listShelterObjects pages through ListObjectsV2 under one vehicle's
+// shelter prefix and returns every batch_*.parquet object it sees. Non-
+// matching entries (e.g. anything not following the batch naming scheme)
+// are dropped.
+func listShelterObjects(ctx context.Context, client *s3.Client, vehicleID string) ([]shelterObject, error) {
+	prefix := strings.TrimRight(gr26config.ShelterS3Prefix, "/") + "/" + vehicleID + "/"
+	var out []shelterObject
+	var token *string
+	for {
+		page, err := client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket:            aws.String(gr26config.ShelterS3Bucket),
+			Prefix:            aws.String(prefix),
+			ContinuationToken: token,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list: %w", err)
+		}
+		for _, o := range page.Contents {
+			key := aws.ToString(o.Key)
+			if extractFileULID(key) == "" {
+				continue
+			}
+			out = append(out, shelterObject{
+				Key:          key,
+				LastModified: aws.ToTime(o.LastModified),
+				SizeBytes:    aws.ToInt64(o.Size),
+			})
+		}
+		if !aws.ToBool(page.IsTruncated) {
+			break
+		}
+		token = page.NextContinuationToken
+	}
+	return out, nil
+}

--- a/gr26/main.go
+++ b/gr26/main.go
@@ -32,6 +32,8 @@ func main() {
 
 	reg := worker.NewRegistry()
 	reg.Register("gr26.ingest_batch", job.IngestBatchHandler)
+	reg.Register("gr26.ingest_latest_batch", job.IngestLatestBatchHandler)
+	reg.Register("gr26.ingest_all_batches", job.IngestAllBatchesHandler)
 	worker.StartPool(context.Background(), reg)
 
 	api.Run()

--- a/gr26/pkg/foreman/client.go
+++ b/gr26/pkg/foreman/client.go
@@ -73,26 +73,47 @@ type FailRequest struct {
 
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
-// Enqueue POSTs the request to foreman. Returns nil on success (201) or
-// conflict (409 — idempotency key collision, treated as "already
-// enqueued"). No-op when FOREMAN_ENDPOINT is unset.
-func Enqueue(ctx context.Context, req EnqueueRequest) error {
+// EnqueueResult is what callers get back from Enqueue. Created
+// distinguishes 201 (new job) from 409 (idempotency key collision,
+// existing job returned). JobID is populated for both — handy for
+// fan-out callers that want to record which jobs they queued.
+type EnqueueResult struct {
+	Created bool
+	JobID   string
+}
+
+// Enqueue POSTs the request to foreman. Treats 409 as a non-error
+// (Created=false) so idempotent retransmits don't bubble as failures.
+// Returns a zero EnqueueResult when FOREMAN_ENDPOINT is unset.
+func Enqueue(ctx context.Context, req EnqueueRequest) (EnqueueResult, error) {
 	if config.ForemanEndpoint == "" {
-		return nil
+		return EnqueueResult{}, nil
 	}
 	resp, err := doJSON(ctx, http.MethodPost, "/foreman/jobs", req)
 	if err != nil {
-		return err
+		return EnqueueResult{}, err
 	}
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case http.StatusCreated:
-		return nil
+		var job Job
+		if err := json.NewDecoder(resp.Body).Decode(&job); err != nil {
+			return EnqueueResult{}, fmt.Errorf("decode created: %w", err)
+		}
+		return EnqueueResult{Created: true, JobID: job.ID}, nil
 	case http.StatusConflict:
-		logger.SugarLogger.Debugf("[FOREMAN] job already enqueued (kind=%s, idem=%v)", req.Kind, deref(req.IdempotencyKey))
-		return nil
+		var body struct {
+			Job Job `json:"job"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			logger.SugarLogger.Debugf("[FOREMAN] conflict decode (kind=%s): %v", req.Kind, err)
+			return EnqueueResult{Created: false}, nil
+		}
+		logger.SugarLogger.Debugf("[FOREMAN] job already enqueued (kind=%s, idem=%v, id=%s)",
+			req.Kind, deref(req.IdempotencyKey), body.Job.ID)
+		return EnqueueResult{Created: false, JobID: body.Job.ID}, nil
 	default:
-		return fmt.Errorf("enqueue: foreman responded %d", resp.StatusCode)
+		return EnqueueResult{}, fmt.Errorf("enqueue: foreman responded %d", resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
- new gr26.ingest_latest_batch handler — resolves the most recent parquet for a vehicle from S3 LastModified and ingests it inline
- new gr26.ingest_all_batches handler — fan-out: enqueues an ingest_batch per parquet uploaded in the last N hours, returns a per-file enqueued/already_done/failed breakdown
- foreman.Enqueue now returns an EnqueueResult struct (Created, JobID) so fan-out callers can distinguish 201 from 409
- shared shelter.go helpers (S3 client, key construction, ULID extraction, listObjects pagination)
- dashboard "New Job" button + dialog on /jobs with kind presets that pre-fill the params JSON skeleton; supports custom kinds
- 409 idempotency conflicts redirect to the existing job