### PR TITLE
perf(live): lock-free hub dispatch + connection hardening

### DIFF
--- a/live/api/api.go
+++ b/live/api/api.go
@@ -32,7 +32,12 @@ func InitializeRouter() *gin.Engine {
 	return r
 }
 
+// streamGate bounds concurrent WS+SSE streams for this replica. Initialized
+// from config in InitializeRoutes, after config.Verify has run.
+var streamGate *connGate
+
 func InitializeRoutes(router *gin.Engine) {
+	streamGate = newConnGate(config.MaxConnections)
 	router.GET("/live/ping", Ping)
 	router.GET("/live/stats", Stats)
 	router.GET("/live/ws", StreamSignalsWS)

--- a/live/api/connlimit.go
+++ b/live/api/connlimit.go
@@ -1,0 +1,30 @@
+package api
+
+import "sync/atomic"
+
+// connGate bounds concurrent live streams per replica. acquire reports whether
+// a slot was taken; the caller must release exactly once iff it returned true.
+type connGate struct {
+	active atomic.Int64
+	max    int64
+}
+
+func newConnGate(max int) *connGate {
+	return &connGate{max: int64(max)}
+}
+
+func (g *connGate) acquire() bool {
+	if g.active.Add(1) > g.max {
+		g.active.Add(-1)
+		return false
+	}
+	return true
+}
+
+func (g *connGate) release() {
+	g.active.Add(-1)
+}
+
+func (g *connGate) count() int64 {
+	return g.active.Load()
+}

--- a/live/api/connlimit_test.go
+++ b/live/api/connlimit_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestConnGateAcquireRelease(t *testing.T) {
+	g := newConnGate(2)
+
+	if !g.acquire() || !g.acquire() {
+		t.Fatal("first two acquires should succeed")
+	}
+	if g.acquire() {
+		t.Fatal("third acquire should fail at cap")
+	}
+	if g.count() != 2 {
+		t.Fatalf("count: want 2, got %d", g.count())
+	}
+
+	g.release()
+	if !g.acquire() {
+		t.Fatal("acquire should succeed after release")
+	}
+	if g.count() != 2 {
+		t.Fatalf("count after release+acquire: want 2, got %d", g.count())
+	}
+}
+
+// TestConnGateConcurrent verifies the cap holds under concurrent acquire/release
+// and never leaks or exceeds. Run with -race.
+func TestConnGateConcurrent(t *testing.T) {
+	const max = 50
+	g := newConnGate(max)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 500; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if g.acquire() {
+				g.release()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if g.count() != 0 {
+		t.Fatalf("expected 0 active after all release, got %d", g.count())
+	}
+	if !g.acquire() {
+		t.Fatal("gate should be fully available again")
+	}
+}

--- a/live/api/ping.go
+++ b/live/api/ping.go
@@ -22,6 +22,10 @@ func Stats(c *gin.Context) {
 			"exact":    exact,
 			"patterns": patterns,
 		},
+		"connections": gin.H{
+			"active": streamGate.count(),
+			"max":    config.MaxConnections,
+		},
 		"cache":   service.Recent.Stats(),
 		"latency": service.Latency.Stats(),
 	})

--- a/live/api/stream_sse.go
+++ b/live/api/stream_sse.go
@@ -7,11 +7,16 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/gaucho-racing/mapache/live/config"
 	"github.com/gaucho-racing/mapache/live/service"
 
 	mapache "github.com/gaucho-racing/mapache/mapache-go/v3"
 	"github.com/gin-gonic/gin"
 )
+
+// sseKeepalive is how often a comment line is sent during signal lulls to
+// keep proxies open and let the write deadline reap dead connections.
+const sseKeepalive = 25 * time.Second
 
 // StreamSignalsSSE streams live signals over Server-Sent Events.
 //
@@ -56,6 +61,12 @@ func StreamSignalsSSE(c *gin.Context) {
 		since = time.Now().Add(-time.Duration(backfillSec) * time.Second)
 	}
 
