### PR TITLE
ECU Sends Mapless Brake Pedal PSI Values

### DIFF
--- a/gr26/model/ecu.go
+++ b/gr26/model/ecu.go
@@ -134,7 +134,7 @@ var ECUAnalogData = mp.Message{
 	}),
 	mp.NewField("brake_pedal", 2, mp.Unsigned, mp.LittleEndian, func(f mp.Field) []mp.Signal {
 		return []mp.Signal{
-			{Name: "brake_pedal", Value: float64(f.Value) / 655.35, RawValue: f.Value},
+			{Name: "brake_pedal", Value: float64(f.Value), RawValue: f.Value},
 		}
 	}),
 }


### PR DESCRIPTION
See https://github.com/Gaucho-Racing/Firmware/commit/af5fb4f2aca162f5fda5e8df5520a9b4c8b8de77

Communication got dropped at some point, we do not have a map on the brake pedal PSI values, this PR means that we no longer divide by 655.35.

ECU calculates the value as `bse_ewma_adc_count / 4096.0f * 5000.0f` and transmits that literally which represents the BSE / Brake F pressure in PSI.