### PR TITLE
feat(mapache-go): add ClickHouse DDL consts for signal and ping

### DIFF
--- a/mapache-go/ping.go
+++ b/mapache-go/ping.go
@@ -17,3 +17,18 @@ type Ping struct {
 func (Ping) TableName() string {
 	return "ping"
 }
+
+// PingClickHouseDDL is the ClickHouse table definition for Ping, shared by
+// every service that writes or migrates the ping table. The dedup key
+// (vehicle_id, ping) mirrors the gorm primary key above; created_at is the
+// ReplacingMergeTree version column so a retransmitted ping collapses on
+// merge.
+const PingClickHouseDDL = `
+CREATE TABLE IF NOT EXISTS ping (
+	vehicle_id LowCardinality(String),
+	ping       Int64,
+	pong       Int64,
+	latency    Int32,
+	created_at DateTime64(6, 'UTC') DEFAULT now64(6)
+) ENGINE = ReplacingMergeTree(created_at)
+ORDER BY (vehicle_id, ping)`

--- a/mapache-go/ping.go
+++ b/mapache-go/ping.go
@@ -19,16 +19,27 @@ func (Ping) TableName() string {
 }
 
 // PingClickHouseDDL is the ClickHouse table definition for Ping, shared by
-// every service that writes or migrates the ping table. The dedup key
-// (vehicle_id, ping) mirrors the gorm primary key above; created_at is the
-// ReplacingMergeTree version column so a retransmitted ping collapses on
-// merge.
+// every service that writes or migrates the ping table.
+//
+// Optimized for bursty vehicle telemetry where the dominant read pattern is:
+//   vehicle_id + ping time window.
+//
+// Dedup identity is logically (vehicle_id, ping), but this table does not use
+// ReplacingMergeTree because pings are append-only and not backfilled/corrected.
 const PingClickHouseDDL = `
 CREATE TABLE IF NOT EXISTS ping (
-	vehicle_id LowCardinality(String),
-	ping       Int64,
-	pong       Int64,
-	latency    Int32,
-	created_at DateTime64(6, 'UTC') DEFAULT now64(6)
-) ENGINE = ReplacingMergeTree(created_at)
+    vehicle_id LowCardinality(String),
+
+    ping       Int64 CODEC(Delta, ZSTD(1)),
+
+    pong       Int64 CODEC(Delta, ZSTD(1)),
+
+    latency    Int32 CODEC(T64, ZSTD(1)),
+
+    ping_at    DateTime64(6, 'UTC')
+        MATERIALIZED fromUnixTimestamp64Micro(ping)
+        CODEC(Delta, ZSTD(1))
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(ping_at)
 ORDER BY (vehicle_id, ping)`

--- a/mapache-go/signal.go
+++ b/mapache-go/signal.go
@@ -37,3 +37,24 @@ type Signal struct {
 func (Signal) TableName() string {
 	return "signal"
 }
+
+// SignalClickHouseDDL is the ClickHouse table definition for Signal, shared
+// by every service that writes or migrates the signal table. The dedup key
+// (vehicle_id, name, timestamp) mirrors the gorm uniqueIndex above;
+// produced_at is derived from timestamp so it is never written directly, and
+// created_at is the ReplacingMergeTree version column so a later write
+// (retransmit, corrected decode, replay) wins on merge.
+const SignalClickHouseDDL = `
+CREATE TABLE IF NOT EXISTS signal (
+	id          String,
+	timestamp   Int64,
+	vehicle_id  LowCardinality(String),
+	name        LowCardinality(String),
+	value       Float64,
+	raw_value   Int64,
+	produced_at DateTime64(6, 'UTC') MATERIALIZED toDateTime64(timestamp / 1e6, 6, 'UTC'),
+	created_at  DateTime64(6, 'UTC') DEFAULT now64(6),
+	INDEX idx_id id TYPE bloom_filter GRANULARITY 4
+) ENGINE = ReplacingMergeTree(created_at)
+PARTITION BY toYYYYMM(produced_at)
+ORDER BY (vehicle_id, name, timestamp)`

--- a/mapache-go/signal.go
+++ b/mapache-go/signal.go
@@ -38,23 +38,41 @@ func (Signal) TableName() string {
 	return "signal"
 }
 
-// SignalClickHouseDDL is the ClickHouse table definition for Signal, shared
-// by every service that writes or migrates the signal table. The dedup key
-// (vehicle_id, name, timestamp) mirrors the gorm uniqueIndex above;
-// produced_at is derived from timestamp so it is never written directly, and
-// created_at is the ReplacingMergeTree version column so a later write
-// (retransmit, corrected decode, replay) wins on merge.
+// SignalClickHouseDDL is the ClickHouse table definition for Signal.
+//
+// Optimized for bursty vehicle telemetry where the dominant read pattern is:
+//   vehicle_id + small timestamp window + many signal names.
+//
+// Dedup key is (vehicle_id, timestamp, name), implemented via the
+// ReplacingMergeTree sorting key. created_at is the version column, so later
+// writes win during background merges.
+//
+// Note: ReplacingMergeTree deduplication is eventual; queries that require
+// immediate latest-row correctness should use FINAL or argMax-style reads.
 const SignalClickHouseDDL = `
 CREATE TABLE IF NOT EXISTS signal (
-	id          String,
-	timestamp   Int64,
-	vehicle_id  LowCardinality(String),
-	name        LowCardinality(String),
-	value       Float64,
-	raw_value   Int64,
-	produced_at DateTime64(6, 'UTC') MATERIALIZED toDateTime64(timestamp / 1e6, 6, 'UTC'),
-	created_at  DateTime64(6, 'UTC') DEFAULT now64(6),
-	INDEX idx_id id TYPE bloom_filter GRANULARITY 4
-) ENGINE = ReplacingMergeTree(created_at)
+    id          String CODEC(ZSTD(1)),
+
+    timestamp   Int64 CODEC(Delta, ZSTD(1)),
+
+    vehicle_id  LowCardinality(String),
+
+    name        LowCardinality(String),
+
+    value       Float64 CODEC(Gorilla, ZSTD(1)),
+
+    raw_value   Int64 CODEC(ZSTD(1)),
+
+    produced_at DateTime64(6, 'UTC')
+        MATERIALIZED fromUnixTimestamp64Micro(timestamp)
+        CODEC(Delta, ZSTD(1)),
+
+    created_at  DateTime64(6, 'UTC')
+        DEFAULT now64(6)
+        CODEC(Delta, ZSTD(1)),
+
+    INDEX idx_id id TYPE bloom_filter GRANULARITY 4
+)
+ENGINE = ReplacingMergeTree(created_at)
 PARTITION BY toYYYYMM(produced_at)
-ORDER BY (vehicle_id, name, timestamp)`
+ORDER BY (vehicle_id, timestamp, name)`


### PR DESCRIPTION
- Adds exported `SignalClickHouseDDL` and `PingClickHouseDDL` consts to mapache-go alongside the `Signal` and `Ping` models
- Shared source of truth for the ClickHouse `signal` / `ping` table DDLs (dedup keys match the gorm indexes; `produced_at` materialized from timestamp on signal; `created_at` is the ReplacingMergeTree version on both)
- Prereq for gr26 (PR #184) to migrate signal + ping from these consts instead of inline copies. `gr26_can` DDL stays in gr26 (CAN model is gr26-specific)

Release flow: merge this, then `./scripts/release.sh -t mapache-go 3.4.0` to publish the module and bump dependent services' go.mod. gr26 switches its migrate() to the consts once it's on v3.4.0.