+	if !streamGate.acquire() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "server at connection capacity"})
+		return
+	}
+	defer streamGate.release()
+
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
@@ -70,14 +81,34 @@ func StreamSignalsSSE(c *gin.Context) {
 	service.Signals.Subscribe(vehicleID, subs, client)
 	defer service.Signals.Unsubscribe(vehicleID, subs, client)
 
+	// http.ResponseController reaches the underlying conn (gin's
+	// ResponseWriter implements Unwrap) so we can bound each write with a
+	// deadline — a client that stops draining can't pin this goroutine.
+	rc := http.NewResponseController(c.Writer)
+	setDeadline := func() {
+		rc.SetWriteDeadline(time.Now().Add(time.Duration(config.WriteTimeoutSec) * time.Second))
+	}
+
+	setDeadline()
 	suppress := sendBackfillSSE(c, vehicleID, subs, since)
 	c.Writer.Flush()
+
+	// Keepalive comment so a half-open connection is detected (write deadline
+	// fires) even during signal lulls, and proxies keep the stream open.
+	ka := time.NewTicker(sseKeepalive)
+	defer ka.Stop()
 
 	ctx := c.Request.Context()
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-ka.C:
+			setDeadline()
+			if _, err := fmt.Fprint(c.Writer, ": keepalive\n\n"); err != nil {
+				return
+			}
+			c.Writer.Flush()
 		case sig, ok := <-client.Send:
 			if !ok {
 				return
@@ -85,6 +116,7 @@ func StreamSignalsSSE(c *gin.Context) {
 			if max, ok := suppress[sig.Name]; ok && sig.CreatedAt.Before(max) {
 				continue
 			}
+			setDeadline()
 			if !writeSSESignal(c, sig) {
 				return
 			}

--- a/live/api/stream_test.go
+++ b/live/api/stream_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gaucho-racing/mapache/live/config"
+	"github.com/gaucho-racing/mapache/live/service"
+
+	mapache "github.com/gaucho-racing/mapache/mapache-go/v3"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+func testServer(t *testing.T, maxConns int) *httptest.Server {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	config.WriteTimeoutSec = 10
+	config.CacheWindowSec = 60
+	config.MaxConnections = maxConns
+	service.InitCache(60 * time.Second)
+
+	r := gin.New()
+	InitializeRoutes(r)
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func sig(vehicle, name string) mapache.Signal {
+	return mapache.Signal{VehicleID: vehicle, Name: name, Timestamp: int(time.Now().UnixMicro()), CreatedAt: time.Now()}
+}
+
+func TestSSEDeliversBackfillThenLive(t *testing.T) {
+	srv := testServer(t, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+		srv.URL+"/live/sse?vehicle_id=v1&signals=motor_rpm&backfill=0", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("sse request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+
+	r := bufio.NewReader(resp.Body)
+	// First event must be the backfill boundary.
+	if !readUntilEvent(t, r, "backfill") {
+		t.Fatal("did not receive backfill event")
+	}
+
+	// Subscription is now active; publish a live signal and expect it through.
+	service.Signals.Publish(sig("v1", "motor_rpm"))
+	if !readUntilEvent(t, r, "signal") {
+		t.Fatal("did not receive live signal event")
+	}
+}
+
+func TestWSDeliversBackfillThenLive(t *testing.T) {
+	srv := testServer(t, 10)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/live/ws?vehicle_id=v1&signals=motor_rpm&backfill=0"
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	defer conn.Close()
+
+	// First frame is the backfill array (possibly empty).
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var backfill []mapache.Signal
+	if err := conn.ReadJSON(&backfill); err != nil {
+		t.Fatalf("read backfill: %v", err)
+	}
+
+	service.Signals.Publish(sig("v1", "motor_rpm"))
+
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var live mapache.Signal
+	if err := conn.ReadJSON(&live); err != nil {
+		t.Fatalf("read live signal: %v", err)
+	}
+	if live.Name != "motor_rpm" || live.VehicleID != "v1" {
+		t.Fatalf("unexpected signal: %+v", live)
+	}
+}
+
+func TestConnectionCapReturns503(t *testing.T) {
+	srv := testServer(t, 1) // cap at 1
+
+	// Hold one SSE connection open (occupies the only slot).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet,
+		srv.URL+"/live/sse?vehicle_id=v1&signals=motor_rpm&backfill=0", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("first sse request: %v", err)
+	}
+	defer resp.Body.Close()
+	// Drain past backfill so the handler has definitely acquired its slot.
+	readUntilEvent(t, bufio.NewReader(resp.Body), "backfill")
+
+	// Second connection must be shed.
+	resp2, err := http.Get(srv.URL + "/live/sse?vehicle_id=v1&signals=motor_rpm&backfill=0")
+	if err != nil {
+		t.Fatalf("second sse request: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("over-cap connection: want 503, got %d", resp2.StatusCode)
+	}
+
+	// Freeing the first slot lets a new connection in.
+	cancel()
+	resp.Body.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	resp3, err := http.Get(srv.URL + "/live/sse?vehicle_id=v1&signals=motor_rpm&backfill=0")
+	if err != nil {
+		t.Fatalf("third sse request: %v", err)
+	}
+	defer resp3.Body.Close()
+	if resp3.StatusCode != http.StatusOK {
+		t.Fatalf("after release: want 200, got %d", resp3.StatusCode)
+	}
+}
+
+// readUntilEvent scans SSE lines until it sees `event: <name>` or times out.
+func readUntilEvent(t *testing.T, r *bufio.Reader, name string) bool {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return false
+		}
+		if strings.TrimSpace(line) == "event: "+name {
+			return true
+		}
+	}
+	return false
+}

--- a/live/api/stream_ws.go
+++ b/live/api/stream_ws.go
@@ -22,6 +22,13 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
+const (
+	// pongWait is how long we wait for a pong before declaring the connection
+	// dead and reaping it. pingPeriod must be comfortably less than pongWait.
+	pongWait   = 60 * time.Second
+	pingPeriod = (pongWait * 9) / 10
+)
+
 // StreamSignalsWS streams live signals over a WebSocket. Subscription is
 // fixed at connect time (URL params). The first frame is always a JSON
 // array of backfill signals (possibly empty); every subsequent frame is a
@@ -53,6 +60,12 @@ func StreamSignalsWS(c *gin.Context) {
 	backfillSec := parseBackfill(c.Query("backfill"))
 	rate := parseRate(c.Query("rate"))
 
+	if !streamGate.acquire() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "server at connection capacity"})
+		return
+	}
+	defer streamGate.release()
+
 	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		return
@@ -72,14 +85,37 @@ func StreamSignalsWS(c *gin.Context) {
 
 	suppress := sendBackfillWS(conn, vehicleID, subs, backfillSec)
 
-	// Reader goroutine — only purpose is detecting client disconnect.
-	// Anything the client sends is ignored (subs are fixed at connect).
+	// Reader goroutine — detects client disconnect and drives the heartbeat:
+	// each pong (and any client frame) extends the read deadline, so a
+	// half-open connection that stops responding is reaped after pongWait.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+		conn.SetReadDeadline(time.Now().Add(pongWait))
+		conn.SetPongHandler(func(string) error {
+			return conn.SetReadDeadline(time.Now().Add(pongWait))
+		})
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {
 				return
+			}
+		}
+	}()
+
+	// Ping goroutine — keeps the connection live and surfaces dead peers.
+	// WriteControl is safe to call concurrently with the WriteJSON in streamWS.
+	go func() {
+		ticker := time.NewTicker(pingPeriod)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				deadline := time.Now().Add(time.Duration(config.WriteTimeoutSec) * time.Second)
+				if err := conn.WriteControl(websocket.PingMessage, nil, deadline); err != nil {
+					return
+				}
 			}
 		}
 	}()
