### PR TITLE
feat(gr26): migrate ingest to MQTT5 with shared subscription

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -108,7 +108,6 @@ services:
       KERBECS_USER: "admin"
       KERBECS_PASSWORD: "admin"
       SKIP_AUTH_CHECK: "true"
-      ENABLE_SIGNAL_DB: "true"
       VEHICLE_UPLOAD_KEY_CACHE_TTL: "600"
       FOREMAN_ENDPOINT: "http://foreman:7011"
       NUM_WORKERS: "1"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -109,7 +109,6 @@ services:
       KERBECS_PASSWORD: "admin"
       SKIP_AUTH_CHECK: "true"
       ENABLE_SIGNAL_DB: "true"
-      ENABLE_SIGNAL_WS: "true"
       VEHICLE_UPLOAD_KEY_CACHE_TTL: "600"
       FOREMAN_ENDPOINT: "http://foreman:7011"
       NUM_WORKERS: "1"

--- a/gr26/api/api.go
+++ b/gr26/api/api.go
@@ -37,7 +37,5 @@ func InitializeRoutes(router *gin.Engine) {
 	router.GET("/gr26/ping", Ping)
 	router.GET("/gr26/messages/:id", GetCANMessage)
 	router.GET("/gr26/signals/:id", GetCANBySignalID)
-	if config.EnableSignalWS {
-		router.GET("/gr26/live", GetLatestSignalWebSocket)
-	}
+	router.GET("/gr26/live", GetLatestSignalWebSocket)
 }