@@ -101,6 +137,7 @@ func sendBackfillWS(conn *websocket.Conn, vehicleID string, subs []string, backf
 	if snap == nil {
 		snap = []mapache.Signal{}
 	}
+	conn.SetWriteDeadline(time.Now().Add(time.Duration(config.WriteTimeoutSec) * time.Second))
 	if err := conn.WriteJSON(snap); err != nil {
 		return nil
 	}
@@ -123,6 +160,13 @@ func streamWS(conn *websocket.Conn, client *service.Client, suppress map[string]
 		return true
 	}
 
+	// writeJSON bounds every frame with a write deadline so a client that
+	// stops draining its socket can't pin this goroutine forever.
+	writeJSON := func(v any) error {
+		conn.SetWriteDeadline(time.Now().Add(time.Duration(config.WriteTimeoutSec) * time.Second))
+		return conn.WriteJSON(v)
+	}
+
 	if rate <= 0 {
 		for {
 			select {
@@ -135,7 +179,7 @@ func streamWS(conn *websocket.Conn, client *service.Client, suppress map[string]
 				if !keep(sig) {
 					continue
 				}
-				if err := conn.WriteJSON(sig); err != nil {
+				if err := writeJSON(sig); err != nil {
 					return
 				}
 			}
@@ -160,7 +204,7 @@ func streamWS(conn *websocket.Conn, client *service.Client, suppress map[string]
 			pending[sig.Name] = sig
 		case <-ticker.C:
 			for _, s := range pending {
-				if err := conn.WriteJSON(s); err != nil {
+				if err := writeJSON(s); err != nil {
 					return
 				}
 			}

--- a/live/config/config.go
+++ b/live/config/config.go
@@ -21,7 +21,7 @@ func (s ServiceInfo) PathPrefix() string {
 
 var Service = ServiceInfo{
 	Name:    "Live",
-	Version:     "3.6.1",
+	Version: "3.6.1",
 }
 
 var Env = os.Getenv("ENV")
@@ -37,6 +37,20 @@ var MQTTPassword = os.Getenv("MQTT_PASSWORD")
 // of 60s comfortably exceeds observed CH lag in practice.
 var CacheWindowSecRaw = os.Getenv("CACHE_WINDOW_SEC")
 var CacheWindowSec int
+
+// MaxConnections caps concurrent live streams (WS + SSE) per replica.
+// New connections over the cap are rejected with 503 so a replica sheds
+// load gracefully instead of exhausting goroutines/FDs/memory. Scale total
+// capacity by adding replicas (clients round-robin onto any of them).
+var MaxConnectionsRaw = os.Getenv("MAX_CONNECTIONS")
+var MaxConnections int
+
+// WriteTimeoutSec bounds a single frame write to a client. A consumer that
+// stops draining its socket must not pin a writer goroutine forever; once a
+// write blocks past this deadline the connection is dropped and its slot
+// reclaimed.
+var WriteTimeoutSecRaw = os.Getenv("WRITE_TIMEOUT_SEC")
+var WriteTimeoutSec int
 
 func IsProduction() bool {
 	return Env == "PROD"

--- a/live/config/verify.go
+++ b/live/config/verify.go
@@ -32,4 +32,20 @@ func Verify() {
 	} else {
 		CacheWindowSec = n
 	}
+	if n, err := strconv.Atoi(MaxConnectionsRaw); err != nil || n < 1 {
+		if MaxConnectionsRaw != "" {
+			logger.SugarLogger.Errorf("MAX_CONNECTIONS=%q is not a positive int, defaulting to 5000", MaxConnectionsRaw)
+		}
+		MaxConnections = 5000
+	} else {
+		MaxConnections = n
+	}
+	if n, err := strconv.Atoi(WriteTimeoutSecRaw); err != nil || n < 1 {
+		if WriteTimeoutSecRaw != "" {
+			logger.SugarLogger.Errorf("WRITE_TIMEOUT_SEC=%q is not a positive int, defaulting to 10", WriteTimeoutSecRaw)
+		}
+		WriteTimeoutSec = 10
+	} else {
+		WriteTimeoutSec = n
+	}
 }

--- a/live/service/hub.go
+++ b/live/service/hub.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	mapache "github.com/gaucho-racing/mapache/mapache-go/v3"
 )
@@ -16,19 +17,50 @@ import (
 type Client struct {
 	ID   string
 	Send chan mapache.Signal
+
+	// seq is the dispatch-dedup marker: Publish stamps it with the current
+	// publish epoch right before sending, so a client matching a signal via
+	// both an exact name and a pattern (or multiple patterns) receives it
+	// once. Touched only by Publish, which is serialized by Hub.pubMu, so it
+	// needs no atomic.
+	seq uint64
+}
+
+// patternBucket is one glob pattern and its (immutable) subscriber slice.
+type patternBucket struct {
+	pattern string
+	clients []*Client
+}
+
+// vehicleSnap is the immutable per-vehicle subscriber snapshot. Once stored in
+// the Hub it is never mutated; writers build a new one and swap it in. This is
+// what lets Publish read without locking against connection churn.
+type vehicleSnap struct {
+	// exact[signalName] = immutable subscriber slice
+	exact map[string][]*Client
+	// patterns holds raw glob buckets, matched with path.Match on each Publish.
+	patterns []patternBucket
 }
 
 // Hub is the package-global signal router. Transport handlers register
 // Clients with a vehicle + set of signal names/patterns; Publish routes
 // incoming signals to every matching client.
+//
+// Concurrency model:
+//   - vehicles holds an immutable snapshot map behind an atomic pointer.
+//     Publish loads it lock-free and never blocks, so connection churn cannot
+//     stall signal dispatch.
+//   - writeMu serializes Subscribe/Unsubscribe, which copy-on-write a new
+//     snapshot and swap it in. Writers pay an O(subscribers-on-the-affected-
+//     signal) copy, kept off the hot dispatch path.
+//   - pubMu serializes publishers so the per-Client seq dedup marker is safe.
+//     There is one publisher (the MQTT callback), so it is uncontended.
 type Hub struct {
-	mu sync.RWMutex
-	// exact[vehicleID][signalName] = subscriber set
-	exact map[string]map[string]map[*Client]struct{}
-	// patterns[vehicleID][rawPattern] = subscriber set. Patterns are
-	// raw glob strings (e.g. "ecu_*", "*_status", "*"); matched with
-	// path.Match on each Publish.
-	patterns map[string]map[string]map[*Client]struct{}
+	writeMu  sync.Mutex
+	vehicles atomic.Pointer[map[string]*vehicleSnap]
+
+	pubMu  sync.Mutex
+	pubSeq uint64
 }
 
 var Signals *Hub
@@ -38,10 +70,10 @@ func init() {
 }
 
 func NewHub() *Hub {
-	return &Hub{
-		exact:    make(map[string]map[string]map[*Client]struct{}),
-		patterns: make(map[string]map[string]map[*Client]struct{}),
-	}
+	h := &Hub{}
+	empty := make(map[string]*vehicleSnap)
+	h.vehicles.Store(&empty)
+	return h
 }
 
 // isPattern reports whether name contains a glob metacharacter. Anything
@@ -65,98 +97,179 @@ func ValidatePatterns(names []string) error {
 	return nil
 }
 
+// cloneVehicles shallow-copies the snapshot map. Entries (vehicleSnap
+// pointers) are shared; callers replace whole entries, never mutate them.
+func cloneVehicles(cur *map[string]*vehicleSnap) map[string]*vehicleSnap {
+	next := make(map[string]*vehicleSnap, len(*cur)+1)
+	for k, v := range *cur {
+		next[k] = v
+	}
+	return next
+}
+
+// cloneSnap copies a vehicleSnap's containers (exact map header + patterns
+// slice). The inner client slices are shared and treated as immutable —
+// modifications replace the whole slice via appendClient/removeClient.
+func cloneSnap(vs *vehicleSnap) *vehicleSnap {
+	n := &vehicleSnap{exact: make(map[string][]*Client)}
+	if vs != nil {
+		for k, v := range vs.exact {
+			n.exact[k] = v
+		}
+		n.patterns = append([]patternBucket(nil), vs.patterns...)
+	}
+	return n
+}
+
+// appendClient returns old with client added, copying so the original
+// (possibly published) slice is never mutated. A no-op if already present.
+func appendClient(old []*Client, client *Client) []*Client {
+	for _, c := range old {
+		if c == client {
+			return old
+		}
+	}
+	n := make([]*Client, len(old)+1)
+	copy(n, old)
+	n[len(old)] = client
+	return n
+}
+
+// removeClient returns old without client (copying) and whether it changed.
+func removeClient(old []*Client, client *Client) ([]*Client, bool) {
+	idx := -1
+	for i, c := range old {
+		if c == client {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return old, false
+	}
+	n := make([]*Client, 0, len(old)-1)
+	n = append(n, old[:idx]...)
+	n = append(n, old[idx+1:]...)
+	return n, true
+}
+
 func (h *Hub) Subscribe(vehicleID string, names []string, client *Client) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
+
+	next := cloneVehicles(h.vehicles.Load())
+	vs := cloneSnap(next[vehicleID])
+
 	for _, name := range names {
 		if isPattern(name) {
-			if h.patterns[vehicleID] == nil {
-				h.patterns[vehicleID] = make(map[string]map[*Client]struct{})
+			found := false
+			for i := range vs.patterns {
+				if vs.patterns[i].pattern == name {
+					vs.patterns[i].clients = appendClient(vs.patterns[i].clients, client)
+					found = true
+					break
+				}
 			}
-			if h.patterns[vehicleID][name] == nil {
-				h.patterns[vehicleID][name] = make(map[*Client]struct{})
+			if !found {
+				vs.patterns = append(vs.patterns, patternBucket{
+					pattern: name,
+					clients: []*Client{client},
+				})
 			}
-			h.patterns[vehicleID][name][client] = struct{}{}
 			continue
 		}
-		if h.exact[vehicleID] == nil {
-			h.exact[vehicleID] = make(map[string]map[*Client]struct{})
-		}
-		if h.exact[vehicleID][name] == nil {
-			h.exact[vehicleID][name] = make(map[*Client]struct{})
-		}
-		h.exact[vehicleID][name][client] = struct{}{}
+		vs.exact[name] = appendClient(vs.exact[name], client)
 	}
+
+	next[vehicleID] = vs
+	h.vehicles.Store(&next)
 }
 
 func (h *Hub) Unsubscribe(vehicleID string, names []string, client *Client) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	h.writeMu.Lock()
+	defer h.writeMu.Unlock()
+
+	cur := h.vehicles.Load()
+	if (*cur)[vehicleID] == nil {
+		return
+	}
+	next := cloneVehicles(cur)
+	vs := cloneSnap(next[vehicleID])
+
 	for _, name := range names {
 		if isPattern(name) {
-			if pats, ok := h.patterns[vehicleID]; ok {
-				if set, ok := pats[name]; ok {
-					delete(set, client)
-					if len(set) == 0 {
-						delete(pats, name)
-					}
+			for i := range vs.patterns {
+				if vs.patterns[i].pattern != name {
+					continue
 				}
-				if len(pats) == 0 {
-					delete(h.patterns, vehicleID)
+				if remaining, _ := removeClient(vs.patterns[i].clients, client); len(remaining) == 0 {
+					vs.patterns = append(vs.patterns[:i], vs.patterns[i+1:]...)
+				} else {
+					vs.patterns[i].clients = remaining
 				}
+				break
 			}
 			continue
 		}
-		if ex, ok := h.exact[vehicleID]; ok {
-			if set, ok := ex[name]; ok {
-				delete(set, client)
-				if len(set) == 0 {
-					delete(ex, name)
-				}
-			}
-			if len(ex) == 0 {
-				delete(h.exact, vehicleID)
+		if remaining, changed := removeClient(vs.exact[name], client); changed {
+			if len(remaining) == 0 {
+				delete(vs.exact, name)
+			} else {
+				vs.exact[name] = remaining
 			}
 		}
 	}
+
+	if len(vs.exact) == 0 && len(vs.patterns) == 0 {
+		delete(next, vehicleID)
+	} else {
+		next[vehicleID] = vs
+	}
+	h.vehicles.Store(&next)
 }
 
 // Publish dispatches signal to every client subscribed to its vehicle that
 // either named it exactly or registered a matching glob pattern. The same
 // client receiving via both routes is deduped — it gets the signal once.
+//
+// Reads the subscriber snapshot lock-free, so it is never blocked by
+// connection churn. The non-blocking send drops for any client whose buffer
+// is full, so a slow consumer cannot backpressure the hub.
 func (h *Hub) Publish(signal mapache.Signal) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	vs := (*h.vehicles.Load())[signal.VehicleID]
+	if vs == nil {
+		return
+	}
 
-	sent := make(map[*Client]struct{})
-	dispatch := func(clients map[*Client]struct{}) {
-		for c := range clients {
-			if _, dup := sent[c]; dup {
-				continue
-			}
-			sent[c] = struct{}{}
-			select {
-			case c.Send <- signal:
-			default:
-			}
+	h.pubMu.Lock()
+	defer h.pubMu.Unlock()
+
+	// pubSeq is always >= 1, so a freshly created Client (seq == 0) is never
+	// mistaken for already-sent.
+	h.pubSeq++
+	seq := h.pubSeq
+
+	send := func(c *Client) {
+		if c.seq == seq {
+			return
+		}
+		c.seq = seq
+		select {
+		case c.Send <- signal:
+		default:
 		}
 	}
 
-	if ex, ok := h.exact[signal.VehicleID]; ok {
-		if clients, ok := ex[signal.Name]; ok {
-			dispatch(clients)
-		}
+	for _, c := range vs.exact[signal.Name] {
+		send(c)
 	}
-	if pats, ok := h.patterns[signal.VehicleID]; ok {
-		for pattern, clients := range pats {
-			// path.Match parses each call, but with realistic pattern
-			// counts (low tens) the cost is negligible vs the win of
-			// not having to maintain a compiled-matcher cache.
-			ok, err := path.Match(pattern, signal.Name)
-			if err != nil || !ok {
-				continue
-			}
-			dispatch(clients)
+	for i := range vs.patterns {
+		ok, err := path.Match(vs.patterns[i].pattern, signal.Name)
+		if err != nil || !ok {
+			continue
+		}
+		for _, c := range vs.patterns[i].clients {
+			send(c)
 		}
 	}
 }
@@ -179,22 +292,17 @@ func Matches(name string, subs []string) bool {
 }
 
 // Stats returns a coarse snapshot of subscription counts for /ping-style
-// observability. Cheap enough to call inline.
+// observability. Reads the snapshot lock-free.
 func (h *Hub) Stats() (vehicles, exactSubs, patternSubs int) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
-	seen := make(map[string]struct{})
-	for v, m := range h.exact {
-		seen[v] = struct{}{}
-		for _, set := range m {
+	m := *h.vehicles.Load()
+	for _, vs := range m {
+		vehicles++
+		for _, set := range vs.exact {
 			exactSubs += len(set)
 		}
-	}
-	for v, m := range h.patterns {
-		seen[v] = struct{}{}
-		for _, set := range m {
-			patternSubs += len(set)
+		for i := range vs.patterns {
+			patternSubs += len(vs.patterns[i].clients)
 		}
 	}
-	return len(seen), exactSubs, patternSubs
+	return vehicles, exactSubs, patternSubs
 }

--- a/live/service/hub_bench_test.go
+++ b/live/service/hub_bench_test.go
@@ -1,0 +1,155 @@
+package service
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mapache "github.com/gaucho-racing/mapache/mapache-go/v3"
+)
+
+const benchVehicle = "veh-bench"
+
+func makeSignal(name string) mapache.Signal {
+	now := time.Now()
+	return mapache.Signal{
+		ID:        "01HABCDEFGHJKMNPQRSTVWXYZ",
+		Timestamp: int(now.UnixMicro()),
+		VehicleID: benchVehicle,
+		Name:      name,
+		Value:     123.456,
+		CreatedAt: now,
+	}
+}
+
+// drainClient returns a client whose Send is continuously drained by a
+// goroutine, so the non-blocking dispatch in Publish always succeeds (we're
+// measuring dispatch cost, not the drop path). Caller must close stop.
+func drainClient(id string, stop <-chan struct{}, wg *sync.WaitGroup) *Client {
+	c := &Client{ID: id, Send: make(chan mapache.Signal, 256)}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-c.Send:
+			}
+		}
+	}()
+	return c
+}
+
+// BenchmarkPublishExactFanout measures the per-signal dispatch cost when N
+// clients all subscribe to the same exact signal name — the hot-signal case
+// (everyone watching the same gauge).
+func BenchmarkPublishExactFanout(b *testing.B) {
+	for _, n := range []int{1, 10, 100, 1000, 5000} {
+		b.Run(fmt.Sprintf("clients=%d", n), func(b *testing.B) {
+			h := NewHub()
+			stop := make(chan struct{})
+			var wg sync.WaitGroup
+			for i := 0; i < n; i++ {
+				h.Subscribe(benchVehicle, []string{"motor_rpm"}, drainClient(fmt.Sprintf("c%d", i), stop, &wg))
+			}
+			sig := makeSignal("motor_rpm")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				h.Publish(sig)
+			}
+			b.StopTimer()
+			close(stop)
+			wg.Wait()
+		})
+	}
+}
+
+// BenchmarkPublishPatternFanout measures dispatch when each client registers a
+// distinct glob pattern, so every Publish runs path.Match against every
+// pattern. Worst case for the pattern loop.
+func BenchmarkPublishPatternFanout(b *testing.B) {
+	for _, n := range []int{10, 100, 1000} {
+		b.Run(fmt.Sprintf("patterns=%d", n), func(b *testing.B) {
+			h := NewHub()
+			stop := make(chan struct{})
+			var wg sync.WaitGroup
+			for i := 0; i < n; i++ {
+				pat := fmt.Sprintf("ecu_%d_*", i)
+				h.Subscribe(benchVehicle, []string{pat}, drainClient(fmt.Sprintf("c%d", i), stop, &wg))
+			}
+			// Matches exactly one pattern (ecu_0_*), but must test all n.
+			sig := makeSignal("ecu_0_temp")
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				h.Publish(sig)
+			}
+			b.StopTimer()
+			close(stop)
+			wg.Wait()
+		})
+	}
+}
+
+// BenchmarkPublishUnderChurn is the key test: it measures dispatch latency
+// while a separate goroutine continuously Subscribe/Unsubscribes, simulating
+// connection churn at scale. Because Subscribe/Unsubscribe take the exclusive
+// hub lock and Publish takes the read lock, this surfaces how much churn
+// stalls the (single) dispatch goroutine. Reports max and mean Publish latency.
+func BenchmarkPublishUnderChurn(b *testing.B) {
+	h := NewHub()
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Steady-state subscribers so dispatch has real work to do.
+	for i := 0; i < 500; i++ {
+		h.Subscribe(benchVehicle, []string{"motor_rpm"}, drainClient(fmt.Sprintf("steady%d", i), stop, &wg))
+	}
+
+	// Churn goroutines: connect+disconnect as fast as possible.
+	var churnOps atomic.Int64
+	churners := 8
+	for g := 0; g < churners; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			i := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				c := &Client{ID: fmt.Sprintf("churn%d-%d", g, i), Send: make(chan mapache.Signal, 1)}
+				h.Subscribe(benchVehicle, []string{"motor_rpm"}, c)
+				h.Unsubscribe(benchVehicle, []string{"motor_rpm"}, c)
+				churnOps.Add(1)
+				i++
+			}
+		}(g)
+	}
+
+	sig := makeSignal("motor_rpm")
+	var maxNs, sumNs int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		t0 := time.Now()
+		h.Publish(sig)
+		d := time.Since(t0).Nanoseconds()
+		sumNs += d
+		if d > maxNs {
+			maxNs = d
+		}
+	}
+	b.StopTimer()
+	close(stop)
+	wg.Wait()
+
+	if b.N > 0 {
+		b.ReportMetric(float64(sumNs)/float64(b.N), "mean-ns/publish")
+		b.ReportMetric(float64(maxNs), "max-ns/publish")
+		b.ReportMetric(float64(churnOps.Load()), "churn-ops")
+	}
+}

--- a/live/service/hub_test.go
+++ b/live/service/hub_test.go
@@ -1,0 +1,214 @@
+package service
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	mapache "github.com/gaucho-racing/mapache/mapache-go/v3"
+)
+
+func newClient(id string, buf int) *Client {
+	return &Client{ID: id, Send: make(chan mapache.Signal, buf)}
+}
+
+func sig(vehicle, name string) mapache.Signal {
+	return mapache.Signal{VehicleID: vehicle, Name: name, Timestamp: 1, CreatedAt: time.Now()}
+}
+
+// drain returns how many signals are currently queued on the client.
+func queued(c *Client) int { return len(c.Send) }
+
+func TestExactDelivery(t *testing.T) {
+	h := NewHub()
+	c := newClient("c1", 4)
+	h.Subscribe("v1", []string{"motor_rpm"}, c)
+
+	h.Publish(sig("v1", "motor_rpm"))
+	h.Publish(sig("v1", "other"))     // not subscribed
+	h.Publish(sig("v2", "motor_rpm")) // wrong vehicle
+
+	if got := queued(c); got != 1 {
+		t.Fatalf("expected 1 delivered, got %d", got)
+	}
+}
+
+func TestPatternDelivery(t *testing.T) {
+	h := NewHub()
+	c := newClient("c1", 8)
+	h.Subscribe("v1", []string{"ecu_*"}, c)
+
+	h.Publish(sig("v1", "ecu_temp"))
+	h.Publish(sig("v1", "ecu_volts"))
+	h.Publish(sig("v1", "motor_rpm")) // no match
+
+	if got := queued(c); got != 2 {
+		t.Fatalf("expected 2 delivered, got %d", got)
+	}
+}
+
+func TestDedupAcrossExactAndPattern(t *testing.T) {
+	h := NewHub()
+	c := newClient("c1", 8)
+	// Same client matches via exact name AND a glob — must receive once.
+	h.Subscribe("v1", []string{"motor_rpm", "motor_*"}, c)
+
+	h.Publish(sig("v1", "motor_rpm"))
+	if got := queued(c); got != 1 {
+		t.Fatalf("expected 1 (deduped), got %d", got)
+	}
+}
+
+func TestDedupAcrossMultiplePatterns(t *testing.T) {
+	h := NewHub()
+	c := newClient("c1", 8)
+	h.Subscribe("v1", []string{"ecu_*", "*_temp"}, c)
+
+	h.Publish(sig("v1", "ecu_temp")) // matches both patterns
+	if got := queued(c); got != 1 {
+		t.Fatalf("expected 1 (deduped), got %d", got)
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	h := NewHub()
+	c := newClient("c1", 4)
+	h.Subscribe("v1", []string{"motor_rpm", "ecu_*"}, c)
+	h.Unsubscribe("v1", []string{"motor_rpm", "ecu_*"}, c)
+
+	h.Publish(sig("v1", "motor_rpm"))
+	h.Publish(sig("v1", "ecu_temp"))
+	if got := queued(c); got != 0 {
+		t.Fatalf("expected 0 after unsubscribe, got %d", got)
+	}
+
+	v, e, p := h.Stats()
+	if v != 0 || e != 0 || p != 0 {
+		t.Fatalf("expected empty stats, got vehicles=%d exact=%d pattern=%d", v, e, p)
+	}
+}
+
+func TestMultipleClientsFanout(t *testing.T) {
+	h := NewHub()
+	clients := make([]*Client, 50)
+	for i := range clients {
+		clients[i] = newClient(fmt.Sprintf("c%d", i), 4)
+		h.Subscribe("v1", []string{"motor_rpm"}, clients[i])
+	}
+	h.Publish(sig("v1", "motor_rpm"))
+	for i, c := range clients {
+		if queued(c) != 1 {
+			t.Fatalf("client %d: expected 1, got %d", i, queued(c))
+		}
+	}
+}
+
+func TestSlowClientDropsNotBlocks(t *testing.T) {
+	h := NewHub()
+	slow := newClient("slow", 2) // tiny buffer, never drained
+	fast := newClient("fast", 100)
+	h.Subscribe("v1", []string{"x"}, slow)
+	h.Subscribe("v1", []string{"x"}, fast)
+
+	for i := 0; i < 10; i++ {
+		h.Publish(sig("v1", "x")) // must not block on slow's full buffer
+	}
+	if queued(slow) != 2 {
+		t.Fatalf("slow client should cap at buffer=2, got %d", queued(slow))
+	}
+	if queued(fast) != 10 {
+		t.Fatalf("fast client should get all 10, got %d", queued(fast))
+	}
+}
+
+func TestStats(t *testing.T) {
+	h := NewHub()
+	h.Subscribe("v1", []string{"a", "b", "ecu_*"}, newClient("c1", 1))
+	h.Subscribe("v1", []string{"a"}, newClient("c2", 1))
+	h.Subscribe("v2", []string{"x"}, newClient("c3", 1))
+
+	v, e, p := h.Stats()
+	if v != 2 {
+		t.Fatalf("vehicles: want 2, got %d", v)
+	}
+	if e != 4 { // v1: a(2)+b(1), v2: x(1)
+		t.Fatalf("exactSubs: want 4, got %d", e)
+	}
+	if p != 1 {
+		t.Fatalf("patternSubs: want 1, got %d", p)
+	}
+}
+
+// TestConcurrentChurnRace hammers Subscribe/Unsubscribe from many goroutines
+// while a publisher dispatches continuously. Run with -race: it must show no
+// data race between lock-free dispatch and copy-on-write writers, and the
+// service must not deadlock.
+func TestConcurrentChurnRace(t *testing.T) {
+	h := NewHub()
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Steady drained subscribers.
+	steady := make([]*Client, 20)
+	for i := range steady {
+		steady[i] = newClient(fmt.Sprintf("s%d", i), 64)
+		h.Subscribe("v1", []string{"motor_rpm", "ecu_*"}, steady[i])
+		wg.Add(1)
+		go func(c *Client) {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-c.Send:
+				}
+			}
+		}(steady[i])
+	}
+
+	// Publisher.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				h.Publish(sig("v1", "motor_rpm"))
+				h.Publish(sig("v1", "ecu_temp"))
+			}
+		}
+	}()
+
+	// Churners.
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			i := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				c := newClient(fmt.Sprintf("churn%d-%d", g, i), 8)
+				h.Subscribe("v1", []string{"motor_rpm", "ecu_*"}, c)
+				h.Unsubscribe("v1", []string{"motor_rpm", "ecu_*"}, c)
+				i++
+			}
+		}(g)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	// Steady subscribers must still be registered after all the churn.
+	_, e, p := h.Stats()
+	if e < len(steady) || p < len(steady) {
+		t.Fatalf("steady subscribers lost during churn: exact=%d pattern=%d", e, p)
+	}
+}


### PR DESCRIPTION
Scales the live service to thousands of concurrent dashboard connections at low latency. Bottlenecks were located with benchmarks (`service/hub_bench_test.go`) before changing anything; all tests pass under `-race`.

**Hub dispatch**
- Rewrite hub as a copy-on-write atomic snapshot so `Publish` reads subscribers lock-free — connection churn no longer stalls signal dispatch (was causing ~2.5ms tail spikes)
- Replace the per-signal dedup map with an epoch-based per-client marker, removing hot-path allocation: 296KB/signal → 0 at 5k clients, 3–12x faster dispatch

**Connection hardening**
- Add write deadlines to all WS/SSE writes so a slow consumer can't pin a writer goroutine forever
- Add WS ping/pong heartbeat + read deadline and SSE keepalive to reap half-open connections
- Add per-replica connection cap with 503 load shedding (`MAX_CONNECTIONS`, default 5000)
- Expose active/max connections in `/live/stats`

**Tests**
- Hub correctness + concurrent-churn race tests, dispatch/churn/pattern benchmarks, end-to-end WS/SSE delivery + cap→503 tests

**Notes**
- CoW moves cost off the hot dispatch path onto per-connection goroutines; a mass-reconnect storm allocates more and can cause transient GC jitter (rare, bounded to one rebuild per connection lifetime)
- Single-goroutine dispatch is still the per-replica ceiling (now 3–12x higher); scale total connections by adding replicas
- CORS misconfig (`AllowAllOrigins`+`AllowCredentials`) is intentionally left out of this branch — unrelated to concurrency