--- a/gr26/api/api.go
+++ b/gr26/api/api.go
@@ -35,7 +35,9 @@ func InitializeRouter() *gin.Engine {
 
 func InitializeRoutes(router *gin.Engine) {
 	router.GET("/gr26/ping", Ping)
-	router.GET("/gr26/live", GetLatestSignalWebSocket)
 	router.GET("/gr26/messages/:id", GetCANMessage)
 	router.GET("/gr26/signals/:id", GetCANBySignalID)
+	if config.EnableSignalWS {
+		router.GET("/gr26/live", GetLatestSignalWebSocket)
+	}
 }

--- a/gr26/api/can.go
+++ b/gr26/api/can.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gaucho-racing/mapache/gr26/config"
 	"github.com/gaucho-racing/mapache/gr26/model"
 	"github.com/gaucho-racing/mapache/gr26/service"
 
@@ -76,6 +77,10 @@ func respondWithCAN(
 	id string,
 	notFoundMsg string,
 ) {
+	if !config.EnableSignalDB {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "ClickHouse disabled on this gr26 instance"})
+		return
+	}
 	can, err := lookup(id)
 	if err != nil {
 		if errors.Is(err, service.ErrNotFound) {

--- a/gr26/api/can.go
+++ b/gr26/api/can.go
@@ -16,9 +16,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// canMessageResponse is the GET /gr26/messages/:id wire shape. We
-// hex-encode the bytes (rather than the default base64 for []byte) so the
-// dashboard can render the hex grid without re-encoding.
+// Bytes is hex-encoded (not the default base64) so the dashboard's hex grid
+// can render without re-encoding.
 type canMessageResponse struct {
 	ID         string                 `json:"id"`
 	VehicleID  string                 `json:"vehicle_id"`
@@ -34,9 +33,6 @@ type canMessageResponse struct {
 	Signals    []mapache.Signal       `json:"signals"`
 }
 
-// canFieldTrace describes one field of a decoded CAN frame: its byte
-// range within the frame, decoded raw value, and which signal names it
-// produces.
 type canFieldTrace struct {
 	Name        string   `json:"name"`
 	Offset      int      `json:"offset"`
@@ -58,10 +54,7 @@ func GetCANMessage(c *gin.Context) {
 }
 
 // GetCANBySignalID returns the same trace shape as GetCANMessage but
-// looks up the CAN frame by the signal id that came from it. Lets the
-// dashboard go straight from a streamed signal.id (which is just
-// mapache.Signal — no extra wire fields) to its source frame in one
-// call.
+// looks up the source CAN frame by signal id.
 func GetCANBySignalID(c *gin.Context) {
 	id := c.Param("id")
 	if id == "" {
@@ -78,7 +71,7 @@ func respondWithCAN(
 	notFoundMsg string,
 ) {
 	if !config.EnableSignalDB {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "ClickHouse disabled on this gr26 instance"})
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "clickhouse disabled"})
 		return
 	}
 	can, err := lookup(id)
@@ -120,12 +113,8 @@ func respondWithCAN(
 	})
 }
 
-// decodeFieldTrace re-runs the gr26 decoder over the stored bytes so the
-// response carries per-field metadata (offset, size, sign, endian, the
-// bytes that contributed, the raw value, and the signal names produced).
-// Returns nil if the can id has no registered decoder or if the bytes
-// don't fit the field layout — both of those are already captured in
-// can.Metadata.
+// decodeFieldTrace re-runs the decoder to expose per-field metadata.
+// Returns nil for unknown can ids or decode failures (already in can.Metadata).
 func decodeFieldTrace(can model.CAN) []canFieldTrace {
 	messageStruct := model.GetMessage(can.CANID)
 	if messageStruct == nil {

--- a/gr26/api/can.go
+++ b/gr26/api/can.go
@@ -70,7 +70,7 @@ func respondWithCAN(
 	id string,
 	notFoundMsg string,
 ) {
-	if !config.EnableSignalDB {
+	if !config.ClickhouseEnabled() {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "clickhouse disabled"})
 		return
 	}

--- a/gr26/config/config.go
+++ b/gr26/config/config.go
@@ -26,9 +26,6 @@ var Service = ServiceInfo{
 
 var SkipAuthCheck = os.Getenv("SKIP_AUTH_CHECK") == "true"
 var VehicleUploadKeyCacheTTL = os.Getenv("VEHICLE_UPLOAD_KEY_CACHE_TTL")
-// EnableSignalDB is the master switch for all ClickHouse access
-// (init, writes, read endpoints). On-car gr26 sets it false.
-var EnableSignalDB = os.Getenv("ENABLE_SIGNAL_DB") != "false"
 
 var Env = os.Getenv("ENV")
 var Port = os.Getenv("PORT")
@@ -40,6 +37,11 @@ var ClickhousePort = os.Getenv("CLICKHOUSE_PORT")
 var ClickhouseUser = os.Getenv("CLICKHOUSE_USER")
 var ClickhousePassword = os.Getenv("CLICKHOUSE_PASSWORD")
 var ClickhouseDatabase = os.Getenv("CLICKHOUSE_DATABASE")
+
+// ClickhouseEnabled is the master switch for all CH access (init, writes,
+// read endpoints). Unset CLICKHOUSE_HOST means "no ClickHouse" — used by
+// the on-car gr26 which has no CH to talk to.
+func ClickhouseEnabled() bool { return ClickhouseHost != "" }
 
 var KerbecsEndpoint = os.Getenv("KERBECS_ENDPOINT")
 var KerbecsUser = os.Getenv("KERBECS_USER")

--- a/gr26/config/config.go
+++ b/gr26/config/config.go
@@ -26,8 +26,20 @@ var Service = ServiceInfo{
 
 var SkipAuthCheck = os.Getenv("SKIP_AUTH_CHECK") == "true"
 var VehicleUploadKeyCacheTTL = os.Getenv("VEHICLE_UPLOAD_KEY_CACHE_TTL")
+// EnableSignalDB gates all ClickHouse operations: the database.Init()
+// connect/migrate, the CreateCAN/CreateSignals/CreatePing inserts, and
+// the CH-backed read endpoints. The on-car gr26 (running on the TCM
+// to feed the on-car dash) has no ClickHouse and must set this false;
+// cloud ingest leaves the default true. Despite the historical name,
+// this is the "do we have a ClickHouse to talk to?" master switch.
 var EnableSignalDB = os.Getenv("ENABLE_SIGNAL_DB") != "false"
-var EnableSignalWS = os.Getenv("ENABLE_SIGNAL_WS") != "false"
+
+// EnableSignalWS gates the in-process signal Hub + /gr26/live WebSocket
+// endpoint. Defaults false because the cloud ingest (which can run as
+// multiple replicas under the shared subscription) gets its live feed
+// from the query/live/<vid>/<name> MQTT republish, not from this hub.
+// The on-car gr26 sets this true to keep feeding the on-car dash.
+var EnableSignalWS = os.Getenv("ENABLE_SIGNAL_WS") == "true"
 
 var Env = os.Getenv("ENV")
 var Port = os.Getenv("PORT")

--- a/gr26/config/config.go
+++ b/gr26/config/config.go
@@ -30,10 +30,6 @@ var VehicleUploadKeyCacheTTL = os.Getenv("VEHICLE_UPLOAD_KEY_CACHE_TTL")
 // (init, writes, read endpoints). On-car gr26 sets it false.
 var EnableSignalDB = os.Getenv("ENABLE_SIGNAL_DB") != "false"
 
-// EnableSignalWS toggles the in-process Hub + /gr26/live WS for the on-car dash.
-// Cloud replicas get the live feed via query/live/<vid>/<name> instead.
-var EnableSignalWS = os.Getenv("ENABLE_SIGNAL_WS") == "true"
-
 var Env = os.Getenv("ENV")
 var Port = os.Getenv("PORT")
 

--- a/gr26/config/config.go
+++ b/gr26/config/config.go
@@ -26,19 +26,12 @@ var Service = ServiceInfo{
 
 var SkipAuthCheck = os.Getenv("SKIP_AUTH_CHECK") == "true"
 var VehicleUploadKeyCacheTTL = os.Getenv("VEHICLE_UPLOAD_KEY_CACHE_TTL")
-// EnableSignalDB gates all ClickHouse operations: the database.Init()
-// connect/migrate, the CreateCAN/CreateSignals/CreatePing inserts, and
-// the CH-backed read endpoints. The on-car gr26 (running on the TCM
-// to feed the on-car dash) has no ClickHouse and must set this false;
-// cloud ingest leaves the default true. Despite the historical name,
-// this is the "do we have a ClickHouse to talk to?" master switch.
+// EnableSignalDB is the master switch for all ClickHouse access
+// (init, writes, read endpoints). On-car gr26 sets it false.
 var EnableSignalDB = os.Getenv("ENABLE_SIGNAL_DB") != "false"
 
-// EnableSignalWS gates the in-process signal Hub + /gr26/live WebSocket
-// endpoint. Defaults false because the cloud ingest (which can run as
-// multiple replicas under the shared subscription) gets its live feed
-// from the query/live/<vid>/<name> MQTT republish, not from this hub.
-// The on-car gr26 sets this true to keep feeding the on-car dash.
+// EnableSignalWS toggles the in-process Hub + /gr26/live WS for the on-car dash.
+// Cloud replicas get the live feed via query/live/<vid>/<name> instead.
 var EnableSignalWS = os.Getenv("ENABLE_SIGNAL_WS") == "true"
 
 var Env = os.Getenv("ENV")

--- a/gr26/config/verify.go
+++ b/gr26/config/verify.go
@@ -15,24 +15,21 @@ func Verify() {
 		Port = "7005"
 		logger.SugarLogger.Infof("PORT is not set, defaulting to %s", Port)
 	}
-	if ClickhouseHost == "" {
-		ClickhouseHost = "localhost"
-		logger.SugarLogger.Infof("CLICKHOUSE_HOST is not set, defaulting to %s", ClickhouseHost)
-	}
-	if ClickhousePort == "" {
-		ClickhousePort = "9000"
-		logger.SugarLogger.Infof("CLICKHOUSE_PORT is not set, defaulting to %s", ClickhousePort)
-	}
-	if ClickhouseUser == "" {
-		ClickhouseUser = "default"
-		logger.SugarLogger.Infof("CLICKHOUSE_USER is not set, defaulting to %s", ClickhouseUser)
-	}
-	if ClickhousePassword == "" {
-		logger.SugarLogger.Infof("CLICKHOUSE_PASSWORD is not set, defaulting to empty")
-	}
-	if ClickhouseDatabase == "" {
-		ClickhouseDatabase = "mapache"
-		logger.SugarLogger.Infof("CLICKHOUSE_DATABASE is not set, defaulting to %s", ClickhouseDatabase)
+	if !ClickhouseEnabled() {
+		logger.SugarLogger.Infoln("CLICKHOUSE_HOST is not set, ClickHouse disabled")
+	} else {
+		if ClickhousePort == "" {
+			ClickhousePort = "9000"
+			logger.SugarLogger.Infof("CLICKHOUSE_PORT is not set, defaulting to %s", ClickhousePort)
+		}
+		if ClickhouseUser == "" {
+			ClickhouseUser = "default"
+			logger.SugarLogger.Infof("CLICKHOUSE_USER is not set, defaulting to %s", ClickhouseUser)
+		}
+		if ClickhouseDatabase == "" {
+			ClickhouseDatabase = "mapache"
+			logger.SugarLogger.Infof("CLICKHOUSE_DATABASE is not set, defaulting to %s", ClickhouseDatabase)
+		}
 	}
 	if MQTTHost == "" {
 		MQTTHost = "localhost"

--- a/gr26/database/db.go
+++ b/gr26/database/db.go
@@ -13,8 +13,6 @@ import (
 	mapache "github.com/gaucho-racing/mapache/mapache-go/v3"
 )
 
-// Conn is the shared ClickHouse connection. Telemetry (signal, gr26_can,
-// ping) lives in ClickHouse now; gr26 holds no Postgres connection.
 var Conn driver.Conn
 
 var dbRetries = 0
@@ -31,11 +29,8 @@ func options(database string) *clickhouse.Options {
 	}
 }
 
-// InsertCtx returns a context that flags inserts as server-side async:
-// gr26 fires many small INSERTs and lets ClickHouse coalesce them into
-// larger parts rather than batching client-side. wait_for_async_insert=0
-// means we don't block on the flush — an acceptable loss window for
-// high-rate telemetry (see plan tradeoffs).
+// InsertCtx flags inserts as server-side async — CH coalesces small INSERTs
+// into larger parts and we don't block on the flush.
 func InsertCtx(parent context.Context) context.Context {
 	return clickhouse.Context(parent, clickhouse.WithSettings(clickhouse.Settings{
 		"async_insert":          1,
@@ -59,8 +54,7 @@ func Init() {
 func connect() error {
 	ctx := context.Background()
 
-	// Ensure the target database exists before opening the app connection
-	// against it, bootstrapping through the always-present "default" db.
+	// Bootstrap through "default" so we can CREATE DATABASE before opening the app conn.
 	bootstrap, err := clickhouse.Open(options("default"))
 	if err != nil {
 		return err
@@ -98,9 +92,7 @@ func migrate(ctx context.Context, conn driver.Conn) error {
 	return nil
 }
 
-// gr26_can has no shared mapache-go model (the CAN frame layout is
-// gr26-specific), so its DDL stays here. signal/ping DDL live on the shared
-// mapache.Signal / mapache.Ping types.
+// gr26_can DDL lives here (gr26-specific); signal/ping DDL live on mapache-go.
 const canDDL = `
 CREATE TABLE IF NOT EXISTS gr26_can (
 	id          String CODEC(ZSTD(1)),

--- a/gr26/go.mod
+++ b/gr26/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.11
 	github.com/aws/aws-sdk-go-v2/config v1.32.22
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.1
-	github.com/eclipse/paho.mqtt.golang v1.5.0
+	github.com/eclipse/paho.golang v0.23.0
 	github.com/fatih/color v1.18.0
 	github.com/gaucho-racing/mapache/mapache-go/v3 v3.4.0
 	github.com/gaucho-racing/ulid-go v1.1.0
@@ -79,7 +79,6 @@ require (
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect

--- a/gr26/go.sum
+++ b/gr26/go.sum
@@ -59,8 +59,8 @@ github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gE
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjOsyvMGvD6o=
-github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
+github.com/eclipse/paho.golang v0.23.0 h1:KHgl2wz6EJo7cMBmkuhpt7C576vP+kpPv7jjvSyR6Mk=
+github.com/eclipse/paho.golang v0.23.0/go.mod h1:nQRhTkoZv8EAiNs5UU0/WdQIx2NrnWUpL9nsGJTQN04=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/gabriel-vasile/mimetype v1.4.12 h1:e9hWvmLYvtp846tLHam2o++qitpguFiYCKbn0w9jyqw=
@@ -225,8 +225,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
-golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/gr26/job/ingest_all_batches.go
+++ b/gr26/job/ingest_all_batches.go
@@ -13,22 +13,14 @@ import (
 	"github.com/gaucho-racing/mapache/gr26/worker"
 )
 
-// ingestAllParams is the params shape for gr26.ingest_all_batches jobs.
-// Hours is how far back from "now" we look; a 24 means anything uploaded
-// in the last day. Reingest=true bypasses the standard idempotency key
-// so files that were previously ingested get queued again (the key is
-// scoped to this fan-out's parent job ID so the run stays internally
-// idempotent against worker retries).
+// Reingest=true scopes the idem key to this parent job so previously-ingested
+// files get re-processed, while worker retries of the parent still dedup.
 type ingestAllParams struct {
 	VehicleID string `json:"vehicle_id"`
 	Hours     int    `json:"hours"`
 	Reingest  bool   `json:"reingest,omitempty"`
 }
 
-// ingestAllResult is the json shape stored on foreman's job.result. The
-// per-file Entries list reflects every file the handler tried to enqueue
-// — including ones that 409'd because they were already enqueued under
-// the same idempotency key.
 type ingestAllResult struct {
 	VehicleID        string           `json:"vehicle_id"`
 	HoursBack        int              `json:"hours_back"`
@@ -47,20 +39,9 @@ type ingestAllEntry struct {
 	Error    string `json:"error,omitempty"`
 }
 
-// IngestAllBatchesHandler fans out: lists every shelter parquet for the
-// given vehicle, filters to those uploaded in the last `hours` hours,
-// and enqueues one gr26.ingest_batch job per file. Returns immediately
-// once enqueueing is done; the spawned ingests run independently and
-// show up as their own rows in /jobs.
-//
-// Default idempotency keys match the live-feed producer
-// (<vehicle>:<file_ulid>) so re-running this handler on the same window
-// is a no-op for already-known files.
-//
-// Reingest=true scopes the key to this fan-out's parent job ID
-// (reingest:<parent_id>:<vehicle>:<file_ulid>) so previously-ingested
-// files get re-processed, while a worker retry of this same parent
-// still collapses to one ingest per file.
+// IngestAllBatchesHandler fans out one gr26.ingest_batch per shelter
+// parquet uploaded in the last `hours` hours. Default idem key
+// (<vehicle>:<file_ulid>) makes re-runs on the same window a no-op.
 func IngestAllBatchesHandler(ctx context.Context, j *foreman.Job, progress *worker.ProgressReporter) (json.RawMessage, error) {
 	if gr26config.ShelterS3Bucket == "" {
 		return nil, errors.New("shelter ingest configured at foreman but SHELTER_S3_BUCKET is unset")

--- a/gr26/job/ingest_batch.go
+++ b/gr26/job/ingest_batch.go
@@ -1,7 +1,4 @@
-// Package job is the home for cross-cutting work that gr26 producers
-// or consumes via foreman. Today it's just shelter cold-storage ingest;
-// new job kinds belong here so the service package stays focused on
-// pure CAN-frame handling.
+// Package job holds foreman-driven work (currently shelter cold-storage ingest).
 package job
 
 import (
@@ -30,14 +27,9 @@ import (
 
 // ─── producer side: gr26.ingest_batch ───────────────────────────────────────
 
-// OnShelterBatchReceived is wired into service.ShelterBatchHook by
-// main.go. When a TCMShelterBatch CAN frame finishes processing in
-// HandleMessage, this fires, reads the parquet file's ULID out of the
-// trailing 16 bytes of the frame's data, and enqueues a foreman job
-// pointing at that exact file.
-//
-// idempotency_key is (vehicleID, file_ulid). ULIDs are globally unique
-// so retransmits collapse to a single foreman job.
+// OnShelterBatchReceived reads the parquet file ULID from the trailing
+// 16 bytes of a TCMShelterBatch frame and enqueues a foreman ingest job.
+// Idempotency key is (vehicleID, file_ulid) so retransmits collapse.
 func OnShelterBatchReceived(vehicleID string, ts int, data []byte) {
 	if len(data) < 32 {
 		logger.SugarLogger.Warnf("[SHELTER] TCMShelterBatch frame too short (%d bytes, want 32) — ULID missing, not enqueuing", len(data))
@@ -47,9 +39,6 @@ func OnShelterBatchReceived(vehicleID string, ts int, data []byte) {
 	copy(u[:], data[16:32])
 	fileULID := u.String()
 
-	// Foreman's unique index is (kind, idempotency_key), so the kind tag
-	// in the key would be redundant — scoping by (vehicle, file_ulid) is
-	// enough.
 	idem := fmt.Sprintf("%s:%s", vehicleID, fileULID)
 	params, _ := json.Marshal(shelterIngestParams{
 		VehicleID: vehicleID,
@@ -74,17 +63,13 @@ func OnShelterBatchReceived(vehicleID string, ts int, data []byte) {
 
 // ─── consumer side: gr26.ingest_batch worker ────────────────────────────────
 
-// shelterIngestParams is what foreman jobs carry as Params. The producer
-// (OnShelterBatchReceived) writes it; the worker (IngestBatchHandler)
-// reads it. file_ulid names the exact parquet to fetch — no S3 scan, no
-// dedup table; foreman's idempotency key is our only dedup.
+// shelterIngestParams is the foreman job payload.
 type shelterIngestParams struct {
 	VehicleID string `json:"vehicle_id"`
 	FileULID  string `json:"file_ulid"`
 }
 
-// shelterRow mirrors the Parquet schema shelter writes to S3
-// (see TCM-26/shelter/model/message.py).
+// shelterRow mirrors the Parquet schema in TCM-26/shelter/model/message.py.
 type shelterRow struct {
 	Timestamp  int64  `parquet:"timestamp"`
 	VehicleID  string `parquet:"vehicle_id"`
@@ -94,14 +79,8 @@ type shelterRow struct {
 	TargetNode string `parquet:"target_node"`
 }
 
-// IngestBatchHandler is the worker entrypoint registered for
-// "gr26.ingest_batch" jobs. Params name the exact parquet file to
-// ingest, so this is a deterministic targeted fetch — no listing,
-// no "what's the next unprocessed" question.
-//
-// On retry (foreman re-claim after lease expiry / restart), the same
-// file gets reprocessed; the downstream upserts on gr26_can + signal
-// keep that safe.
+// IngestBatchHandler is the worker for "gr26.ingest_batch". Retries are
+// safe because the downstream ReplacingMergeTree dedups on natural keys.
 func IngestBatchHandler(ctx context.Context, job *foreman.Job, progress *worker.ProgressReporter) (json.RawMessage, error) {
 	if gr26config.ShelterS3Bucket == "" {
 		return nil, errors.New("shelter ingest configured at foreman but SHELTER_S3_BUCKET is unset")
@@ -141,9 +120,7 @@ func processFile(ctx context.Context, client *s3.Client, key string, progress *w
 	}
 	defer obj.Body.Close()
 
-	// Files are ~6 MB compressed at our current batch sizing — fine to
-	// pull fully into memory on a cloud server. If sizes ever push past
-	// a couple hundred MB we'd switch to a tempfile + io.ReaderAt.
+	// ~6 MB compressed today — fine to buffer fully in memory.
 	body, err := io.ReadAll(obj.Body)
 	if err != nil {
 		return ingestResult{}, fmt.Errorf("download: %w", err)
@@ -174,9 +151,7 @@ func processFile(ctx context.Context, client *s3.Client, key string, progress *w
 	}
 
 	duration := time.Since(start)
-	// Pin progress to (total, total) so the worker's final heartbeat
-	// flush stores a clean 100% reading instead of whatever the last
-	// in-flight tick caught.
+	// Pin to (total, total) so the final heartbeat stores a clean 100%.
 	progress.Set(totalRows, totalRows, "complete")
 	logger.SugarLogger.Infof("[SHELTER] %s: %d rows in %s (decoded=%d unknown=%d errors=%d)",
 		key, total, duration, stats.decoded, stats.unknown, stats.decodeError)
@@ -192,8 +167,6 @@ func processFile(ctx context.Context, client *s3.Client, key string, progress *w
 	}, nil
 }
 
-// dispatchRow parses the topic out of one Parquet row and runs it
-// through replayFrame, threading the per-job stats accumulator.
 func dispatchRow(r shelterRow, stats *ingestStats) {
 	// Topic format: gr26/{vehicle}/{node}/0x{can_id_hex}
 	parts := strings.Split(r.Topic, "/")
@@ -209,16 +182,11 @@ func dispatchRow(r shelterRow, stats *ingestStats) {
 	replayFrame(r.VehicleID, nodeID, int(canIDInt), int(r.Timestamp), r.Data, stats)
 }
 
-// replayFrame is the cold-storage decode-and-persist function. Shares
-// the pure decode step (service.ProcessFrame) with the live MQTT path;
-// the persistence side-effects diverge here — UploadKey stays 0 since
-// shelter-sourced frames don't carry one, no WS publish (data is
-// historical), no side-channel hook (would recursively re-enqueue
-// ingest jobs if the replayed frame is itself a TCMShelterBatch).
+// replayFrame is the cold-storage decode-and-persist path. UploadKey
+// stays 0 (bucket access is the trust boundary), and no WS/side-channel
+// firing — historical data, and we don't want to re-enqueue shelter batches.
 func replayFrame(vehicleID, nodeID string, canID, ts int, data []byte, stats *ingestStats) {
 	can, signals := service.ProcessFrame(vehicleID, nodeID, canID, ts, data)
-	// UploadKey left at 0 — bucket access is the trust boundary.
-
 	stats.record(canID, can.Metadata)
 
 	if _, err := service.CreateCAN(can); err != nil {
@@ -233,9 +201,6 @@ func replayFrame(vehicleID, nodeID string, canID, ts int, data []byte, stats *in
 
 // ─── result reporting ───────────────────────────────────────────────────────
 
-// ingestStats accumulates per-canID outcomes as the parquet rows stream
-// through. Running totals (decoded/unknown/decodeError) are kept so we
-// don't have to re-sum the maps at the end.
 type ingestStats struct {
 	decoded        int
 	unknown        int
@@ -256,10 +221,6 @@ func newIngestStats() *ingestStats {
 	}
 }
 
-// record peeks at the metadata blob ProcessFrame just built to bucket
-// this row's outcome. Unknown statuses are silently ignored — they can
-// only happen if ProcessFrame grows a new status string without us
-// noticing, and counting them as "not decoded" would be misleading.
 func (s *ingestStats) record(canID int, metadata []byte) {
 	var meta struct {
 		Status string `json:"status"`
@@ -296,10 +257,7 @@ type errorBreakdownEntry struct {
 	SampleError string `json:"sample_error,omitempty"`
 }
 
-// ingestResult is the json shape stored on foreman's job.result column.
-// Top-N caps keep payload size bounded even on pathological batches.
-// FileULID is set by the handler after processFile returns — handy for
-// ingest_latest_batch where the file_ulid isn't in the job params.
+// ingestResult lands on foreman.job.result. Top-N caps bound payload size.
 type ingestResult struct {
 	FileULID             string                `json:"file_ulid,omitempty"`
 	TotalRows            int                   `json:"total_rows"`

--- a/gr26/job/ingest_latest_batch.go
+++ b/gr26/job/ingest_latest_batch.go
@@ -13,20 +13,12 @@ import (
 	"github.com/gaucho-racing/mapache/gr26/worker"
 )
 
-// ingestLatestParams is the params shape for gr26.ingest_latest_batch
-// jobs. Just a vehicle_id — the handler resolves the actual file at
-// claim time.
 type ingestLatestParams struct {
 	VehicleID string `json:"vehicle_id"`
 }
 
-// IngestLatestBatchHandler picks the most recently uploaded parquet
-// under the vehicle's shelter prefix and ingests it inline. The
-// resolved file_ulid lands in the job's result so the dashboard makes
-// it obvious which file got processed.
-//
-// Sort order is by S3 LastModified (newest first), matching the dialog
-// preset language ("most recently uploaded").
+// IngestLatestBatchHandler ingests the newest (by S3 LastModified) batch
+// for the vehicle, inline. file_ulid lands in the result.
 func IngestLatestBatchHandler(ctx context.Context, j *foreman.Job, progress *worker.ProgressReporter) (json.RawMessage, error) {
 	if gr26config.ShelterS3Bucket == "" {
 		return nil, errors.New("shelter ingest configured at foreman but SHELTER_S3_BUCKET is unset")

--- a/gr26/job/shelter.go
+++ b/gr26/job/shelter.go
@@ -13,9 +13,6 @@ import (
 	gr26config "github.com/gaucho-racing/mapache/gr26/config"
 )
 
-// newS3Client builds an S3 client from the default credential chain +
-// configured region. Centralised so every shelter job uses identical
-// auth wiring.
 func newS3Client(ctx context.Context) (*s3.Client, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithRegion(gr26config.ShelterS3Region),
@@ -26,16 +23,13 @@ func newS3Client(ctx context.Context) (*s3.Client, error) {
 	return s3.NewFromConfig(cfg), nil
 }
 
-// shelterKey returns the canonical S3 key for a given vehicle + file ULID,
-// matching the layout TCM-26's shelter/service/upload.py writes to.
+// shelterKey matches TCM-26/shelter/service/upload.py's layout.
 func shelterKey(vehicleID, fileULID string) string {
 	prefix := strings.TrimRight(gr26config.ShelterS3Prefix, "/")
 	return fmt.Sprintf("%s/%s/batch_%s.parquet", prefix, vehicleID, fileULID)
 }
 
-// extractFileULID parses the ULID out of a shelter S3 key. Returns the
-// empty string if the basename doesn't match the expected
-// "batch_<ulid>.parquet" shape — callers should treat that as a skip.
+// extractFileULID returns "" when the basename isn't batch_<ulid>.parquet.
 func extractFileULID(key string) string {
 	base := key
 	if i := strings.LastIndex(base, "/"); i >= 0 {
@@ -47,18 +41,13 @@ func extractFileULID(key string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(base, "batch_"), ".parquet")
 }
 
-// shelterObject is the slim subset of an S3 ListObjectsV2 entry the
-// shelter jobs care about.
 type shelterObject struct {
 	Key          string
 	LastModified time.Time
 	SizeBytes    int64
 }
 
-// listShelterObjects pages through ListObjectsV2 under one vehicle's
-// shelter prefix and returns every batch_*.parquet object it sees. Non-
-// matching entries (e.g. anything not following the batch naming scheme)
-// are dropped.
+// listShelterObjects pages through every batch_*.parquet under the vehicle's prefix.
 func listShelterObjects(ctx context.Context, client *s3.Client, vehicleID string) ([]shelterObject, error) {
 	prefix := strings.TrimRight(gr26config.ShelterS3Prefix, "/") + "/" + vehicleID + "/"
 	var out []shelterObject

--- a/gr26/main.go
+++ b/gr26/main.go
@@ -21,14 +21,27 @@ func main() {
 	config.Verify()
 	config.PrintStartupBanner()
 	kerbecs.Init(config.KerbecsEndpoint, config.KerbecsUser, config.KerbecsPassword)
-	database.Init()
+	// Skip ClickHouse entirely when ENABLE_SIGNAL_DB=false (the on-car
+	// gr26 has no ClickHouse to talk to). Writes/reads also short-circuit
+	// on this flag so any code path that would have used database.Conn
+	// is a no-op (writes) or returns 503 (reads).
+	if config.EnableSignalDB {
+		database.Init()
+	} else {
+		logger.SugarLogger.Infoln("ClickHouse disabled (ENABLE_SIGNAL_DB=false), skipping database.Init")
+	}
 
 	// Wire the service-level side-channel hook into the job module. Has
 	// to happen before MQTT.Init so the hook is set by the time the
 	// subscriber callback starts firing.
 	service.ShelterBatchHook = job.OnShelterBatchReceived
 
-	mqtt.Init(service.SubscribeTopics)
+	// SetMessageHandler must run before Init so the OnConnectionUp
+	// subscribe doesn't race against the first arriving frames.
+	mqtt.SetMessageHandler(service.HandleInboundMessage)
+	if err := mqtt.Init(context.Background()); err != nil {
+		logger.SugarLogger.Fatalf("Failed to initialize MQTT: %v", err)
+	}
 
 	reg := worker.NewRegistry()
 	reg.Register("gr26.ingest_batch", job.IngestBatchHandler)

--- a/gr26/main.go
+++ b/gr26/main.go
@@ -21,10 +21,8 @@ func main() {
 	config.Verify()
 	config.PrintStartupBanner()
 	kerbecs.Init(config.KerbecsEndpoint, config.KerbecsUser, config.KerbecsPassword)
-	if config.EnableSignalDB {
+	if config.ClickhouseEnabled() {
 		database.Init()
-	} else {
-		logger.SugarLogger.Infoln("ClickHouse disabled (ENABLE_SIGNAL_DB=false), skipping database.Init")
 	}
 
 	// Wire hook + handler before mqtt.Init so neither races the first frame.

--- a/gr26/main.go
+++ b/gr26/main.go
@@ -21,23 +21,14 @@ func main() {
 	config.Verify()
 	config.PrintStartupBanner()
 	kerbecs.Init(config.KerbecsEndpoint, config.KerbecsUser, config.KerbecsPassword)
-	// Skip ClickHouse entirely when ENABLE_SIGNAL_DB=false (the on-car
-	// gr26 has no ClickHouse to talk to). Writes/reads also short-circuit
-	// on this flag so any code path that would have used database.Conn
-	// is a no-op (writes) or returns 503 (reads).
 	if config.EnableSignalDB {
 		database.Init()
 	} else {
 		logger.SugarLogger.Infoln("ClickHouse disabled (ENABLE_SIGNAL_DB=false), skipping database.Init")
 	}
 
-	// Wire the service-level side-channel hook into the job module. Has
-	// to happen before MQTT.Init so the hook is set by the time the
-	// subscriber callback starts firing.
+	// Wire hook + handler before mqtt.Init so neither races the first frame.
 	service.ShelterBatchHook = job.OnShelterBatchReceived
-
-	// SetMessageHandler must run before Init so the OnConnectionUp
-	// subscribe doesn't race against the first arriving frames.
 	mqtt.SetMessageHandler(service.HandleInboundMessage)
 	if err := mqtt.Init(context.Background()); err != nil {
 		logger.SugarLogger.Fatalf("Failed to initialize MQTT: %v", err)

--- a/gr26/model/can.go
+++ b/gr26/model/can.go
@@ -2,11 +2,9 @@ package model
 
 import "time"
 
-// CAN is a stored record of a single decoded CAN frame received from a
-// gr26 vehicle. The composite (vehicle_id, node_id, timestamp) tuple
-// uniquely identifies a frame. The signal table joins back to this row
-// via that same tuple (node_id is recovered from the signal name's
-// prefix) — no separate link table required.
+// CAN is a stored record of a decoded CAN frame.
+// Natural key: (vehicle_id, node_id, timestamp).
+// Metadata carries {"status": ok|unknown_can_id|decode_error, "note": ...}.
 type CAN struct {
 	ID         string    `json:"id" gorm:"primaryKey"`
 	VehicleID  string    `json:"vehicle_id" gorm:"uniqueIndex:idx_gr26_can_unique"`
@@ -15,9 +13,6 @@ type CAN struct {
 	CANID      int       `json:"can_id"`
 	Bytes      []byte    `json:"bytes" gorm:"type:bytea"`
 	UploadKey  int       `json:"upload_key"`
-	// Metadata always carries a {"status": ...} field describing the
-	// decode outcome (ok, unknown_can_id, decode_error) and an optional
-	// "note" with the human-readable detail.
 	Metadata   []byte    `json:"metadata,omitempty" gorm:"type:jsonb"`
 	ProducedAt time.Time `json:"produced_at" gorm:"precision:6"`
 	CreatedAt  time.Time `json:"created_at" gorm:"autoCreateTime;precision:6"`

--- a/gr26/mqtt/mqtt.go
+++ b/gr26/mqtt/mqtt.go
@@ -1,59 +1,149 @@
 package mqtt
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/gaucho-racing/mapache/gr26/config"
 	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
 
-	mq "github.com/eclipse/paho.mqtt.golang"
+	"github.com/eclipse/paho.golang/autopaho"
+	"github.com/eclipse/paho.golang/paho"
 )
 
-var Client mq.Client
+// Shared subscription so multiple gr26 replicas fan out the CAN-frame
+// stream — NanoMQ load-balances delivery across all members of the
+// "ingest" group. Single-replica deployments still work; the broker
+// just routes everything to the one member.
+const (
+	sharedSubGroup = "ingest"
+	canTopicFilter = "$share/" + sharedSubGroup + "/gr26/#"
+)
 
 const (
-	connectTimeout       = 15 * time.Second
-	connectRetryInterval = 5 * time.Second
+	keepAliveSeconds = 30
+	connectTimeout   = 15 * time.Second
 )
 
-func Init(onConnect func()) {
+// Manager is the singleton autopaho v5 ConnectionManager. Exposed so
+// publish-side callers (pongs, decoded signals) can reach it directly;
+// inbound messages come through the handler registered via
+// SetMessageHandler.
+var Manager *autopaho.ConnectionManager
+
+type MessageHandler func(topic string, payload []byte)
+
+var (
+	handlerMu sync.RWMutex
+	handler   MessageHandler
+)
+
+// SetMessageHandler wires the function that processes inbound
+// messages from the shared subscription. Call this before Init so the
+// OnConnectionUp subscribe can't race against arriving frames.
+func SetMessageHandler(h MessageHandler) {
+	handlerMu.Lock()
+	handler = h
+	handlerMu.Unlock()
+}
+
+// Init brings up the autopaho-managed v5 connection and subscribes
+// to the shared CAN-frame topic inside OnConnectionUp so the
+// subscription is re-established on every reconnect.
+func Init(ctx context.Context) error {
+	serverURL, err := url.Parse(fmt.Sprintf("mqtt://%s:%s", config.MQTTHost, config.MQTTPort))
+	if err != nil {
+		return fmt.Errorf("invalid MQTT URL: %w", err)
+	}
+
 	host, err := os.Hostname()
 	if err != nil || host == "" {
 		host = fmt.Sprintf("pid%d", os.Getpid())
 	}
-	opts := mq.NewClientOptions()
-	opts.AddBroker(fmt.Sprintf("tcp://%s:%s", config.MQTTHost, config.MQTTPort))
-	opts.SetUsername(config.MQTTUser)
-	opts.SetPassword(config.MQTTPassword)
-	opts.SetCleanSession(true)
-	opts.SetOrderMatters(false)
-	opts.SetAutoReconnect(true)
-	opts.SetConnectTimeout(connectTimeout)
-	opts.SetConnectRetry(true)
-	opts.SetConnectRetryInterval(connectRetryInterval)
-	opts.SetClientID(fmt.Sprintf("%s-%s", config.Service.Name, host))
-	opts.SetOnConnectHandler(func(c mq.Client) {
-		logger.SugarLogger.Infoln("[MQ] Connected to MQTT broker")
-		if onConnect != nil {
-			onConnect()
-		}
-	})
-	opts.SetConnectionLostHandler(func(c mq.Client, err error) {
-		logger.SugarLogger.Warnf("[MQ] Connection lost: %v", err)
-	})
-	Client = mq.NewClient(opts)
+	clientID := fmt.Sprintf("%s-%s", config.Service.Name, host)
 
-	go func() {
-		token := Client.Connect()
-		if !token.WaitTimeout(connectTimeout) {
-			logger.SugarLogger.Warnf("[MQ] Initial connect to %s:%s timed out after %s, paho will keep retrying every %s",
-				config.MQTTHost, config.MQTTPort, connectTimeout, connectRetryInterval)
-			return
-		}
-		if err := token.Error(); err != nil {
-			logger.SugarLogger.Warnf("[MQ] Initial connect failed: %v, paho will keep retrying every %s", err, connectRetryInterval)
-		}
-	}()
+	cfg := autopaho.ClientConfig{
+		ServerUrls:      []*url.URL{serverURL},
+		KeepAlive:       keepAliveSeconds,
+		ConnectTimeout:  connectTimeout,
+		ConnectUsername: config.MQTTUser,
+		ConnectPassword: []byte(config.MQTTPassword),
+		// Mirror the v3 SetCleanSession(true) behavior — we're QoS 0
+		// with no need for retained session state across reconnects.
+		CleanStartOnInitialConnection: true,
+		SessionExpiryInterval:         0,
+		OnConnectionUp: func(cm *autopaho.ConnectionManager, _ *paho.Connack) {
+			logger.SugarLogger.Infoln("[MQ] Connected to MQTT broker")
+			if _, err := cm.Subscribe(context.Background(), &paho.Subscribe{
+				Subscriptions: []paho.SubscribeOptions{
+					{Topic: canTopicFilter, QoS: 0},
+				},
+			}); err != nil {
+				logger.SugarLogger.Warnf("[MQ] Subscribe to %s failed: %v", canTopicFilter, err)
+			}
+		},
+		OnConnectError: func(err error) {
+			logger.SugarLogger.Warnf("[MQ] Connection error: %v", err)
+		},
+		ClientConfig: paho.ClientConfig{
+			ClientID: clientID,
+			OnPublishReceived: []func(paho.PublishReceived) (bool, error){
+				func(pr paho.PublishReceived) (bool, error) {
+					handlerMu.RLock()
+					h := handler
+					handlerMu.RUnlock()
+					if h != nil {
+						h(pr.Packet.Topic, pr.Packet.Payload)
+					}
+					return true, nil
+				},
+			},
+			OnClientError: func(err error) {
+				logger.SugarLogger.Warnf("[MQ] Client error: %v", err)
+			},
+			OnServerDisconnect: func(d *paho.Disconnect) {
+				logger.SugarLogger.Warnf("[MQ] Server disconnect: reason=%d", d.ReasonCode)
+			},
+		},
+	}
+
+	cm, err := autopaho.NewConnection(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("autopaho.NewConnection: %w", err)
+	}
+	Manager = cm
+	return nil
+}
+
+// Publish is a fire-and-forget QoS 0 helper. At QoS 0 paho returns
+// once the packet hits TCP; broker-down surfaces as an error here
+// (we log and move on — next CAN frame for the same ID is 30-100ms
+// behind, retrying QoS 0 is wasted effort).
+func Publish(ctx context.Context, topic string, payload []byte) {
+	if Manager == nil {
+		return
+	}
+	if _, err := Manager.Publish(ctx, &paho.Publish{
+		QoS:     0,
+		Topic:   topic,
+		Payload: payload,
+	}); err != nil {
+		logger.SugarLogger.Warnf("[MQ] Publish to %s failed: %v", topic, err)
+	}
+}
+
+// PublishJSON marshals v to JSON and publishes it at QoS 0, retain=false.
+// Used by the decoded-signal fan-out to query/live/<vid>/<name>.
+func PublishJSON(ctx context.Context, topic string, v any) {
+	payload, err := json.Marshal(v)
+	if err != nil {
+		logger.SugarLogger.Warnf("[MQ] JSON marshal for %s failed: %v", topic, err)
+		return
+	}
+	Publish(ctx, topic, payload)
 }

--- a/gr26/mqtt/mqtt.go
+++ b/gr26/mqtt/mqtt.go
@@ -16,12 +16,8 @@ import (
 	"github.com/eclipse/paho.golang/paho"
 )
 
-// Shared subscription so multiple gr26 replicas fan out the CAN-frame
-// stream — NanoMQ load-balances delivery across all members of the
-// "ingest" group. Single-replica deployments still work; the broker
-// just routes everything to the one member.
 const (
-	sharedSubGroup = "ingest"
+	sharedSubGroup = "gr26-cluster"
 	canTopicFilter = "$share/" + sharedSubGroup + "/gr26/#"
 )
 
@@ -30,10 +26,6 @@ const (
 	connectTimeout   = 15 * time.Second
 )
 
-// Manager is the singleton autopaho v5 ConnectionManager. Exposed so
-// publish-side callers (pongs, decoded signals) can reach it directly;
-// inbound messages come through the handler registered via
-// SetMessageHandler.
 var Manager *autopaho.ConnectionManager
 
 type MessageHandler func(topic string, payload []byte)
@@ -43,18 +35,12 @@ var (
 	handler   MessageHandler
 )
 
-// SetMessageHandler wires the function that processes inbound
-// messages from the shared subscription. Call this before Init so the
-// OnConnectionUp subscribe can't race against arriving frames.
 func SetMessageHandler(h MessageHandler) {
 	handlerMu.Lock()
 	handler = h
 	handlerMu.Unlock()
 }
 
-// Init brings up the autopaho-managed v5 connection and subscribes
-// to the shared CAN-frame topic inside OnConnectionUp so the
-// subscription is re-established on every reconnect.
 func Init(ctx context.Context) error {
 	serverURL, err := url.Parse(fmt.Sprintf("mqtt://%s:%s", config.MQTTHost, config.MQTTPort))
 	if err != nil {
@@ -68,13 +54,11 @@ func Init(ctx context.Context) error {
 	clientID := fmt.Sprintf("%s-%s", config.Service.Name, host)
 
 	cfg := autopaho.ClientConfig{
-		ServerUrls:      []*url.URL{serverURL},
-		KeepAlive:       keepAliveSeconds,
-		ConnectTimeout:  connectTimeout,
-		ConnectUsername: config.MQTTUser,
-		ConnectPassword: []byte(config.MQTTPassword),
-		// Mirror the v3 SetCleanSession(true) behavior — we're QoS 0
-		// with no need for retained session state across reconnects.
+		ServerUrls:                    []*url.URL{serverURL},
+		KeepAlive:                     keepAliveSeconds,
+		ConnectTimeout:                connectTimeout,
+		ConnectUsername:               config.MQTTUser,
+		ConnectPassword:               []byte(config.MQTTPassword),
 		CleanStartOnInitialConnection: true,
 		SessionExpiryInterval:         0,
 		OnConnectionUp: func(cm *autopaho.ConnectionManager, _ *paho.Connack) {
@@ -120,10 +104,6 @@ func Init(ctx context.Context) error {
 	return nil
 }
 
-// Publish is a fire-and-forget QoS 0 helper. At QoS 0 paho returns
-// once the packet hits TCP; broker-down surfaces as an error here
-// (we log and move on — next CAN frame for the same ID is 30-100ms
-// behind, retrying QoS 0 is wasted effort).
 func Publish(ctx context.Context, topic string, payload []byte) {
 	if Manager == nil {
 		return
@@ -137,8 +117,6 @@ func Publish(ctx context.Context, topic string, payload []byte) {
 	}
 }
 
-// PublishJSON marshals v to JSON and publishes it at QoS 0, retain=false.
-// Used by the decoded-signal fan-out to query/live/<vid>/<name>.
 func PublishJSON(ctx context.Context, topic string, v any) {
 	payload, err := json.Marshal(v)
 	if err != nil {

--- a/gr26/service/can.go
+++ b/gr26/service/can.go
@@ -92,7 +92,7 @@ const insertCANSQL = `INSERT INTO gr26_can (id, vehicle_id, node_id, timestamp, 
 
 func CreateCAN(can model.CAN) (model.CAN, error) {
 	can.ID = ulid.Make().Prefixed("can")
-	if !config.EnableSignalDB {
+	if !config.ClickhouseEnabled() {
 		return can, nil
 	}
 	ctx := database.InsertCtx(context.Background())

--- a/gr26/service/can.go
+++ b/gr26/service/can.go
@@ -16,32 +16,22 @@ import (
 	ulid "github.com/gaucho-racing/ulid-go"
 )
 
-// ErrNotFound is returned by the lookup helpers when no row matches. The
-// API layer maps it to a 404. (Replaces gorm.ErrRecordNotFound now that
-// gr26 reads from ClickHouse.)
+// ErrNotFound is mapped to 404 by the API layer.
 var ErrNotFound = errors.New("record not found")
 
+// MATERIALIZED columns are excluded from SELECT *, so we list explicitly.
 const canColumns = `id, vehicle_id, node_id, timestamp, can_id, bytes, upload_key, metadata, produced_at, created_at`
-
-// MATERIALIZED columns (produced_at) are excluded from `SELECT *`, so the
-// trace lookups list columns explicitly. canColumnsC is the same list
-// qualified to the join alias `c`.
 const canColumnsC = `c.id, c.vehicle_id, c.node_id, c.timestamp, c.can_id, c.bytes, c.upload_key, c.metadata, c.produced_at, c.created_at`
 
-// GetCAN looks up a stored CAN frame by its ulid. Returns ErrNotFound if
-// no row matches.
+// GetCAN looks up a stored CAN frame by ulid.
 func GetCAN(id string) (model.CAN, error) {
 	row := database.Conn.QueryRow(context.Background(),
 		"SELECT "+canColumns+" FROM gr26_can FINAL WHERE id = ? LIMIT 1", id)
 	return scanCANRow(row)
 }
 
-// GetCANForSignal looks up the CAN frame that produced a given signal by
-// joining on the natural keys (vehicle_id, timestamp, node_id) — node_id
-// is recovered from the signal name's prefix, since CreateSignals stamps
-// each signal with the node it was decoded from as `<node>_<short>`.
-// Returns ErrNotFound if no frame matches (e.g. the source frame was never
-// persisted, or the signal name doesn't follow the node-prefix convention).
+// GetCANForSignal joins back to the source CAN frame using the signal
+// name's `<node>_<short>` prefix to recover node_id.
 func GetCANForSignal(signalID string) (model.CAN, error) {
 	row := database.Conn.QueryRow(context.Background(), `
 		SELECT `+canColumnsC+`
@@ -55,9 +45,8 @@ func GetCANForSignal(signalID string) (model.CAN, error) {
 	return scanCANRow(row)
 }
 
-// GetSignalsForCAN returns every signal that was decoded from the given
-// CAN frame, joining on the natural keys (vehicle_id, timestamp, node_id).
-// Ordered by signal name so the response is stable and easy to scan.
+// GetSignalsForCAN returns every signal decoded from the given frame,
+// ordered by name for a stable response.
 func GetSignalsForCAN(canMessageID string) ([]mapache.Signal, error) {
 	rows, err := database.Conn.Query(context.Background(), `
 		SELECT s.id, s.timestamp, s.vehicle_id, s.name, s.value, s.raw_value, s.produced_at, s.created_at
@@ -97,10 +86,8 @@ func GetSignalsForCAN(canMessageID string) ([]mapache.Signal, error) {
 	return signals, rows.Err()
 }
 
-// CreateCAN inserts a CAN frame and returns it with the generated id
-// populated. Dedup on (vehicle_id, node_id, timestamp) is handled by the
-// ReplacingMergeTree engine (latest created_at wins on merge), so no
-// explicit conflict handling is needed.
+// Dedup on (vehicle_id, node_id, timestamp) is handled by the
+// ReplacingMergeTree engine — latest created_at wins on merge.
 const insertCANSQL = `INSERT INTO gr26_can (id, vehicle_id, node_id, timestamp, can_id, bytes, upload_key, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 
 func CreateCAN(can model.CAN) (model.CAN, error) {

--- a/gr26/service/message.go
+++ b/gr26/service/message.go
@@ -17,18 +17,9 @@ import (
 	mapache "github.com/gaucho-racing/mapache/mapache-go/v3"
 )
 
-// ShelterBatchHook fires at the tail of HandleMessage when a frame's
-// canID matches model.MsgIDShelterBatch. Wired up in main.go to the
-// job package — left as a nil-able package var here so service stays
-// importable without job (avoids the circular import; service is the
-// lower layer).
+// ShelterBatchHook is set by main.go to avoid a service → job import cycle.
 var ShelterBatchHook func(vehicleID string, ts int, data []byte)
 
-// HandleInboundMessage is the per-message callback registered with
-// mqtt.SetMessageHandler. Parses the topic into vehicle/node/can-id,
-// dispatches ping/pong specially, and hands off CAN frames to
-// HandleMessage in a fresh goroutine so the paho receive loop never
-// blocks on downstream I/O.
 func HandleInboundMessage(topic string, payload []byte) {
 	if len(strings.Split(topic, "/")) != 4 {
 		logger.SugarLogger.Infof("[MQ] Received invalid topic: %s, ignoring", topic)
@@ -64,21 +55,10 @@ func HandleInboundMessage(topic string, payload []byte) {
 	go HandleMessage(vehicleID, nodeID, int(canIDInt), payload)
 }
 
-// ProcessFrame decodes a single CAN frame and returns the assembled
-// gr26_can record + the list of signals it produced, ready for the
-// caller to persist however it wants. Pure data transformation — no
-// DB writes, no WS publish, no side-channel hooks.
-//
-// The returned CAN's UploadKey is left at 0; the live MQTT path fills
-// it in from the envelope, the cold-storage replay path leaves it.
-// Signals are stamped with the node-prefixed Name and the per-frame
-// metadata (Timestamp, VehicleID, ProducedAt, CreatedAt) so the caller
-// can pass them straight to CreateSignals.
-//
-// On unknown canID or a decode_error, the CAN comes back with its
-// Metadata field set to a {status, note} blob and signals is empty —
-// callers still want to persist the raw frame so "what bytes did we
-// fail to parse" stays answerable.
+// ProcessFrame is pure data transformation: decode bytes → (CAN, signals).
+// UploadKey on the returned CAN is left at 0 for the caller to fill in.
+// Unknown canID / decode errors return an empty signals list and a status
+// blob in CAN.Metadata so the raw frame can still be persisted.
 func ProcessFrame(vehicleID, nodeID string, canID, timestamp int, data []byte) (model.CAN, []mapache.Signal) {
 	producedAt := time.UnixMicro(int64(timestamp))
 
@@ -150,11 +130,7 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 	can, signals := ProcessFrame(vehicleID, nodeID, canID, ts, data)
 	can.UploadKey = uploadKeyInt
 
-	// Each persist step is independent — signals are still meaningful
-	// even if the gr26_can write fails (they're queryable by name +
-	// timestamp + vehicle), and the WS feed is worth firing for live
-	// consumers regardless of DB state. So we log and continue rather
-	// than short-circuit the rest of the pipeline.
+	// Persist steps log-and-continue so one failure doesn't drop the rest.
 	if _, err := CreateCAN(can); err != nil {
 		logger.SugarLogger.Infof("Error creating CAN record: %s", err)
 	}
@@ -163,19 +139,10 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 		if err := CreateSignals(signals); err != nil {
 			logger.SugarLogger.Infof("Error creating signals: %s", err)
 		}
-		// Fan decoded signals back out over MQTT so any consumer
-		// (live dashboard, query bridge, etc.) can subscribe to
-		// query/live/<vid>/<name> instead of relying on an in-process
-		// hub. Done per-replica: under the shared sub each frame is
-		// handled by exactly one replica, so each decoded signal is
-		// published exactly once.
 		for _, s := range signals {
 			topic := fmt.Sprintf("query/live/%s/%s", s.VehicleID, s.Name)
 			mqtt.PublishJSON(context.Background(), topic, s)
 		}
-		// On-car gr26 also fans signals to the in-process Hub so the
-		// on-car dash can keep using the /gr26/live WebSocket. Cloud
-		// replicas leave this off — see EnableSignalWS in config.
 		if config.EnableSignalWS {
 			for _, s := range signals {
 				Hub.Publish(s)
@@ -183,22 +150,16 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 		}
 	}
 
-	// Side-channel: when shelter announces a successful upload, hand off
-	// to whichever module registered the hook (today: gr26/job/, which
-	// enqueues a foreman ingest job).
 	if canID == model.MsgIDShelterBatch && ShelterBatchHook != nil {
 		go ShelterBatchHook(vehicleID, ts, data)
 	}
 }
 
-// MustJSON marshals v to JSON, returning a sentinel error blob if
-// marshaling fails. Exported because gr26/job's replayFrame builds the
-// same status/note metadata blobs and we share this rather than copy it.
+// MustJSON marshals v, falling back to a sentinel blob on error so
+// callers always get valid jsonb. Shared with gr26/job's replayFrame.
 func MustJSON(v any) []byte {
 	b, err := json.Marshal(v)
 	if err != nil {
-		// json.Marshal on a map of strings/strings can't fail in practice;
-		// fall back to a literal so callers always get a valid jsonb value.
 		return []byte(`{"status":"marshal_error"}`)
 	}
 	return b

--- a/gr26/service/message.go
+++ b/gr26/service/message.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gaucho-racing/mapache/gr26/config"
 	"github.com/gaucho-racing/mapache/gr26/model"
 	"github.com/gaucho-racing/mapache/gr26/mqtt"
 	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
@@ -142,11 +141,7 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 		for _, s := range signals {
 			topic := fmt.Sprintf("query/live/%s/%s", s.VehicleID, s.Name)
 			mqtt.PublishJSON(context.Background(), topic, s)
-		}
-		if config.EnableSignalWS {
-			for _, s := range signals {
-				Hub.Publish(s)
-			}
+			Hub.Publish(s)
 		}
 	}
 

--- a/gr26/service/message.go
+++ b/gr26/service/message.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -14,8 +15,6 @@ import (
 	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
 
 	mapache "github.com/gaucho-racing/mapache/mapache-go/v3"
-
-	mq "github.com/eclipse/paho.mqtt.golang"
 )
 
 // ShelterBatchHook fires at the tail of HandleMessage when a frame's
@@ -25,43 +24,44 @@ import (
 // lower layer).
 var ShelterBatchHook func(vehicleID string, ts int, data []byte)
 
-func SubscribeTopics() {
-	mqtt.Client.Subscribe("gr26/#", 0, func(client mq.Client, msg mq.Message) {
-		topic := msg.Topic()
-		if len(strings.Split(topic, "/")) != 4 {
-			logger.SugarLogger.Infof("[MQ] Received invalid topic: %s, ignoring", topic)
-			return
-		}
-		vehicleID := strings.Split(topic, "/")[1]
-		nodeID := strings.Split(topic, "/")[2]
-		canID := strings.Split(topic, "/")[3]
+// HandleInboundMessage is the per-message callback registered with
+// mqtt.SetMessageHandler. Parses the topic into vehicle/node/can-id,
+// dispatches ping/pong specially, and hands off CAN frames to
+// HandleMessage in a fresh goroutine so the paho receive loop never
+// blocks on downstream I/O.
+func HandleInboundMessage(topic string, payload []byte) {
+	if len(strings.Split(topic, "/")) != 4 {
+		logger.SugarLogger.Infof("[MQ] Received invalid topic: %s, ignoring", topic)
+		return
+	}
+	vehicleID := strings.Split(topic, "/")[1]
+	nodeID := strings.Split(topic, "/")[2]
+	canID := strings.Split(topic, "/")[3]
 
-		if vehicleID == "" {
-			logger.SugarLogger.Infof("[MQ] Received invalid vehicle id: %s, ignoring", topic)
-			return
-		}
-		if nodeID == "" {
-			logger.SugarLogger.Infof("[MQ] Received invalid node id: %s, ignoring", topic)
-			return
-		}
+	if vehicleID == "" {
+		logger.SugarLogger.Infof("[MQ] Received invalid vehicle id: %s, ignoring", topic)
+		return
+	}
+	if nodeID == "" {
+		logger.SugarLogger.Infof("[MQ] Received invalid node id: %s, ignoring", topic)
+		return
+	}
 
-		if canID == "ping" {
-			go HandlePing(vehicleID, nodeID, msg.Payload())
-			return
-		} else if canID == "pong" {
-			return
-		}
+	if canID == "ping" {
+		go HandlePing(vehicleID, nodeID, payload)
+		return
+	} else if canID == "pong" {
+		return
+	}
 
-		message := msg.Payload()
-		canID = strings.TrimPrefix(canID, "0x")
-		canIDInt, err := strconv.ParseInt(canID, 16, 64)
-		if err != nil {
-			logger.SugarLogger.Infof("[MQ] Received invalid can id: %s, ignoring", canID)
-			return
-		}
-		logger.SugarLogger.Infof("[MQ] Received message: %s", topic)
-		go HandleMessage(vehicleID, nodeID, int(canIDInt), message)
-	})
+	canID = strings.TrimPrefix(canID, "0x")
+	canIDInt, err := strconv.ParseInt(canID, 16, 64)
+	if err != nil {
+		logger.SugarLogger.Infof("[MQ] Received invalid can id: %s, ignoring", canID)
+		return
+	}
+	logger.SugarLogger.Infof("[MQ] Received message: %s", topic)
+	go HandleMessage(vehicleID, nodeID, int(canIDInt), payload)
 }
 
 // ProcessFrame decodes a single CAN frame and returns the assembled
@@ -163,6 +163,19 @@ func HandleMessage(vehicleID string, nodeID string, canID int, message []byte) {
 		if err := CreateSignals(signals); err != nil {
 			logger.SugarLogger.Infof("Error creating signals: %s", err)
 		}
+		// Fan decoded signals back out over MQTT so any consumer
+		// (live dashboard, query bridge, etc.) can subscribe to
+		// query/live/<vid>/<name> instead of relying on an in-process
+		// hub. Done per-replica: under the shared sub each frame is
+		// handled by exactly one replica, so each decoded signal is
+		// published exactly once.
+		for _, s := range signals {
+			topic := fmt.Sprintf("query/live/%s/%s", s.VehicleID, s.Name)
+			mqtt.PublishJSON(context.Background(), topic, s)
+		}
+		// On-car gr26 also fans signals to the in-process Hub so the
+		// on-car dash can keep using the /gr26/live WebSocket. Cloud
+		// replicas leave this off — see EnableSignalWS in config.
 		if config.EnableSignalWS {
 			for _, s := range signals {
 				Hub.Publish(s)

--- a/gr26/service/ping.go
+++ b/gr26/service/ping.go
@@ -51,7 +51,7 @@ func SendPong(vehicleID string, nodeID string, ping uint64) {
 const insertPingSQL = `INSERT INTO ping (vehicle_id, ping, pong, latency) VALUES (?, ?, ?, ?)`
 
 func CreatePing(ping mapache.Ping) error {
-	if !config.EnableSignalDB {
+	if !config.ClickhouseEnabled() {
 		return nil
 	}
 	ctx := database.InsertCtx(context.Background())

--- a/gr26/service/ping.go
+++ b/gr26/service/ping.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gaucho-racing/mapache/gr26/config"
 	"github.com/gaucho-racing/mapache/gr26/database"
 	"github.com/gaucho-racing/mapache/gr26/mqtt"
 	"github.com/gaucho-racing/mapache/gr26/pkg/logger"
@@ -33,7 +34,7 @@ func SendPong(vehicleID string, nodeID string, ping uint64) {
 	binary.BigEndian.PutUint64(payload, ping)
 	binary.BigEndian.PutUint64(payload[8:], pong)
 
-	mqtt.Client.Publish(topic, 0, false, payload)
+	mqtt.Publish(context.Background(), topic, payload)
 	logger.SugarLogger.Infof("[PING] Received ping from gr26/%s/%s in %dms", vehicleID, nodeID, latency/1000)
 
 	err := CreatePing(mapache.Ping{
@@ -53,6 +54,9 @@ func SendPong(vehicleID string, nodeID string, ping uint64) {
 const insertPingSQL = `INSERT INTO ping (vehicle_id, ping, pong, latency) VALUES (?, ?, ?, ?)`
 
 func CreatePing(ping mapache.Ping) error {
+	if !config.EnableSignalDB {
+		return nil
+	}
 	ctx := database.InsertCtx(context.Background())
 	return database.Conn.Exec(ctx, insertPingSQL,
 		ping.VehicleID, int64(ping.Ping), int64(ping.Pong), int32(ping.Latency))

--- a/gr26/service/ping.go
+++ b/gr26/service/ping.go
@@ -48,9 +48,6 @@ func SendPong(vehicleID string, nodeID string, ping uint64) {
 	}
 }
 
-// ping is a plain append-only MergeTree (no version column, no dedup), so a
-// retransmitted ping just appends another row — fine for write-only latency
-// telemetry that is never read back or corrected.
 const insertPingSQL = `INSERT INTO ping (vehicle_id, ping, pong, latency) VALUES (?, ?, ?, ?)`
 
 func CreatePing(ping mapache.Ping) error {

--- a/gr26/service/signal.go
+++ b/gr26/service/signal.go
@@ -11,15 +11,8 @@ import (
 	ulid "github.com/gaucho-racing/ulid-go"
 )
 
-// CreateSignals writes decoded signals to ClickHouse. WebSocket publishing
-// lives in HandleMessage so the published payload can carry the
-// can_message_id alongside the signal.
-//
-// produced_at and created_at are omitted from the insert: produced_at is a
-// MATERIALIZED column derived from timestamp, and created_at defaults to
-// the insert wall clock and acts as the ReplacingMergeTree version (latest
-// write wins on merge), so retransmits and corrected decodes dedup
-// naturally without an explicit ON CONFLICT.
+// produced_at is MATERIALIZED from timestamp; created_at defaults to insert
+// wall clock and acts as the ReplacingMergeTree version. Both omitted here.
 const insertSignalSQL = `INSERT INTO signal (id, timestamp, vehicle_id, name, value, raw_value) VALUES (?, ?, ?, ?, ?, ?)`
 
 func CreateSignals(signals []mapache.Signal) error {

--- a/gr26/service/signal.go
+++ b/gr26/service/signal.go
@@ -28,7 +28,7 @@ func CreateSignals(signals []mapache.Signal) error {
 		}
 		signals[i].ID = ulid.Make().Prefixed("sgnl")
 	}
-	if !config.EnableSignalDB {
+	if !config.ClickhouseEnabled() {
 		return nil
 	}
 	ctx := database.InsertCtx(context.Background())

--- a/gr26/service/signal_hub.go
+++ b/gr26/service/signal_hub.go
@@ -12,9 +12,7 @@ type Client struct {
 	Send chan mapache.Signal
 }
 
-// WildcardSignal is the sentinel signal name that subscribes a client to every
-// signal for a vehicle. A client subscribed to "*" receives all signals
-// published for the vehicle in addition to any specific names it subscribed to.
+// WildcardSignal subscribes a client to every signal for a vehicle.
 const WildcardSignal = "*"
 
 type SignalHub struct {

--- a/kerbecs.yaml
+++ b/kerbecs.yaml
@@ -123,14 +123,6 @@ routes:
       strip_prefix: /api
     envelope: default
 
-  - name: gr26-live
-    match:
-      path: /api/gr26/live
-    upstream: gr26
-    rewrite:
-      strip_prefix: /api
-    envelope: passthrough
-
   - name: gr26
     match:
       path: /api/gr26/*


### PR DESCRIPTION
- Swap gr26 ingest client from paho.mqtt.golang (v3.1.1) to paho.golang/autopaho (v5)
- Subscribe via \`\$share/ingest/gr26/#\` so multiple replicas fan out CAN frames through the broker
- Republish decoded signals to \`query/live/<vehicle_id>/<signal_name>\` (JSON-encoded \`mapache.Signal\`, QoS 0) — replaces the in-process WS hub fan-out which would only see one replica's share
- WS path retained for on-car gr26 (the TCM-resident instance feeding the on-car dash): \`ENABLE_SIGNAL_WS\` gates the Hub + \`/gr26/live\` endpoint, default false (cloud) / true (on-car)
- \`ENABLE_SIGNAL_DB\` now gates all ClickHouse operations: \`database.Init\` is skipped when off, \`CreateCAN\`/\`CreateSignals\`/\`CreatePing\` no-op, CH-backed read endpoints return 503 — lets the on-car gr26 run without ClickHouse
- TCM-26 stays on the v3 paho client; shared subs work fine with v3 publishers + v5 subscribers (broker-side feature)

## Deploy notes
- Cloud compose unchanged (\`ENABLE_SIGNAL_DB=true\`, no \`ENABLE_SIGNAL_WS\` needed — defaults false)
- \`jetson-infra\` on-car gr26 manifest needs \`ENABLE_SIGNAL_DB=false\` + \`ENABLE_SIGNAL_WS=true\`