### PR TITLE
feat(signals): Signals page overhaul — ECharts, multi-panel, derived traces & more

### DIFF
--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -11,7 +11,7 @@ Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip bu
 Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
 
 ## Resume here
-➡️ **T5 — Derived/expression traces** (next `todo`)
+➡️ **T8 — Per-trace normalization w/ shared-scale groups** (next `todo`)
 
 After `/clear`: read this file, then run
 `git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
@@ -26,7 +26,7 @@ After `/clear`: read this file, then run
 | T3 | Stacked multi-widget layout, shared time axis | done | dc32f0d | new SignalWidget.tsx (owns query/chart-type/fetch); page holds widgetIds+hiddenIds, add/delete/hide; synced cursor via echarts.connect group "signals-page" (additive groupId prop on QueryChart); brush bubbles to shared timeframe |
 | T4 | Cleaner chip query builder | done | 94458f6 | sentence-style clauses (Show…of…where…grouped by…every…), same MQL AST, sub-second rollups reachable |
 | T9 | Zoom out / reset window (in-chart, no requery) | done | ea79fdc | inside dataZoom on mouse-wheel (brush keeps left-drag→requery); page-level Zoom out / Reset dispatch to connect group via onReady instances; no network on zoom. Fixed initial-mount crash: getOption() is undefined before first setOption |
-| T5 | Derived/expression traces (frontend compute) | todo | — | |
+| T5 | Derived/expression traces (frontend compute) | done | ba116c9 | safe lib/expr.ts evaluator (no eval); s0/s1 + friendly-label var aliases; DerivedTraces.tsx UI; derived series render as non-stacked lines, exempt from stack + top-K. tsc/eslint clean. Needs browser smoke test |
 | T8 | Per-trace normalization w/ shared-scale groups | todo | — | multi-y-axis; builds on T3/T5 trace model |
 | T6 | Highlight regions / boxes (frontend compute) | todo | — | |
 | T7 | Export (CSV data + PNG chart) | todo | — | |

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -11,7 +11,7 @@ Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip bu
 Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
 
 ## Resume here
-➡️ **T3 — Stacked multi-widget layout, shared time axis** (next `todo`)
+➡️ **T9 — Zoom out / reset window** (next `todo`)
 
 After `/clear`: read this file, then run
 `git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
@@ -23,9 +23,11 @@ After `/clear`: read this file, then run
 | T0 | Branch + tracking scaffold | done | 5453ffe | branch `feat/signals-overhaul` created |
 | T1 | Sub-second binning (backend + frontend mirror) | done | 0cc4601 | added 16/50/100/500ms; ms-based steps; native CH MILLISECOND interval. Needs live-CH smoke test |
 | T2 | Swap Recharts → ECharts in chart component | done | 1660347 | echarts core (canvas), brush via zrender, top-K/stack/tooltip preserved, 20k gate removed; empty-state made overlay so init is robust for T3 |
-| T3 | Stacked multi-widget layout, shared time axis | todo | — | |
-| T4 | Cleaner chip query builder | done | _pending_ | sentence-style clauses (Show…of…where…grouped by…every…), same MQL AST, sub-second rollups reachable |
+| T3 | Stacked multi-widget layout, shared time axis | done | _pending_ | new SignalWidget.tsx (owns query/chart-type/fetch); page holds widgetIds+hiddenIds, add/delete/hide; synced cursor via echarts.connect group "signals-page" (additive groupId prop on QueryChart); brush bubbles to shared timeframe |
+| T4 | Cleaner chip query builder | done | 94458f6 | sentence-style clauses (Show…of…where…grouped by…every…), same MQL AST, sub-second rollups reachable |
+| T9 | Zoom out / reset window (in-chart, no requery) | todo | — | builds on T3 shared axis (dataZoom) |
 | T5 | Derived/expression traces (frontend compute) | todo | — | |
+| T8 | Per-trace normalization w/ shared-scale groups | todo | — | multi-y-axis; builds on T3/T5 trace model |
 | T6 | Highlight regions / boxes (frontend compute) | todo | — | |
 | T7 | Export (CSV data + PNG chart) | todo | — | |
 
@@ -72,3 +74,23 @@ in-browser (reuses T5 evaluator to threshold). Boxes span the stacked panels.
 CSV of underlying series points + PNG via ECharts `getDataURL`. Export control on
 widget/page.
 **Check:** CSV columns correct; PNG matches on-screen chart.
+
+### T8 — Per-trace normalization with shared-scale groups (frontend)
+Let a trace be **normalized-to-fit** (opt-in per trace) so e.g. a boolean `drive_enable`
+(0/1) is rescaled so its `1` reaches the top of the plot, while same-unit traces keep a
+shared real scale relative to each other. Concretely: assign traces to a y-scale group;
+a "normalize" trace is min/max-rescaled to span a reference group's range, while members
+of a native-unit group (e.g. three °C temps) share one axis and are NOT rescaled against
+each other. Implement with ECharts multiple `yAxis` + per-trace data scaling; tooltip
+should still show the true (un-normalized) value. Builds on the T3/T5 trace model.
+**Check:** drive_enable's 1 reaches the top of a plot shared with motor/accumulator/
+controller temps; the three temps stay on one shared °C axis, un-rescaled vs each other;
+tooltip shows real values.
+
+### T9 — Zoom out / reset window (frontend)
+In-chart zoom (ECharts `dataZoom`, inside + optional slider) with an easy way to **step
+back out** and **reset** to the originally-queried window — without a full requery. Synced
+across the stacked shared-axis panels (T3). Full reset is best-effort (user can always
+re-query a wider range); the priority is jumping back out after zooming too far in.
+**Check:** zoom into a window on one panel, all panels follow; "zoom out"/"reset"
+returns to the queried range; no network requery fired.

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -1,0 +1,74 @@
+# Signals Page Overhaul — Progress Tracker
+
+Branch: `feat/signals-overhaul` (off `main`). One commit per task. **Add, never remove** —
+all current behavior (chip grouping, bar/line/area toggle, brush-select timeframe, top-K
+rollup, signal discovery table) must keep working.
+
+Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip builder only**
+(keep MQL AST); derived traces + highlight boxes → **frontend-computed**; layout →
+**stacked panels, shared/synced time axis**.
+
+Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
+
+## Resume here
+➡️ **T1 — Sub-second binning** (next `todo`)
+
+After `/clear`: read this file, then run
+`git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
+
+## Tasks
+
+| ID | Task | Status | Commit | Note |
+|----|------|--------|--------|------|
+| T0 | Branch + tracking scaffold | done | _(this commit)_ | branch `feat/signals-overhaul` created |
+| T1 | Sub-second binning (backend + frontend mirror) | todo | — | |
+| T2 | Swap Recharts → ECharts in chart component | todo | — | |
+| T3 | Stacked multi-widget layout, shared time axis | todo | — | |
+| T4 | Cleaner chip query builder | todo | — | |
+| T5 | Derived/expression traces (frontend compute) | todo | — | |
+| T6 | Highlight regions / boxes (frontend compute) | todo | — | |
+| T7 | Export (CSV data + PNG chart) | todo | — | |
+
+## Task detail
+
+### T1 — Sub-second binning
+Add sub-second rollups (`500ms`, `100ms`, `50ms`, `16ms`). Backend: `ROLLUP_INTERVALS`
+in `query/query/service/query_lang.py`, `INTERVALS` map in
+`query/query/service/signals.py` (confirm ClickHouse handles `INTERVAL n MILLISECOND` /
+ms-epoch `intDiv`). Frontend mirror: `ROLLUP_INTERVALS` in `dashboard/src/lib/query.ts`
++ auto-interval picker in `SignalsPage.tsx`.
+**Check:** `50ms` rollup on a 60 Hz signal returns ~20 buckets/sec.
+
+### T2 — Recharts → ECharts
+Rewrite `dashboard/src/components/signals/QueryChart.tsx` on ECharts (canvas). Preserve
+bar/line/area, `onBrushSelect`, top-K "+N other", tooltip, palette, null handling. Drop
+the 20k confirm gate. Add `echarts` to `dashboard/package.json`.
+**Check:** existing queries render identically; >20k points render without the gate.
+
+### T3 — Stacked multi-widget layout, shared x-axis
+`SignalsPage.tsx`: one chart → ordered list of chart widgets, each with its own query.
+Add / delete / hide. Vertical stack; synced x-axis + time cursor (ECharts `connect` /
+linked `axisPointer`).
+**Check:** two panels scrub together with one cursor; add/remove/hide work.
+
+### T4 — Cleaner chip query builder
+Redesign `dashboard/src/components/signals/QueryBuilder.tsx` to read naturally; keep chip
+flow, fuzzy search, wildcard expansion, grouping schema. Same MQL AST (`lib/query.ts`),
+no grammar change.
+**Check:** every query expressible today still is; reads cleaner.
+
+### T5 — Derived / expression traces (frontend)
+Trace defined as a function of other fetched series (`current_ac^2`, ratios, sums).
+Expression input per trace; evaluate in-browser over the aligned (zero-filled) bucket
+axis. Safe evaluator; no backend change.
+**Check:** `current_ac^2` plots correctly vs the raw `current_ac` trace.
+
+### T6 — Highlight regions / boxes (frontend)
+Shade regions where a condition holds (throttle = 100%) via ECharts `markArea`. Detection
+in-browser (reuses T5 evaluator to threshold). Boxes span the stacked panels.
+**Check:** "throttle = 100%" paints red bands across all panels at the right times.
+
+### T7 — Export
+CSV of underlying series points + PNG via ECharts `getDataURL`. Export control on
+widget/page.
+**Check:** CSV columns correct; PNG matches on-screen chart.

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -11,7 +11,7 @@ Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip bu
 Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
 
 ## Resume here
-➡️ **T6 — Highlight regions / boxes** (next `todo`)
+➡️ **T7 — Export (CSV data + PNG chart)** (next `todo`)
 
 After `/clear`: read this file, then run
 `git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
@@ -28,7 +28,7 @@ After `/clear`: read this file, then run
 | T9 | Zoom out / reset window (in-chart, no requery) | done | ea79fdc | inside dataZoom on mouse-wheel (brush keeps left-drag→requery); page-level Zoom out / Reset dispatch to connect group via onReady instances; no network on zoom. Fixed initial-mount crash: getOption() is undefined before first setOption |
 | T5 | Derived/expression traces (frontend compute) | done | ba116c9 | safe lib/expr.ts evaluator (no eval); s0/s1 + friendly-label var aliases; DerivedTraces.tsx UI; derived series render as non-stacked lines, exempt from stack + top-K. tsc/eslint clean. Needs browser smoke test |
 | T8 | Per-trace normalization w/ shared-scale groups | done | 787264d | axisSettings keyed by label → axisConfig; one real yAxis per native group + hidden [0,1] axis for normalized; {value,raw} items so tooltip shows true value; stack only when all base share one group; new TraceAxisControls.tsx. tsc/eslint clean. Needs browser smoke test |
-| T6 | Highlight regions / boxes (frontend compute) | todo | — | |
+| T6 | Highlight regions / boxes (frontend compute) | done | e83a1ea | per-widget/local; expr.ts gained == != > >= < <= (bare = ok) + and/or; shared compileAgainstSeries backs traces+highlights; new Highlights.tsx; __highlight__ markArea separate from __brush__. tsc/eslint clean. Needs browser smoke test |
 | T7 | Export (CSV data + PNG chart) | todo | — | |
 
 ## Task detail

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -25,7 +25,7 @@ After `/clear`: read this file, then run
 | T2 | Swap Recharts → ECharts in chart component | done | 1660347 | echarts core (canvas), brush via zrender, top-K/stack/tooltip preserved, 20k gate removed; empty-state made overlay so init is robust for T3 |
 | T3 | Stacked multi-widget layout, shared time axis | done | dc32f0d | new SignalWidget.tsx (owns query/chart-type/fetch); page holds widgetIds+hiddenIds, add/delete/hide; synced cursor via echarts.connect group "signals-page" (additive groupId prop on QueryChart); brush bubbles to shared timeframe |
 | T4 | Cleaner chip query builder | done | 94458f6 | sentence-style clauses (Show…of…where…grouped by…every…), same MQL AST, sub-second rollups reachable |
-| T9 | Zoom out / reset window (in-chart, no requery) | done | _pending_ | inside dataZoom on mouse-wheel (brush keeps left-drag→requery); page-level Zoom out / Reset dispatch to connect group via onReady instances; no network on zoom. Fixed initial-mount crash: getOption() is undefined before first setOption |
+| T9 | Zoom out / reset window (in-chart, no requery) | done | ea79fdc | inside dataZoom on mouse-wheel (brush keeps left-drag→requery); page-level Zoom out / Reset dispatch to connect group via onReady instances; no network on zoom. Fixed initial-mount crash: getOption() is undefined before first setOption |
 | T5 | Derived/expression traces (frontend compute) | todo | — | |
 | T8 | Per-trace normalization w/ shared-scale groups | todo | — | multi-y-axis; builds on T3/T5 trace model |
 | T6 | Highlight regions / boxes (frontend compute) | todo | — | |

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -30,6 +30,7 @@ After `/clear`: read this file, then run
 | T8 | Per-trace normalization w/ shared-scale groups | done | 787264d | axisSettings keyed by label → axisConfig; one real yAxis per native group + hidden [0,1] axis for normalized; {value,raw} items so tooltip shows true value; stack only when all base share one group; new TraceAxisControls.tsx. tsc/eslint clean. Needs browser smoke test |
 | T6 | Highlight regions / boxes (frontend compute) | done | e83a1ea | per-widget/local; expr.ts gained == != > >= < <= (bare = ok) + and/or; shared compileAgainstSeries backs traces+highlights; new Highlights.tsx; __highlight__ markArea separate from __brush__. tsc/eslint clean. Needs browser smoke test |
 | T7 | Export (CSV data + PNG chart) | todo | — | |
+| T10 | Collapse normalize/derived/highlights into an "Advanced options" disclosure | todo | — | declutter the widget; editors hidden by default behind a toggle |
 
 ## Task detail
 
@@ -94,3 +95,19 @@ across the stacked shared-axis panels (T3). Full reset is best-effort (user can 
 re-query a wider range); the priority is jumping back out after zooming too far in.
 **Check:** zoom into a window on one panel, all panels follow; "zoom out"/"reset"
 returns to the queried range; no network requery fired.
+
+### T10 — "Advanced options" disclosure (frontend)
+The widget header has grown crowded: the query builder now stacks the derived-traces
+(T5), per-trace normalization / axis-group (T8), and highlights (T6) editors beneath it,
+so a simple "count(signal)" query shows a wall of controls it doesn't need. Tuck those
+three editors behind one collapsible **Advanced options** toggle in `SignalWidget.tsx`,
+**collapsed by default**, so the default widget is just the query builder + chart. The
+query builder, chart-type toggle, hide/delete, and timeframe stay always-visible.
+Show a subtle "on" affordance when any advanced editor is non-empty (a configured
+derived trace / normalization / highlight) so collapsing doesn't hide active state
+silently — e.g. a small count badge on the toggle. Pure presentation: no change to the
+trace/highlight/axis models or evaluation; the editors and their state move under the
+disclosure unchanged. Per-widget local state (each widget remembers its own open/closed).
+**Check:** a fresh widget shows only builder + chart; expanding reveals derived traces,
+normalization, and highlights; configuring any of them and collapsing still applies them
+and flags that advanced options are active.

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -11,7 +11,7 @@ Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip bu
 Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
 
 ## Resume here
-➡️ **T1 — Sub-second binning** (next `todo`)
+➡️ **T2 — Swap Recharts → ECharts** (next `todo`)
 
 After `/clear`: read this file, then run
 `git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
@@ -20,8 +20,8 @@ After `/clear`: read this file, then run
 
 | ID | Task | Status | Commit | Note |
 |----|------|--------|--------|------|
-| T0 | Branch + tracking scaffold | done | _(this commit)_ | branch `feat/signals-overhaul` created |
-| T1 | Sub-second binning (backend + frontend mirror) | todo | — | |
+| T0 | Branch + tracking scaffold | done | 5453ffe | branch `feat/signals-overhaul` created |
+| T1 | Sub-second binning (backend + frontend mirror) | done | _pending_ | added 16/50/100/500ms; ms-based steps; native CH MILLISECOND interval. Needs live-CH smoke test |
 | T2 | Swap Recharts → ECharts in chart component | todo | — | |
 | T3 | Stacked multi-widget layout, shared time axis | todo | — | |
 | T4 | Cleaner chip query builder | todo | — | |

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -11,7 +11,7 @@ Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip bu
 Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
 
 ## Resume here
-➡️ **T8 — Per-trace normalization w/ shared-scale groups** (next `todo`)
+➡️ **T6 — Highlight regions / boxes** (next `todo`)
 
 After `/clear`: read this file, then run
 `git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
@@ -27,7 +27,7 @@ After `/clear`: read this file, then run
 | T4 | Cleaner chip query builder | done | 94458f6 | sentence-style clauses (Show…of…where…grouped by…every…), same MQL AST, sub-second rollups reachable |
 | T9 | Zoom out / reset window (in-chart, no requery) | done | ea79fdc | inside dataZoom on mouse-wheel (brush keeps left-drag→requery); page-level Zoom out / Reset dispatch to connect group via onReady instances; no network on zoom. Fixed initial-mount crash: getOption() is undefined before first setOption |
 | T5 | Derived/expression traces (frontend compute) | done | ba116c9 | safe lib/expr.ts evaluator (no eval); s0/s1 + friendly-label var aliases; DerivedTraces.tsx UI; derived series render as non-stacked lines, exempt from stack + top-K. tsc/eslint clean. Needs browser smoke test |
-| T8 | Per-trace normalization w/ shared-scale groups | todo | — | multi-y-axis; builds on T3/T5 trace model |
+| T8 | Per-trace normalization w/ shared-scale groups | done | 787264d | axisSettings keyed by label → axisConfig; one real yAxis per native group + hidden [0,1] axis for normalized; {value,raw} items so tooltip shows true value; stack only when all base share one group; new TraceAxisControls.tsx. tsc/eslint clean. Needs browser smoke test |
 | T6 | Highlight regions / boxes (frontend compute) | todo | — | |
 | T7 | Export (CSV data + PNG chart) | todo | — | |
 

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -31,6 +31,7 @@ After `/clear`: read this file, then run
 | T6 | Highlight regions / boxes (frontend compute) | done | e83a1ea | per-widget/local; expr.ts gained == != > >= < <= (bare = ok) + and/or; shared compileAgainstSeries backs traces+highlights; new Highlights.tsx; __highlight__ markArea separate from __brush__. tsc/eslint clean. Needs browser smoke test |
 | T7 | Export (CSV data + PNG chart) | done | 3f97aa1 | per-widget CSV (plotted series, true values) + PNG via getDataURL@2x; new lib/export.ts; wrapped onReady keeps page group-zoom. tsc/eslint clean. Needs browser smoke test |
 | T10 | Collapse normalize/derived/highlights into an "Advanced options" disclosure | todo | — | declutter the widget; editors hidden by default behind a toggle |
+| T11 | Per-trace visibility toggle (hide a fetched signal from the chart while keeping it for derived traces / highlights) | done | 92efee3 | eye toggle in TraceAxisControls row next to normalize/group; optional `hidden` on AxisSetting; chart/axisConfig/colors/export use a `visibleSeries` filter; derived+highlights unaffected (read base `series`). tsc/eslint clean. Needs browser smoke test |
 
 ## Task detail
 

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -11,7 +11,8 @@ Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip bu
 Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
 
 ## Resume here
-➡️ **T10 — "Advanced options" disclosure** (next `todo`)
+✅ **All tasks complete.** Frontend tasks (T1–T11) still want a live-CH browser
+smoke test (see per-row notes). No `todo` remaining.
 
 After `/clear`: read this file, then run
 `git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
@@ -30,7 +31,7 @@ After `/clear`: read this file, then run
 | T8 | Per-trace normalization w/ shared-scale groups | done | 787264d | axisSettings keyed by label → axisConfig; one real yAxis per native group + hidden [0,1] axis for normalized; {value,raw} items so tooltip shows true value; stack only when all base share one group; new TraceAxisControls.tsx. tsc/eslint clean. Needs browser smoke test |
 | T6 | Highlight regions / boxes (frontend compute) | done | e83a1ea | per-widget/local; expr.ts gained == != > >= < <= (bare = ok) + and/or; shared compileAgainstSeries backs traces+highlights; new Highlights.tsx; __highlight__ markArea separate from __brush__. tsc/eslint clean. Needs browser smoke test |
 | T7 | Export (CSV data + PNG chart) | done | 3f97aa1 | per-widget CSV (plotted series, true values) + PNG via getDataURL@2x; new lib/export.ts; wrapped onReady keeps page group-zoom. tsc/eslint clean. Needs browser smoke test |
-| T10 | Collapse normalize/derived/highlights into an "Advanced options" disclosure | todo | — | declutter the widget; editors hidden by default behind a toggle |
+| T10 | Collapse normalize/derived/highlights into an "Advanced options" disclosure | done | cfbde70 | one collapsed-by-default disclosure wraps DerivedTraces/TraceAxisControls/Highlights; builder+chart-type+export+hide/delete stay visible; per-widget open state; count badge of configured editors; eval unchanged + still applies while collapsed. tsc/eslint clean. Needs browser smoke test |
 | T11 | Per-trace visibility toggle (hide a fetched signal from the chart while keeping it for derived traces / highlights) | done | 92efee3 | eye toggle in TraceAxisControls row next to normalize/group; optional `hidden` on AxisSetting; chart/axisConfig/colors/export use a `visibleSeries` filter; derived+highlights unaffected (read base `series`). tsc/eslint clean. Needs browser smoke test |
 
 ## Task detail

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -11,7 +11,7 @@ Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip bu
 Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
 
 ## Resume here
-➡️ **T9 — Zoom out / reset window** (next `todo`)
+➡️ **T5 — Derived/expression traces** (next `todo`)
 
 After `/clear`: read this file, then run
 `git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
@@ -23,9 +23,9 @@ After `/clear`: read this file, then run
 | T0 | Branch + tracking scaffold | done | 5453ffe | branch `feat/signals-overhaul` created |
 | T1 | Sub-second binning (backend + frontend mirror) | done | 0cc4601 | added 16/50/100/500ms; ms-based steps; native CH MILLISECOND interval. Needs live-CH smoke test |
 | T2 | Swap Recharts → ECharts in chart component | done | 1660347 | echarts core (canvas), brush via zrender, top-K/stack/tooltip preserved, 20k gate removed; empty-state made overlay so init is robust for T3 |
-| T3 | Stacked multi-widget layout, shared time axis | done | _pending_ | new SignalWidget.tsx (owns query/chart-type/fetch); page holds widgetIds+hiddenIds, add/delete/hide; synced cursor via echarts.connect group "signals-page" (additive groupId prop on QueryChart); brush bubbles to shared timeframe |
+| T3 | Stacked multi-widget layout, shared time axis | done | dc32f0d | new SignalWidget.tsx (owns query/chart-type/fetch); page holds widgetIds+hiddenIds, add/delete/hide; synced cursor via echarts.connect group "signals-page" (additive groupId prop on QueryChart); brush bubbles to shared timeframe |
 | T4 | Cleaner chip query builder | done | 94458f6 | sentence-style clauses (Show…of…where…grouped by…every…), same MQL AST, sub-second rollups reachable |
-| T9 | Zoom out / reset window (in-chart, no requery) | todo | — | builds on T3 shared axis (dataZoom) |
+| T9 | Zoom out / reset window (in-chart, no requery) | done | _pending_ | inside dataZoom on mouse-wheel (brush keeps left-drag→requery); page-level Zoom out / Reset dispatch to connect group via onReady instances; no network on zoom. Fixed initial-mount crash: getOption() is undefined before first setOption |
 | T5 | Derived/expression traces (frontend compute) | todo | — | |
 | T8 | Per-trace normalization w/ shared-scale groups | todo | — | multi-y-axis; builds on T3/T5 trace model |
 | T6 | Highlight regions / boxes (frontend compute) | todo | — | |

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -11,7 +11,7 @@ Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip bu
 Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
 
 ## Resume here
-➡️ **T7 — Export (CSV data + PNG chart)** (next `todo`)
+➡️ **T10 — "Advanced options" disclosure** (next `todo`)
 
 After `/clear`: read this file, then run
 `git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
@@ -29,7 +29,7 @@ After `/clear`: read this file, then run
 | T5 | Derived/expression traces (frontend compute) | done | ba116c9 | safe lib/expr.ts evaluator (no eval); s0/s1 + friendly-label var aliases; DerivedTraces.tsx UI; derived series render as non-stacked lines, exempt from stack + top-K. tsc/eslint clean. Needs browser smoke test |
 | T8 | Per-trace normalization w/ shared-scale groups | done | 787264d | axisSettings keyed by label → axisConfig; one real yAxis per native group + hidden [0,1] axis for normalized; {value,raw} items so tooltip shows true value; stack only when all base share one group; new TraceAxisControls.tsx. tsc/eslint clean. Needs browser smoke test |
 | T6 | Highlight regions / boxes (frontend compute) | done | e83a1ea | per-widget/local; expr.ts gained == != > >= < <= (bare = ok) + and/or; shared compileAgainstSeries backs traces+highlights; new Highlights.tsx; __highlight__ markArea separate from __brush__. tsc/eslint clean. Needs browser smoke test |
-| T7 | Export (CSV data + PNG chart) | todo | — | |
+| T7 | Export (CSV data + PNG chart) | done | 3f97aa1 | per-widget CSV (plotted series, true values) + PNG via getDataURL@2x; new lib/export.ts; wrapped onReady keeps page group-zoom. tsc/eslint clean. Needs browser smoke test |
 | T10 | Collapse normalize/derived/highlights into an "Advanced options" disclosure | todo | — | declutter the widget; editors hidden by default behind a toggle |
 
 ## Task detail

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -11,7 +11,7 @@ Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip bu
 Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
 
 ## Resume here
-➡️ **T2 — Swap Recharts → ECharts** and **T4 — Cleaner chip builder** (both in-progress, parallel)
+➡️ **T3 — Stacked multi-widget layout, shared time axis** (next `todo`)
 
 After `/clear`: read this file, then run
 `git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
@@ -22,9 +22,9 @@ After `/clear`: read this file, then run
 |----|------|--------|--------|------|
 | T0 | Branch + tracking scaffold | done | 5453ffe | branch `feat/signals-overhaul` created |
 | T1 | Sub-second binning (backend + frontend mirror) | done | 0cc4601 | added 16/50/100/500ms; ms-based steps; native CH MILLISECOND interval. Needs live-CH smoke test |
-| T2 | Swap Recharts → ECharts in chart component | done | _pending_ | echarts core (canvas), brush via zrender, top-K/stack/tooltip preserved, 20k gate removed; empty-state made overlay so init is robust for T3 |
+| T2 | Swap Recharts → ECharts in chart component | done | 1660347 | echarts core (canvas), brush via zrender, top-K/stack/tooltip preserved, 20k gate removed; empty-state made overlay so init is robust for T3 |
 | T3 | Stacked multi-widget layout, shared time axis | todo | — | |
-| T4 | Cleaner chip query builder | in-progress | — | |
+| T4 | Cleaner chip query builder | done | _pending_ | sentence-style clauses (Show…of…where…grouped by…every…), same MQL AST, sub-second rollups reachable |
 | T5 | Derived/expression traces (frontend compute) | todo | — | |
 | T6 | Highlight regions / boxes (frontend compute) | todo | — | |
 | T7 | Export (CSV data + PNG chart) | todo | — | |

--- a/SIGNALS-OVERHAUL.md
+++ b/SIGNALS-OVERHAUL.md
@@ -11,7 +11,7 @@ Locked decisions: chart lib → **ECharts**; query surface → **cleaner chip bu
 Full plan: `~/.claude/plans/i-have-a-bunch-gentle-engelbart.md`.
 
 ## Resume here
-➡️ **T2 — Swap Recharts → ECharts** (next `todo`)
+➡️ **T2 — Swap Recharts → ECharts** and **T4 — Cleaner chip builder** (both in-progress, parallel)
 
 After `/clear`: read this file, then run
 `git log --oneline main..feat/signals-overhaul`. The first `todo` row below is next.
@@ -21,10 +21,10 @@ After `/clear`: read this file, then run
 | ID | Task | Status | Commit | Note |
 |----|------|--------|--------|------|
 | T0 | Branch + tracking scaffold | done | 5453ffe | branch `feat/signals-overhaul` created |
-| T1 | Sub-second binning (backend + frontend mirror) | done | _pending_ | added 16/50/100/500ms; ms-based steps; native CH MILLISECOND interval. Needs live-CH smoke test |
-| T2 | Swap Recharts → ECharts in chart component | todo | — | |
+| T1 | Sub-second binning (backend + frontend mirror) | done | 0cc4601 | added 16/50/100/500ms; ms-based steps; native CH MILLISECOND interval. Needs live-CH smoke test |
+| T2 | Swap Recharts → ECharts in chart component | done | _pending_ | echarts core (canvas), brush via zrender, top-K/stack/tooltip preserved, 20k gate removed; empty-state made overlay so init is robust for T3 |
 | T3 | Stacked multi-widget layout, shared time axis | todo | — | |
-| T4 | Cleaner chip query builder | todo | — | |
+| T4 | Cleaner chip query builder | in-progress | — | |
 | T5 | Derived/expression traces (frontend compute) | todo | — | |
 | T6 | Highlight regions / boxes (frontend compute) | todo | — | |
 | T7 | Export (CSV data + PNG chart) | todo | — | |

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mp_dashboard",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mp_dashboard",
-      "version": "3.6.1",
+      "version": "3.7.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.6.0",
         "@fortawesome/free-brands-svg-icons": "6.6.0",
@@ -43,6 +43,7 @@
         "crypto-js": "^4.2.0",
         "date-fns": "^3.6.0",
         "dotenv": "^16.6.1",
+        "echarts": "^5.6.0",
         "fuse.js": "^7.4.2",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.453.0",
@@ -102,17 +103,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -782,497 +772,6 @@
       "deprecated": "Use @eslint/object-schema instead",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1349,142 +848,6 @@
       "integrity": "sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.7.tgz",
-      "integrity": "sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.7.tgz",
-      "integrity": "sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.7.tgz",
-      "integrity": "sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.7.tgz",
-      "integrity": "sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.7.tgz",
-      "integrity": "sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.7.tgz",
-      "integrity": "sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.7.tgz",
-      "integrity": "sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.7.tgz",
-      "integrity": "sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3201,18 +2564,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@swc/types": {
       "version": "0.1.26",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
@@ -4766,17 +4117,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -4861,6 +4201,22 @@
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
+    },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.369",
@@ -7165,52 +6521,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8014,6 +7324,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/zustand": {
       "version": "4.5.7",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -47,6 +47,7 @@
     "crypto-js": "^4.2.0",
     "date-fns": "^3.6.0",
     "dotenv": "^16.6.1",
+    "echarts": "^5.6.0",
     "fuse.js": "^7.4.2",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.453.0",

--- a/dashboard/src/components/signals/DerivedTraces.tsx
+++ b/dashboard/src/components/signals/DerivedTraces.tsx
@@ -1,0 +1,262 @@
+import { Input } from "@/components/ui/input";
+import { DERIVED_KEY, seriesLabel, type Series } from "./QueryChart";
+import { compileExpression, type DerivedTrace } from "@/lib/expr";
+import { cn } from "@/lib/utils";
+import { Plus, X } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Variable model
+//
+// Each fetched base series becomes a variable the expression can reference.
+// Two aliases are exposed per series:
+//   - a positional alias `s0, s1, …` (always available, stable by index), and
+//   - a friendly alias derived from the series label (`current_ac`) *when*
+//     that label sanitizes to a valid, unique identifier.
+// The friendly alias is what makes an expression read naturally
+// (`current_ac^2`); the positional alias is the always-there fallback.
+// ---------------------------------------------------------------------------
+
+export interface SeriesVariable {
+  /** Positional alias — always present. */
+  index: string;
+  /** Friendly alias from the series label, or null if it didn't sanitize to
+   *  a valid/unique identifier. */
+  friendly: string | null;
+  /** Human label of the underlying series (for the hint UI). */
+  label: string;
+}
+
+/** Sanitize a series label to a candidate identifier: lowercase, collapse
+ *  runs of non-`[a-z0-9_]` to `_`, trim leading/trailing underscores. Returns
+ *  null when nothing valid survives or the result starts with a digit (we
+ *  prefix-guard rather than mangle further). */
+function sanitizeIdent(label: string): string | null {
+  const cleaned = label
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (cleaned === "") return null;
+  if (/^[0-9]/.test(cleaned)) return null;
+  return cleaned;
+}
+
+/** Build the variable table for a set of base series. Friendly aliases are
+ *  only assigned when unique across the set *and* not colliding with a
+ *  positional alias (`s0, s1, …`); on any collision we drop the friendly
+ *  alias for the affected series and the user falls back to `sN`. */
+export function buildSeriesVariables(series: Series[]): SeriesVariable[] {
+  // First pass: tally candidate friendly idents so we can detect dupes.
+  const candidates = series.map((s) => sanitizeIdent(seriesLabel(s.tags)));
+  const counts = new Map<string, number>();
+  for (const c of candidates) {
+    if (c) counts.set(c, (counts.get(c) ?? 0) + 1);
+  }
+  const positional = new Set(series.map((_, i) => `s${i}`));
+
+  return series.map((s, i) => {
+    const cand = candidates[i];
+    const unique = cand !== null && counts.get(cand) === 1 && !positional.has(cand);
+    return {
+      index: `s${i}`,
+      friendly: unique ? cand : null,
+      label: seriesLabel(s.tags),
+    };
+  });
+}
+
+/** Result of evaluating one derived trace: either the computed series or a
+ *  per-trace error message to surface inline. */
+export interface DerivedResult {
+  id: string;
+  series?: Series;
+  error?: string;
+}
+
+/** Compute derived series from the fetched base series + the user's traces.
+ *  Each trace is compiled once, then evaluated per bucket index, building the
+ *  per-bucket variable map from each base series' value at that index (null →
+ *  0, matching the chart's existing null handling). Unknown variable refs and
+ *  non-finite results yield null points (the chart renders null → 0) rather
+ *  than throwing. */
+export function computeDerivedSeries(
+  series: Series[],
+  traces: DerivedTrace[],
+): DerivedResult[] {
+  const variables = buildSeriesVariables(series);
+  // The bucket axis is shared across every base series (server zero-fills),
+  // so the first series defines the bucket strings the derived series reuse.
+  const buckets = series[0]?.points.map((p) => p.bucket) ?? [];
+
+  return traces.map((trace) => {
+    const label = trace.label.trim() || trace.expression.trim() || "derived";
+
+    if (trace.expression.trim() === "") {
+      // An empty expression isn't an error worth shouting about — just skip
+      // it (no series, no message) so the row can sit there mid-edit.
+      return { id: trace.id };
+    }
+
+    const result = compileExpression(trace.expression);
+    if (!result.ok || !result.compiled) {
+      const err = result.error;
+      return {
+        id: trace.id,
+        error: err
+          ? `${err.message} (col ${err.position + 1})`
+          : "Invalid expression",
+      };
+    }
+
+    // Validate referenced variables up-front so a typo'd alias is a clear
+    // message instead of a silently flat (all-zero) line.
+    const known = new Set<string>();
+    for (const v of variables) {
+      known.add(v.index);
+      if (v.friendly) known.add(v.friendly);
+    }
+    const unknown = result.compiled.variables.filter((v) => !known.has(v));
+    if (unknown.length > 0) {
+      return {
+        id: trace.id,
+        error: `Unknown variable${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`,
+      };
+    }
+
+    const compiled = result.compiled;
+    const points = buckets.map((bucket, i) => {
+      // Build the per-bucket variable map: each base series contributes its
+      // value at index `i` under both its positional and friendly aliases.
+      const vars: Record<string, number> = {};
+      for (let si = 0; si < series.length; si++) {
+        const value = series[si].points[i]?.value ?? 0;
+        vars[`s${si}`] = value;
+        const friendly = variables[si].friendly;
+        if (friendly) vars[friendly] = value;
+      }
+      const out = compiled.evaluate(vars);
+      // NaN (div-by-zero, etc.) → null; the chart coerces null → 0.
+      return { bucket, value: Number.isFinite(out) ? out : null };
+    });
+
+    return {
+      id: trace.id,
+      series: { tags: { [DERIVED_KEY]: label }, points },
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// UI
+// ---------------------------------------------------------------------------
+
+let traceSeq = 0;
+function newTraceId(): string {
+  traceSeq += 1;
+  return `dt_${traceSeq}_${Date.now().toString(36)}`;
+}
+
+interface DerivedTracesProps {
+  traces: DerivedTrace[];
+  onChange: (next: DerivedTrace[]) => void;
+  /** Variables available to reference, shown as a hint. */
+  variables: SeriesVariable[];
+  /** Per-trace parse/eval errors keyed by trace id. */
+  errors: Record<string, string>;
+}
+
+/** Compact editor for derived/expression traces, styled to match the query
+ *  builder's chip/sentence language. Lives below the QueryBuilder. */
+export function DerivedTraces({
+  traces,
+  onChange,
+  variables,
+  errors,
+}: DerivedTracesProps) {
+  function add() {
+    onChange([
+      ...traces,
+      { id: newTraceId(), label: "", expression: "" },
+    ]);
+  }
+
+  function update(id: string, patch: Partial<DerivedTrace>) {
+    onChange(traces.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  }
+
+  function remove(id: string) {
+    onChange(traces.filter((t) => t.id !== id));
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <span className="select-none text-xs font-medium text-muted-foreground">
+          Derived traces
+        </span>
+        {traces.length === 0 ? (
+          <span className="select-none text-xs italic text-muted-foreground/60">
+            none
+          </span>
+        ) : null}
+      </div>
+
+      {traces.map((trace) => (
+        <div key={trace.id} className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <Input
+              value={trace.label}
+              onChange={(e) => update(trace.id, { label: e.target.value })}
+              placeholder="label"
+              className="h-7 w-32 font-mono text-xs"
+            />
+            <span className="select-none text-xs text-muted-foreground/70">
+              =
+            </span>
+            <Input
+              value={trace.expression}
+              onChange={(e) => update(trace.id, { expression: e.target.value })}
+              placeholder="expression (e.g. s0 * 2)"
+              className="h-7 flex-1 font-mono text-xs"
+            />
+            <button
+              type="button"
+              aria-label="Remove derived trace"
+              onClick={() => remove(trace.id)}
+              className="rounded-sm p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              title="Remove derived trace"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          {errors[trace.id] ? (
+            <p className="pl-1 text-xs text-destructive">{errors[trace.id]}</p>
+          ) : null}
+        </div>
+      ))}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={add}
+          className={cn(
+            "inline-flex h-7 items-center gap-1 rounded-md border border-dashed bg-transparent px-2 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
+          )}
+        >
+          <Plus className="h-3 w-3" />
+          derived trace
+        </button>
+      </div>
+
+      {variables.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-muted-foreground/70">
+          <span className="uppercase tracking-wider">vars</span>
+          {variables.map((v) => (
+            <code key={v.index} className="font-mono">
+              {v.friendly ? `${v.index} = ${v.friendly}` : v.index}
+            </code>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/src/components/signals/DerivedTraces.tsx
+++ b/dashboard/src/components/signals/DerivedTraces.tsx
@@ -64,6 +64,70 @@ export function buildSeriesVariables(series: Series[]): SeriesVariable[] {
   });
 }
 
+/** Compile an expression against a set of base series, sharing the variable
+ *  model (positional `sN` + friendly aliases) and up-front unknown-variable
+ *  validation used by BOTH derived traces and highlights. On success returns a
+ *  per-bucket evaluator `evalAt(i)` that builds the variable map for bucket
+ *  index `i` (each base series' value, null → 0, under both its aliases) and
+ *  evaluates the compiled expression — yielding NaN for non-finite results.
+ *  This is the single code path so the two features can't drift apart. */
+export interface SeriesEvaluator {
+  ok: boolean;
+  /** Present when `!ok` — already formatted for inline display. */
+  error?: string;
+  /** Present when `ok`. Evaluate the expression at a given bucket index. */
+  evalAt?: (bucketIndex: number) => number;
+}
+
+export function compileAgainstSeries(
+  expression: string,
+  series: Series[],
+): SeriesEvaluator {
+  const result = compileExpression(expression);
+  if (!result.ok || !result.compiled) {
+    const err = result.error;
+    return {
+      ok: false,
+      error: err
+        ? `${err.message} (col ${err.position + 1})`
+        : "Invalid expression",
+    };
+  }
+
+  const variables = buildSeriesVariables(series);
+
+  // Validate referenced variables up-front so a typo'd alias is a clear
+  // message instead of a silently flat (all-zero) line / empty highlight.
+  const known = new Set<string>();
+  for (const v of variables) {
+    known.add(v.index);
+    if (v.friendly) known.add(v.friendly);
+  }
+  const unknown = result.compiled.variables.filter((v) => !known.has(v));
+  if (unknown.length > 0) {
+    return {
+      ok: false,
+      error: `Unknown variable${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`,
+    };
+  }
+
+  const compiled = result.compiled;
+  const evalAt = (i: number): number => {
+    // Build the per-bucket variable map: each base series contributes its
+    // value at index `i` under both its positional and friendly aliases.
+    const vars: Record<string, number> = {};
+    for (let si = 0; si < series.length; si++) {
+      const value = series[si].points[i]?.value ?? 0;
+      vars[`s${si}`] = value;
+      const friendly = variables[si].friendly;
+      if (friendly) vars[friendly] = value;
+    }
+    return compiled.evaluate(vars);
+  };
+
+  return { ok: true, evalAt };
+}
+
 /** Result of evaluating one derived trace: either the computed series or a
  *  per-trace error message to surface inline. */
 export interface DerivedResult {
@@ -82,7 +146,6 @@ export function computeDerivedSeries(
   series: Series[],
   traces: DerivedTrace[],
 ): DerivedResult[] {
-  const variables = buildSeriesVariables(series);
   // The bucket axis is shared across every base series (server zero-fills),
   // so the first series defines the bucket strings the derived series reuse.
   const buckets = series[0]?.points.map((p) => p.bucket) ?? [];
@@ -96,44 +159,16 @@ export function computeDerivedSeries(
       return { id: trace.id };
     }
 
-    const result = compileExpression(trace.expression);
-    if (!result.ok || !result.compiled) {
-      const err = result.error;
-      return {
-        id: trace.id,
-        error: err
-          ? `${err.message} (col ${err.position + 1})`
-          : "Invalid expression",
-      };
+    // One shared compile-and-validate path with highlights (see
+    // `compileAgainstSeries`); a failure carries the formatted message.
+    const evaluator = compileAgainstSeries(trace.expression, series);
+    if (!evaluator.ok || !evaluator.evalAt) {
+      return { id: trace.id, error: evaluator.error };
     }
 
-    // Validate referenced variables up-front so a typo'd alias is a clear
-    // message instead of a silently flat (all-zero) line.
-    const known = new Set<string>();
-    for (const v of variables) {
-      known.add(v.index);
-      if (v.friendly) known.add(v.friendly);
-    }
-    const unknown = result.compiled.variables.filter((v) => !known.has(v));
-    if (unknown.length > 0) {
-      return {
-        id: trace.id,
-        error: `Unknown variable${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`,
-      };
-    }
-
-    const compiled = result.compiled;
+    const evalAt = evaluator.evalAt;
     const points = buckets.map((bucket, i) => {
-      // Build the per-bucket variable map: each base series contributes its
-      // value at index `i` under both its positional and friendly aliases.
-      const vars: Record<string, number> = {};
-      for (let si = 0; si < series.length; si++) {
-        const value = series[si].points[i]?.value ?? 0;
-        vars[`s${si}`] = value;
-        const friendly = variables[si].friendly;
-        if (friendly) vars[friendly] = value;
-      }
-      const out = compiled.evaluate(vars);
+      const out = evalAt(i);
       // NaN (div-by-zero, etc.) → null; the chart coerces null → 0.
       return { bucket, value: Number.isFinite(out) ? out : null };
     });

--- a/dashboard/src/components/signals/Highlights.tsx
+++ b/dashboard/src/components/signals/Highlights.tsx
@@ -48,20 +48,23 @@ export interface HighlightRanges {
   ranges: [number, number][];
 }
 
-/** Pure evaluation: for each highlight, compile its condition against the
- *  series (via the shared `compileAgainstSeries` helper), evaluate per bucket
- *  index, and coalesce contiguous truthy buckets into inclusive index ranges.
- *  A compile/unknown-variable error yields empty ranges (and is surfaced to the
- *  editor separately via `highlightErrors`). NaN / falsey buckets break a run. */
-export function computeHighlightRanges(
+/** Pure evaluation in a single pass: for each highlight, compile its condition
+ *  ONCE against the series (via the shared `compileAgainstSeries` helper),
+ *  evaluate per bucket index, coalesce contiguous truthy buckets into inclusive
+ *  index ranges the chart paints as bands, AND collect any compile/unknown-
+ *  variable error for inline display in the editor. A failing condition yields
+ *  empty ranges + an error; NaN / falsey buckets break a run. Returning both
+ *  from one call avoids compiling each expression twice. */
+export function evaluateHighlights(
   series: Series[],
   highlights: Highlight[],
-): HighlightRanges[] {
+): { ranges: HighlightRanges[]; errors: Record<string, string> } {
   // Shared bucket axis (server zero-fills every series), so the first series
   // defines how many bucket indices there are to walk.
   const bucketCount = series[0]?.points.length ?? 0;
+  const errors: Record<string, string> = {};
 
-  return highlights.map((h) => {
+  const ranges = highlights.map((h): HighlightRanges => {
     if (h.expression.trim() === "") {
       // Empty condition mid-edit — no bands, no error.
       return { id: h.id, color: h.color, ranges: [] };
@@ -69,12 +72,13 @@ export function computeHighlightRanges(
 
     const evaluator = compileAgainstSeries(h.expression, series);
     if (!evaluator.ok || !evaluator.evalAt) {
-      // Compile / unknown-variable error → no bands. The editor shows why.
+      // Compile / unknown-variable error → no bands; surface why in the editor.
+      if (evaluator.error) errors[h.id] = evaluator.error;
       return { id: h.id, color: h.color, ranges: [] };
     }
 
     const evalAt = evaluator.evalAt;
-    const ranges: [number, number][] = [];
+    const bands: [number, number][] = [];
     let runStart: number | null = null;
     for (let i = 0; i < bucketCount; i++) {
       const v = evalAt(i);
@@ -83,30 +87,17 @@ export function computeHighlightRanges(
       if (hit) {
         if (runStart === null) runStart = i;
       } else if (runStart !== null) {
-        ranges.push([runStart, i - 1]);
+        bands.push([runStart, i - 1]);
         runStart = null;
       }
     }
     // Close a run that extends to the last bucket.
-    if (runStart !== null) ranges.push([runStart, bucketCount - 1]);
+    if (runStart !== null) bands.push([runStart, bucketCount - 1]);
 
-    return { id: h.id, color: h.color, ranges };
+    return { id: h.id, color: h.color, ranges: bands };
   });
-}
 
-/** Surface per-highlight compile/unknown-variable errors keyed by id, mirroring
- *  the derived-traces error map. Empty expressions produce no error. */
-export function computeHighlightErrors(
-  series: Series[],
-  highlights: Highlight[],
-): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const h of highlights) {
-    if (h.expression.trim() === "") continue;
-    const evaluator = compileAgainstSeries(h.expression, series);
-    if (!evaluator.ok && evaluator.error) out[h.id] = evaluator.error;
-  }
-  return out;
+  return { ranges, errors };
 }
 
 // ---------------------------------------------------------------------------

--- a/dashboard/src/components/signals/Highlights.tsx
+++ b/dashboard/src/components/signals/Highlights.tsx
@@ -1,0 +1,248 @@
+import { Input } from "@/components/ui/input";
+import { type Series } from "./QueryChart";
+import {
+  compileAgainstSeries,
+  type SeriesVariable,
+} from "./DerivedTraces";
+import { cn } from "@/lib/utils";
+import { Plus, X } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Highlight regions (T6)
+//
+// A highlight shades the bucket ranges of THIS widget's chart where a boolean
+// condition holds — e.g. `throttle = 100` paints translucent vertical bands
+// over the times throttle is pinned. Detection runs entirely in-browser by
+// reusing the safe expression evaluator (a condition is just an expression read
+// as truthy, `!= 0`). Per-widget and local: nothing is broadcast across panels.
+// ---------------------------------------------------------------------------
+
+/** One user-defined highlight: a boolean condition + the band color to paint
+ *  wherever it holds. */
+export interface Highlight {
+  /** Stable id (for React keys / state updates). */
+  id: string;
+  /** Boolean condition over base-series variables (e.g. `throttle >= 100`). */
+  expression: string;
+  /** Translucent band color (a value from `HIGHLIGHT_COLORS`). */
+  color: string;
+}
+
+/** A small palette of translucent band colors. Kept low-alpha so bands read as
+ *  background wash behind the data lines/bars rather than competing with them.
+ *  Default (first) is red — the canonical "this is the interesting region" hue. */
+export const HIGHLIGHT_COLORS: { name: string; value: string }[] = [
+  { name: "red", value: "rgba(239, 68, 68, 0.18)" },
+  { name: "amber", value: "rgba(245, 158, 11, 0.18)" },
+  { name: "green", value: "rgba(16, 185, 129, 0.18)" },
+  { name: "blue", value: "rgba(59, 130, 246, 0.18)" },
+];
+
+export const DEFAULT_HIGHLIGHT_COLOR = HIGHLIGHT_COLORS[0].value;
+
+/** The computed bands for one highlight: contiguous truthy bucket indices
+ *  coalesced into inclusive `[startIdx, endIdx]` index ranges. */
+export interface HighlightRanges {
+  id: string;
+  color: string;
+  ranges: [number, number][];
+}
+
+/** Pure evaluation: for each highlight, compile its condition against the
+ *  series (via the shared `compileAgainstSeries` helper), evaluate per bucket
+ *  index, and coalesce contiguous truthy buckets into inclusive index ranges.
+ *  A compile/unknown-variable error yields empty ranges (and is surfaced to the
+ *  editor separately via `highlightErrors`). NaN / falsey buckets break a run. */
+export function computeHighlightRanges(
+  series: Series[],
+  highlights: Highlight[],
+): HighlightRanges[] {
+  // Shared bucket axis (server zero-fills every series), so the first series
+  // defines how many bucket indices there are to walk.
+  const bucketCount = series[0]?.points.length ?? 0;
+
+  return highlights.map((h) => {
+    if (h.expression.trim() === "") {
+      // Empty condition mid-edit — no bands, no error.
+      return { id: h.id, color: h.color, ranges: [] };
+    }
+
+    const evaluator = compileAgainstSeries(h.expression, series);
+    if (!evaluator.ok || !evaluator.evalAt) {
+      // Compile / unknown-variable error → no bands. The editor shows why.
+      return { id: h.id, color: h.color, ranges: [] };
+    }
+
+    const evalAt = evaluator.evalAt;
+    const ranges: [number, number][] = [];
+    let runStart: number | null = null;
+    for (let i = 0; i < bucketCount; i++) {
+      const v = evalAt(i);
+      // Truthy = finite and non-zero. NaN (undefined condition) is falsey.
+      const hit = Number.isFinite(v) && v !== 0;
+      if (hit) {
+        if (runStart === null) runStart = i;
+      } else if (runStart !== null) {
+        ranges.push([runStart, i - 1]);
+        runStart = null;
+      }
+    }
+    // Close a run that extends to the last bucket.
+    if (runStart !== null) ranges.push([runStart, bucketCount - 1]);
+
+    return { id: h.id, color: h.color, ranges };
+  });
+}
+
+/** Surface per-highlight compile/unknown-variable errors keyed by id, mirroring
+ *  the derived-traces error map. Empty expressions produce no error. */
+export function computeHighlightErrors(
+  series: Series[],
+  highlights: Highlight[],
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const h of highlights) {
+    if (h.expression.trim() === "") continue;
+    const evaluator = compileAgainstSeries(h.expression, series);
+    if (!evaluator.ok && evaluator.error) out[h.id] = evaluator.error;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// UI
+// ---------------------------------------------------------------------------
+
+let highlightSeq = 0;
+function newHighlightId(): string {
+  highlightSeq += 1;
+  return `hl_${highlightSeq}_${Date.now().toString(36)}`;
+}
+
+interface HighlightsProps {
+  highlights: Highlight[];
+  onChange: (next: Highlight[]) => void;
+  /** Variables available to reference, shown as a hint. */
+  variables: SeriesVariable[];
+  /** Per-highlight parse/unknown-variable errors keyed by id. */
+  errors: Record<string, string>;
+}
+
+/** Compact editor for highlight regions, styled to match the derived-traces /
+ *  query-builder chip/sentence language. Lives below the axis controls. */
+export function Highlights({
+  highlights,
+  onChange,
+  variables,
+  errors,
+}: HighlightsProps) {
+  function add() {
+    onChange([
+      ...highlights,
+      {
+        id: newHighlightId(),
+        expression: "",
+        color: DEFAULT_HIGHLIGHT_COLOR,
+      },
+    ]);
+  }
+
+  function update(id: string, patch: Partial<Highlight>) {
+    onChange(highlights.map((h) => (h.id === id ? { ...h, ...patch } : h)));
+  }
+
+  function remove(id: string) {
+    onChange(highlights.filter((h) => h.id !== id));
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <span className="select-none text-xs font-medium text-muted-foreground">
+          Highlights
+        </span>
+        {highlights.length === 0 ? (
+          <span className="select-none text-xs italic text-muted-foreground/60">
+            none
+          </span>
+        ) : null}
+      </div>
+
+      {highlights.map((highlight) => (
+        <div key={highlight.id} className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            {/* Color swatch picker — cycle through the preset translucent
+                colors. The swatch shows the currently-chosen band hue. */}
+            <div className="flex items-center gap-1">
+              {HIGHLIGHT_COLORS.map((c) => (
+                <button
+                  key={c.value}
+                  type="button"
+                  aria-label={`Highlight color ${c.name}`}
+                  title={c.name}
+                  onClick={() => update(highlight.id, { color: c.value })}
+                  className={cn(
+                    "h-4 w-4 rounded-sm border transition-transform hover:scale-110",
+                    highlight.color === c.value
+                      ? "border-foreground"
+                      : "border-transparent",
+                  )}
+                  style={{ backgroundColor: c.value }}
+                />
+              ))}
+            </div>
+            <span className="select-none text-xs text-muted-foreground/70">
+              when
+            </span>
+            <Input
+              value={highlight.expression}
+              onChange={(e) =>
+                update(highlight.id, { expression: e.target.value })
+              }
+              placeholder="condition (e.g. throttle = 100)"
+              className="h-7 flex-1 font-mono text-xs"
+            />
+            <button
+              type="button"
+              aria-label="Remove highlight"
+              onClick={() => remove(highlight.id)}
+              className="rounded-sm p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              title="Remove highlight"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          {errors[highlight.id] ? (
+            <p className="pl-1 text-xs text-destructive">
+              {errors[highlight.id]}
+            </p>
+          ) : null}
+        </div>
+      ))}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={add}
+          className={cn(
+            "inline-flex h-7 items-center gap-1 rounded-md border border-dashed bg-transparent px-2 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
+          )}
+        >
+          <Plus className="h-3 w-3" />
+          highlight
+        </button>
+      </div>
+
+      {variables.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-muted-foreground/70">
+          <span className="uppercase tracking-wider">vars</span>
+          {variables.map((v) => (
+            <code key={v.index} className="font-mono">
+              {v.friendly ? `${v.index} = ${v.friendly}` : v.index}
+            </code>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/src/components/signals/QueryBuilder.tsx
+++ b/dashboard/src/components/signals/QueryBuilder.tsx
@@ -25,7 +25,7 @@ import {
 import { cn } from "@/lib/utils";
 import Fuse from "fuse.js";
 import { ChevronDown, Plus, X } from "lucide-react";
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 
 interface QueryBuilderProps {
   value: Query;
@@ -49,6 +49,7 @@ export function QueryBuilder({
   const fieldOptions: FieldName[] = ROW_COUNT_AGGS.has(value.fn)
     ? [COUNT_FIELD]
     : NUMERIC_FIELDS;
+  const fieldFixed = fieldOptions.length === 1;
 
   function setFn(fn: Aggregator) {
     // Swapping aggregator classes (count ↔ avg/sum/...) invalidates the
@@ -70,10 +71,7 @@ export function QueryBuilder({
   function addFilter() {
     onChange({
       ...value,
-      filters: [
-        ...value.filters,
-        { column: "name", op: "=", value: "" },
-      ],
+      filters: [...value.filters, { column: "name", op: "=", value: "" }],
     });
   }
 
@@ -112,75 +110,91 @@ export function QueryBuilder({
     onChange(next ? { ...rest, rollup: next } : rest);
   }
 
+  const canAddGroup = value.groupBy.length < GROUPABLE_COLUMNS.length;
+
   return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex flex-wrap items-center gap-1.5">
-        <SelectChip
-          label={value.fn}
-          options={AGGREGATORS.map((a) => ({
-            value: a.value,
-            label: a.label,
-          }))}
-          onSelect={(v) => setFn(v as Aggregator)}
-        />
-        <SelectChip
-          label={value.field}
-          options={fieldOptions.map((f) => ({ value: f, label: f }))}
-          onSelect={(v) => setField(v as FieldName)}
-          disabled={fieldOptions.length === 1}
-        />
+    <div className="flex flex-col gap-2.5">
+      {/* The builder reads as a left-to-right sentence:
+       *   Show <agg> of <field>   where <filters>   grouped by <groups>   every <rollup>
+       * Each clause is its own visual segment with a soft keyword lead-in
+       * so the structure is legible without reading the chips as a run-on. */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-2 leading-7">
+        <Clause keyword="Show">
+          <SelectChip
+            label={value.fn}
+            options={AGGREGATORS.map((a) => ({
+              value: a.value,
+              label: a.label,
+            }))}
+            onSelect={(v) => setFn(v as Aggregator)}
+          />
+          <Connector>of</Connector>
+          <SelectChip
+            label={value.field}
+            options={fieldOptions.map((f) => ({ value: f, label: f }))}
+            onSelect={(v) => setField(v as FieldName)}
+            disabled={fieldFixed}
+          />
+        </Clause>
 
-        <span className="px-1 text-xs uppercase tracking-wide text-muted-foreground">
-          from
-        </span>
-        {value.filters.map((pred, i) => {
-          // Adjacent filters on the same column union (OR semantics);
-          // show a tiny "or" between them so the user sees this rather
-          // than reading the visual sequence as AND.
-          const prev = i > 0 ? value.filters[i - 1] : null;
-          const sameColAsPrev = prev !== null && prev.column === pred.column;
-          return (
-            <span key={i} className="inline-flex items-center gap-1.5">
-              {sameColAsPrev ? (
-                <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  or
+        <Clause keyword="where">
+          {value.filters.length === 0 ? (
+            <Hint>all signals</Hint>
+          ) : (
+            value.filters.map((pred, i) => {
+              // Adjacent filters on the same column union (OR semantics);
+              // show a tiny "or" between them so the user sees this rather
+              // than reading the visual sequence as AND.
+              const prev = i > 0 ? value.filters[i - 1] : null;
+              const sameColAsPrev = prev !== null && prev.column === pred.column;
+              return (
+                <span key={i} className="inline-flex items-center gap-2">
+                  {sameColAsPrev ? <Connector>or</Connector> : null}
+                  <FilterChip
+                    value={pred}
+                    onChange={(next) => updateFilter(i, next)}
+                    onRemove={() => removeFilter(i)}
+                    signalNames={signalNames}
+                  />
                 </span>
-              ) : null}
-              <FilterChip
-                value={pred}
-                onChange={(next) => updateFilter(i, next)}
-                onRemove={() => removeFilter(i)}
-                signalNames={signalNames}
-              />
-            </span>
-          );
-        })}
-        <AddChip label="Filter" onClick={addFilter} />
+              );
+            })
+          )}
+          <AddChip label="filter" onClick={addFilter} />
+        </Clause>
 
-        <span className="px-1 text-xs uppercase tracking-wide text-muted-foreground">
-          by
-        </span>
-        {value.groupBy.map((col) => (
-          <GroupChip key={col} column={col} onRemove={() => removeGroup(col)} />
-        ))}
-        {value.groupBy.length < GROUPABLE_COLUMNS.length ? (
-          <AddChip label="Group" onClick={addGroup} />
-        ) : null}
+        <Clause keyword="grouped by">
+          {value.groupBy.length === 0 ? <Hint>nothing</Hint> : null}
+          {value.groupBy.map((col) => (
+            <GroupChip
+              key={col}
+              column={col}
+              onRemove={() => removeGroup(col)}
+            />
+          ))}
+          {canAddGroup ? (
+            <AddChip label="group" onClick={addGroup} />
+          ) : null}
+        </Clause>
 
-        <span className="px-1 text-xs uppercase tracking-wide text-muted-foreground">
-          rollup
-        </span>
-        <RollupChip value={value.rollup} onChange={setRollup} />
+        <Clause keyword="every">
+          <RollupChip value={value.rollup} onChange={setRollup} />
+        </Clause>
       </div>
 
-      <code
-        className={cn(
-          "block font-mono text-xs text-muted-foreground",
-          error && "text-destructive",
-        )}
-      >
-        {serializeQuery(value)}
-      </code>
+      <div className="flex flex-col gap-1 rounded-md border bg-muted/30 px-2.5 py-1.5">
+        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          MQL
+        </span>
+        <code
+          className={cn(
+            "block break-all font-mono text-xs text-foreground/80",
+            error && "text-destructive",
+          )}
+        >
+          {serializeQuery(value)}
+        </code>
+      </div>
       {error ? (
         <p className="text-xs text-destructive">
           {error.message}
@@ -194,11 +208,59 @@ export function QueryBuilder({
 }
 
 // ---------------------------------------------------------------------------
+// Sentence scaffolding
+// ---------------------------------------------------------------------------
+
+/** A clause is a keyword lead-in ("where", "grouped by", ...) followed by its
+ *  chips, kept together so they wrap as a unit and read as one phrase. */
+function Clause({
+  keyword,
+  children,
+}: {
+  keyword: string;
+  children: ReactNode;
+}) {
+  return (
+    <span className="inline-flex flex-wrap items-center gap-2">
+      <Keyword>{keyword}</Keyword>
+      {children}
+    </span>
+  );
+}
+
+function Keyword({ children }: { children: ReactNode }) {
+  return (
+    <span className="select-none text-xs font-medium text-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+/** Inline lowercase connector word between chips ("of", "or"). */
+function Connector({ children }: { children: ReactNode }) {
+  return (
+    <span className="select-none text-xs text-muted-foreground/70">
+      {children}
+    </span>
+  );
+}
+
+/** Muted placeholder shown when a clause has no chips yet, so the sentence
+ *  still reads ("where all signals", "grouped by nothing"). */
+function Hint({ children }: { children: ReactNode }) {
+  return (
+    <span className="select-none text-xs italic text-muted-foreground/60">
+      {children}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Chip primitives
 // ---------------------------------------------------------------------------
 
 const CHIP_BASE =
-  "inline-flex h-7 items-center gap-1 rounded-md border bg-background px-2 text-xs font-mono transition-colors";
+  "inline-flex h-7 items-center gap-1 rounded-md border bg-background px-2.5 text-xs font-mono transition-colors";
 
 function SelectChip({
   label,
@@ -224,7 +286,10 @@ function SelectChip({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className={cn(CHIP_BASE, "hover:bg-accent/50")}
+          className={cn(
+            CHIP_BASE,
+            "font-medium hover:border-primary/40 hover:bg-accent/50",
+          )}
         >
           {label}
           <ChevronDown className="h-3 w-3 opacity-50" />
@@ -258,8 +323,7 @@ function AddChip({ label, onClick }: { label: string; onClick: () => void }) {
       type="button"
       onClick={onClick}
       className={cn(
-        CHIP_BASE,
-        "border-dashed text-muted-foreground hover:bg-accent/40 hover:text-foreground",
+        "inline-flex h-7 items-center gap-1 rounded-md border border-dashed bg-transparent px-2 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
       )}
     >
       <Plus className="h-3 w-3" />
@@ -285,7 +349,7 @@ function RollupChip({
           type="button"
           className={cn(
             CHIP_BASE,
-            "hover:bg-accent/50",
+            "font-medium hover:border-primary/40 hover:bg-accent/50",
             isAuto && "text-muted-foreground",
           )}
         >
@@ -293,7 +357,7 @@ function RollupChip({
           <ChevronDown className="h-3 w-3 opacity-50" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-[180px] p-1">
+      <PopoverContent align="start" className="max-h-[280px] w-[200px] overflow-auto p-1">
         <button
           type="button"
           onClick={() => {
@@ -340,12 +404,12 @@ function GroupChip({
   onRemove: () => void;
 }) {
   return (
-    <span className={cn(CHIP_BASE, "pr-1")}>
+    <span className={cn(CHIP_BASE, "gap-1.5 pr-1 font-medium")}>
       {column}
       <button
         type="button"
         onClick={onRemove}
-        className="rounded-sm p-0.5 hover:bg-accent"
+        className="rounded-sm p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
         title="Remove group"
       >
         <X className="h-3 w-3" />
@@ -368,45 +432,50 @@ function FilterChip({
   // Open the popover automatically when the chip is freshly added (empty
   // value) so the user doesn't have to click again to start typing.
   const [open, setOpen] = useState(value.value === "");
-
-  const display = value.value
-    ? `${value.column} = "${value.value}"`
-    : `${value.column} = …`;
+  const filled = Boolean(value.value);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className={cn(
-            CHIP_BASE,
-            "pr-1 hover:bg-accent/50",
-            !value.value && "border-destructive/40 text-muted-foreground",
-          )}
-        >
-          {display}
-          <span
-            role="button"
-            aria-label="Remove filter"
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemove();
-            }}
-            className="ml-1 rounded-sm p-0.5 hover:bg-accent"
+    <span
+      className={cn(
+        CHIP_BASE,
+        "gap-1.5 pr-1",
+        !filled && "border-destructive/40",
+      )}
+    >
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 rounded-sm hover:text-primary"
           >
-            <X className="h-3 w-3" />
-          </span>
-        </button>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-[300px] p-2">
-        <FilterEditor
-          value={value}
-          onChange={onChange}
-          signalNames={signalNames}
-          onCommit={() => setOpen(false)}
-        />
-      </PopoverContent>
-    </Popover>
+            <span className="font-medium">{value.column}</span>
+            <span className="text-muted-foreground">is</span>
+            {filled ? (
+              <span>{value.value}</span>
+            ) : (
+              <span className="italic text-muted-foreground">choose…</span>
+            )}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-[300px] p-2">
+          <FilterEditor
+            value={value}
+            onChange={onChange}
+            signalNames={signalNames}
+            onCommit={() => setOpen(false)}
+          />
+        </PopoverContent>
+      </Popover>
+      <button
+        type="button"
+        aria-label="Remove filter"
+        onClick={onRemove}
+        className="rounded-sm p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+        title="Remove filter"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </span>
   );
 }
 
@@ -461,11 +530,9 @@ function FilterEditor({
         <SelectChip
           label={value.column}
           options={FILTERABLE_COLUMNS.map((c) => ({ value: c, label: c }))}
-          onSelect={(c) =>
-            onChange({ ...value, column: c as FilterColumn })
-          }
+          onSelect={(c) => onChange({ ...value, column: c as FilterColumn })}
         />
-        <span className="text-xs text-muted-foreground">=</span>
+        <span className="text-xs text-muted-foreground">is</span>
         <Input
           autoFocus
           value={search}
@@ -499,9 +566,7 @@ function FilterEditor({
       </div>
       <div className="max-h-[220px] overflow-auto rounded-sm border bg-popover">
         {matches.length === 0 ? (
-          <div className="p-2 text-xs text-muted-foreground">
-            No matches
-          </div>
+          <div className="p-2 text-xs text-muted-foreground">No matches</div>
         ) : (
           matches.map((name) => (
             <button

--- a/dashboard/src/components/signals/QueryChart.tsx
+++ b/dashboard/src/components/signals/QueryChart.tsx
@@ -83,6 +83,13 @@ interface QueryChartProps {
    *  When every plotted label is default, the chart collapses to exactly its
    *  prior single-axis, single-stack rendering. */
   axisConfig?: Record<string, AxisSetting>;
+  /** Highlight bands (T6): translucent vertical regions over the bucket index
+   *  ranges where a per-widget condition holds. Each range is an inclusive
+   *  `[loIdx, hiIdx]` over the shared category axis. Rendered as a dedicated,
+   *  silent `__highlight__` markArea series that sits behind the data and never
+   *  interferes with the transient `__brush__` selection. Absent/empty → the
+   *  chart renders exactly as today. */
+  highlights?: { id: string; color: string; ranges: [number, number][] }[];
 }
 
 // Stable, high-contrast palette. Datadog-ish saturated colors that survive
@@ -256,6 +263,7 @@ export function QueryChart({
   groupId,
   onReady,
   axisConfig,
+  highlights,
 }: QueryChartProps) {
   // Top-K rollup before any other shaping; bar/area would stack hundreds
   // of slivers otherwise.
@@ -437,6 +445,36 @@ export function QueryChart({
       };
     });
 
+    // Highlight bands (T6) live on their own dedicated, silent series id —
+    // `__highlight__` — kept entirely separate from the transient `__brush__`
+    // markArea so brush-to-select and condition bands never clobber each other.
+    // Each `[lo, hi]` index range becomes one markArea band; every range across
+    // every highlight is flattened into this single series' data, each carrying
+    // its own translucent color via per-item `itemStyle`. With no highlights the
+    // series carries empty data and is visually inert. `silent: true` keeps it
+    // from intercepting the zrender brush mouse handlers, and `z: 0` parks it
+    // behind the data lines/bars.
+    const highlightAreas = (highlights ?? []).flatMap((h) =>
+      h.ranges.map(([lo, hi]) => [
+        { xAxis: lo, itemStyle: { color: h.color } },
+        { xAxis: hi },
+      ]),
+    );
+    const highlightSeries = {
+      id: "__highlight__",
+      type: "line" as const,
+      data: [],
+      silent: true,
+      z: 0,
+      markArea: {
+        silent: true,
+        // Default color is a no-op — every band overrides it per-item above —
+        // but ECharts wants an itemStyle present.
+        itemStyle: { color: "transparent" },
+        data: highlightAreas,
+      },
+    };
+
     return {
       animation: false,
       grid: { top: 8, right: 8, bottom: 24, left: 56, containLabel: false },
@@ -559,7 +597,7 @@ export function QueryChart({
           filterMode: "none",
         },
       ],
-      series: echartsSeries,
+      series: [...echartsSeries, highlightSeries],
     };
   }, [
     plotSeries,
@@ -570,6 +608,7 @@ export function QueryChart({
     nativeGroups,
     hasNormalized,
     normalizedAxisIndex,
+    highlights,
   ]);
 
   // Initialize the instance once.

--- a/dashboard/src/components/signals/QueryChart.tsx
+++ b/dashboard/src/components/signals/QueryChart.tsx
@@ -1,25 +1,30 @@
-import { Button } from "@/components/ui/button";
+import * as echarts from "echarts/core";
+import { BarChart, LineChart } from "echarts/charts";
 import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-  type ChartConfig,
-} from "@/components/ui/chart";
-import { AlertTriangle } from "lucide-react";
-import { useMemo, useState } from "react";
-import {
-  Area,
-  AreaChart,
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Line,
-  LineChart,
-  ReferenceArea,
-  XAxis,
-  YAxis,
-} from "recharts";
+  GridComponent,
+  TooltipComponent,
+  MarkAreaComponent,
+} from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import type {
+  ECharts,
+  EChartsCoreOption,
+  ElementEvent,
+} from "echarts/core";
+import { useEffect, useMemo, useRef } from "react";
 import type { ChartType } from "./ChartTypeToggle";
+
+// Canvas renderer only — that's the whole point of moving off recharts.
+// One <canvas> for the entire plot means a >20k-point query draws without
+// hanging the tab, so there's no longer a "render anyway" confirm gate.
+echarts.use([
+  BarChart,
+  LineChart,
+  GridComponent,
+  TooltipComponent,
+  MarkAreaComponent,
+  CanvasRenderer,
+]);
 
 export interface SeriesPoint {
   bucket: string;
@@ -145,6 +150,18 @@ function topK(series: Series[], max: number): { kept: Series[]; otherCount: numb
   return { kept, otherCount: tail.length };
 }
 
+/** Resolve an HSL CSS custom property (stored as "H S% L%") to an
+ *  `hsl(...)` string ECharts can consume, with an optional alpha. Falls
+ *  back to a sane dark-theme grey if the var is missing (e.g. SSR). */
+function cssHsl(varName: string, fallback: string, alpha = 1): string {
+  if (typeof window === "undefined") return fallback;
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue(varName)
+    .trim();
+  if (!raw) return fallback;
+  return alpha === 1 ? `hsl(${raw})` : `hsl(${raw} / ${alpha})`;
+}
+
 export function QueryChart({
   series,
   type,
@@ -152,239 +169,305 @@ export function QueryChart({
   maxSeries = 10,
   onBrushSelect,
 }: QueryChartProps) {
-  // Brush state. `start` is fixed on mousedown; `current` follows the
-  // mouse and renders the live highlight. We commit on mouseup when the
-  // two are distinct buckets — a same-bucket release is treated as a
-  // click (tooltip), not a selection, so single clicks keep working.
-  const [brushStart, setBrushStart] = useState<string | null>(null);
-  const [brushCurrent, setBrushCurrent] = useState<string | null>(null);
-
-  type ChartMouseEvent = { activeLabel?: string | number | null };
-  const handleMouseDown = onBrushSelect
-    ? (e: ChartMouseEvent | null) => {
-        const label = e?.activeLabel;
-        if (typeof label === "string") {
-          setBrushStart(label);
-          setBrushCurrent(label);
-        }
-      }
-    : undefined;
-  const handleMouseMove = onBrushSelect
-    ? (e: ChartMouseEvent | null) => {
-        if (brushStart === null) return;
-        const label = e?.activeLabel;
-        if (typeof label === "string") setBrushCurrent(label);
-      }
-    : undefined;
-  const handleMouseUp = onBrushSelect
-    ? () => {
-        if (brushStart !== null && brushCurrent !== null && brushStart !== brushCurrent) {
-          const a = new Date(brushStart);
-          const b = new Date(brushCurrent);
-          const [start, end] = a < b ? [a, b] : [b, a];
-          // Extend `end` to the *end* of its bucket so a brush that
-          // visually covers a bar actually includes that bar's data.
-          // intervalSec is the bucket width in seconds.
-          onBrushSelect(
-            start,
-            new Date(end.getTime() + intervalSec * 1000),
-          );
-        }
-        setBrushStart(null);
-        setBrushCurrent(null);
-      }
-    : undefined;
-  // Cancel an in-progress drag if the cursor leaves the chart — avoids
-  // a stuck highlight when the user releases the button off-chart.
-  const handleMouseLeave = onBrushSelect
-    ? () => {
-        setBrushStart(null);
-        setBrushCurrent(null);
-      }
-    : undefined;
   // Top-K rollup before any other shaping; bar/area would stack hundreds
   // of slivers otherwise.
   const { kept } = useMemo(() => topK(series, maxSeries), [series, maxSeries]);
 
-  // Pivot tall → wide so recharts can render multiple series from one
-  // dataset. Each row: { bucket, [seriesKey1]: value1, [seriesKey2]: ... }.
-  // Series keys are array indices ("s0", "s1", ...) so we never collide on
-  // user-provided values like "name".
-  const { data, seriesKeys, config } = useMemo(() => {
-    const seriesKeys: { key: string; label: string; color: string }[] = kept.map(
-      (s, i) => ({
-        key: `s${i}`,
-        label: seriesLabel(s.tags),
-        color: PALETTE[i % PALETTE.length],
-      }),
-    );
-    const config: ChartConfig = Object.fromEntries(
-      seriesKeys.map(({ key, label, color }) => [key, { label, color }]),
-    );
+  // Shape into the columnar form ECharts wants: a shared category axis of
+  // bucket ISO strings plus one value array per series. Series keys mirror
+  // the old "s0", "s1", ... indexing so colors stay stable by position.
+  const { buckets, plotSeries } = useMemo(() => {
     const buckets = kept[0]?.points.map((p) => p.bucket) ?? [];
-    const data = buckets.map((bucket, i) => {
-      const row: Record<string, string | number | null> = { bucket };
-      kept.forEach((s, sIdx) => {
-        row[`s${sIdx}`] = s.points[i]?.value ?? 0;
-      });
-      return row;
-    });
-    return { data, seriesKeys, config };
+    const plotSeries = kept.map((s, i) => ({
+      key: `s${i}`,
+      label: seriesLabel(s.tags),
+      color: PALETTE[i % PALETTE.length],
+      // Nulls render as 0, matching the old recharts behavior (it coerced
+      // null → 0 in the pivot).
+      values: buckets.map((_, bi) => s.points[bi]?.value ?? 0),
+    }));
+    return { buckets, plotSeries };
   }, [kept]);
 
-  const isMulti = seriesKeys.length > 1;
+  const isMulti = plotSeries.length > 1;
   // Bar/area stack by default in multi-series; line doesn't (lines stacked
-  // on top of each other are unreadable). Single-series ignores stackId.
-  const stackId = isMulti && type !== "line" ? "stack" : undefined;
+  // on top of each other are unreadable). Single-series never stacks.
+  const stack = isMulti && type !== "line" ? "stack" : undefined;
 
-  // Safety rail. Recharts is SVG-based — each bucket × series renders a
-  // DOM element, and the browser starts choking past ~20k of them. Bar
-  // charts hit this hardest (one <rect> per bar); line charts only render
-  // one <path> per series so they're cheap. We treat any chart type the
-  // same here for simplicity — if 20k is too conservative for line later,
-  // we can split the threshold by type.
-  const RENDER_LIMIT = 20_000;
-  const renderElementCount = data.length * Math.max(1, seriesKeys.length);
-  const renderSig = `${data.length}x${seriesKeys.length}`;
-  const [confirmedSig, setConfirmedSig] = useState<string | null>(null);
-  const needsConfirm =
-    renderElementCount > RENDER_LIMIT && confirmedSig !== renderSig;
+  const chartRef = useRef<HTMLDivElement | null>(null);
+  const instanceRef = useRef<ECharts | null>(null);
+  // Brush drag state lives in refs so the native zrender mouse handlers
+  // (registered once) always read the latest values without re-binding.
+  const brushRef = useRef<{ startIdx: number | null; curIdx: number | null }>({
+    startIdx: null,
+    curIdx: null,
+  });
+  // Keep the latest props the handlers need without re-creating handlers.
+  const cbRef = useRef<{
+    onBrushSelect?: (start: Date, end: Date) => void;
+    buckets: string[];
+    intervalSec: number;
+  }>({ onBrushSelect, buckets, intervalSec });
+  cbRef.current = { onBrushSelect, buckets, intervalSec };
 
-  if (data.length === 0) {
-    return (
-      <div className="flex h-[260px] items-center justify-center text-sm text-muted-foreground">
-        No data in this window
-      </div>
+  // Build the ECharts option. Memoized so we only recompute on real input
+  // changes; the brush markArea is layered on separately during a drag.
+  const option = useMemo<EChartsCoreOption>(() => {
+    const axisLabelColor = cssHsl("--muted-foreground", "#a1a1aa");
+    const splitLineColor = cssHsl("--border", "#27272a");
+
+    const echartsSeries = plotSeries.map((s) => {
+      const base = {
+        id: s.key,
+        name: s.label,
+        data: s.values,
+        itemStyle: { color: s.color },
+        ...(stack ? { stack } : {}),
+      };
+      if (type === "bar") {
+        return {
+          ...base,
+          type: "bar" as const,
+          // Match recharts' rounded top corners.
+          itemStyle: { color: s.color, borderRadius: [2, 2, 0, 0] },
+        };
+      }
+      if (type === "line") {
+        return {
+          ...base,
+          type: "line" as const,
+          smooth: true,
+          showSymbol: false,
+          lineStyle: { width: 2, color: s.color },
+        };
+      }
+      // area
+      return {
+        ...base,
+        type: "line" as const,
+        smooth: true,
+        showSymbol: false,
+        lineStyle: { width: 2, color: s.color },
+        areaStyle: { color: s.color, opacity: 0.25 },
+      };
+    });
+
+    return {
+      animation: false,
+      grid: { top: 8, right: 8, bottom: 24, left: 56, containLabel: false },
+      tooltip: {
+        trigger: "axis",
+        // ECharts handles dark backgrounds itself; nudge styling toward the
+        // shadcn tooltip look.
+        backgroundColor: cssHsl("--popover", "#18181b"),
+        borderColor: splitLineColor,
+        textStyle: { color: cssHsl("--popover-foreground", "#fafafa") },
+        formatter: (params: unknown) => {
+          const arr = Array.isArray(params) ? params : [params];
+          if (arr.length === 0) return "";
+          const iso = buckets[(arr[0] as { dataIndex: number }).dataIndex];
+          const header = iso ? new Date(iso).toLocaleString() : "";
+          const rows = (
+            arr as Array<{
+              seriesName: string;
+              value: number;
+              marker: string;
+            }>
+          )
+            .map(
+              (p) =>
+                `<div style="display:flex;justify-content:space-between;gap:12px">` +
+                `<span>${p.marker}${p.seriesName}</span>` +
+                `<span style="font-variant-numeric:tabular-nums">${formatCount(
+                  p.value,
+                )}</span></div>`,
+            )
+            .join("");
+          return `<div style="font-weight:500;margin-bottom:4px">${header}</div>${rows}`;
+        },
+      },
+      xAxis: {
+        type: "category" as const,
+        data: buckets,
+        boundaryGap: type === "bar",
+        axisTick: { show: false },
+        axisLine: { show: false },
+        axisLabel: {
+          color: axisLabelColor,
+          hideOverlap: true,
+          formatter: (v: string) => formatBucketTick(v, intervalSec),
+        },
+      },
+      yAxis: {
+        type: "value" as const,
+        axisTick: { show: false },
+        axisLine: { show: false },
+        axisLabel: { color: axisLabelColor, formatter: formatCount },
+        splitLine: { lineStyle: { color: splitLineColor, type: "dashed" } },
+      },
+      series: echartsSeries,
+    };
+  }, [plotSeries, buckets, type, stack, intervalSec]);
+
+  // Initialize the instance once.
+  useEffect(() => {
+    if (!chartRef.current) return;
+    const inst = echarts.init(chartRef.current, undefined, {
+      renderer: "canvas",
+    });
+    instanceRef.current = inst;
+
+    const ro = new ResizeObserver(() => inst.resize());
+    ro.observe(chartRef.current);
+
+    // --- Brush-to-select-timeframe ---
+    // Reproduces the old recharts behavior on canvas: on mousedown we record
+    // the bucket under the cursor; on mousemove we draw a translucent
+    // markArea highlight between start and current; on mouseup we commit
+    // [start, end) — but only if start and current land on *different*
+    // buckets (a same-bucket release is a click, not a selection). The end
+    // is extended by one bucket width (intervalSec) so the brush includes
+    // the bar it visually covers.
+    const zr = inst.getZr();
+
+    // Map a pixel x within the grid to the nearest category index. Returns
+    // null if the point is outside the plot area.
+    const pixelToIndex = (event: ElementEvent): number | null => {
+      const x = event.offsetX;
+      const y = event.offsetY;
+      if (!inst.containPixel({ gridIndex: 0 }, [x, y])) return null;
+      const val = inst.convertFromPixel({ gridIndex: 0 }, [x, y]);
+      const idx = Array.isArray(val) ? Math.round(val[0] as number) : null;
+      if (idx === null) return null;
+      const len = cbRef.current.buckets.length;
+      if (idx < 0 || idx >= len) return null;
+      return idx;
+    };
+
+    const renderHighlight = () => {
+      const { startIdx, curIdx } = brushRef.current;
+      if (startIdx === null || curIdx === null || startIdx === curIdx) {
+        inst.setOption({ series: [{ id: "__brush__", markArea: { data: [] } }] });
+        return;
+      }
+      const lo = Math.min(startIdx, curIdx);
+      const hi = Math.max(startIdx, curIdx);
+      inst.setOption({
+        series: [
+          {
+            id: "__brush__",
+            type: "line",
+            data: [],
+            silent: true,
+            markArea: {
+              itemStyle: { color: cssHsl("--foreground", "#fafafa", 0.12) },
+              data: [[{ xAxis: lo }, { xAxis: hi }]],
+            },
+          },
+        ],
+      });
+    };
+
+    const onDown = (event: ElementEvent) => {
+      if (!cbRef.current.onBrushSelect) return;
+      const idx = pixelToIndex(event);
+      if (idx === null) return;
+      brushRef.current = { startIdx: idx, curIdx: idx };
+    };
+    const onMove = (event: ElementEvent) => {
+      if (!cbRef.current.onBrushSelect) return;
+      if (brushRef.current.startIdx === null) return;
+      const idx = pixelToIndex(event);
+      if (idx === null) return;
+      brushRef.current.curIdx = idx;
+      renderHighlight();
+    };
+    const commit = () => {
+      const { onBrushSelect: cb, buckets: bkts, intervalSec: iv } =
+        cbRef.current;
+      const { startIdx, curIdx } = brushRef.current;
+      brushRef.current = { startIdx: null, curIdx: null };
+      renderHighlight();
+      if (
+        cb &&
+        startIdx !== null &&
+        curIdx !== null &&
+        startIdx !== curIdx
+      ) {
+        const lo = Math.min(startIdx, curIdx);
+        const hi = Math.max(startIdx, curIdx);
+        const startIso = bkts[lo];
+        const endIso = bkts[hi];
+        if (startIso && endIso) {
+          const start = new Date(startIso);
+          // Extend `end` to the end of its bucket so a brush that visually
+          // covers a bar actually includes that bar's data.
+          const end = new Date(new Date(endIso).getTime() + iv * 1000);
+          cb(start, end);
+        }
+      }
+    };
+
+    zr.on("mousedown", onDown);
+    zr.on("mousemove", onMove);
+    zr.on("mouseup", commit);
+    // Cancel an in-progress drag if the cursor leaves the canvas — avoids a
+    // stuck highlight when the button is released off-chart.
+    zr.on("globalout", () => {
+      if (brushRef.current.startIdx !== null) {
+        brushRef.current = { startIdx: null, curIdx: null };
+        renderHighlight();
+      }
+    });
+
+    return () => {
+      ro.disconnect();
+      zr.off("mousedown", onDown);
+      zr.off("mousemove", onMove);
+      zr.off("mouseup", commit);
+      inst.dispose();
+      instanceRef.current = null;
+    };
+  }, []);
+
+  // Push option changes. `notMerge: false` so the persistent "__brush__"
+  // markArea series isn't clobbered by data updates, but we must include a
+  // placeholder brush series so ECharts keeps its id slot stable.
+  useEffect(() => {
+    const inst = instanceRef.current;
+    if (!inst) return;
+    const opt = option as { series: unknown[] };
+    inst.setOption(
+      {
+        ...opt,
+        series: [...opt.series, { id: "__brush__", type: "line", data: [] }],
+      },
+      { notMerge: true },
     );
-  }
+  }, [option]);
 
-  if (needsConfirm) {
-    return (
-      <div className="flex h-[260px] flex-col items-center justify-center gap-3 rounded-md border border-dashed border-amber-500/40 bg-amber-500/5 p-6 text-center">
-        <AlertTriangle className="h-6 w-6 text-amber-500" />
-        <div>
-          <p className="text-sm font-medium">
-            Large render &mdash;{" "}
-            {data.length.toLocaleString()} buckets &times;{" "}
-            {seriesKeys.length} series ={" "}
-            {renderElementCount.toLocaleString()} elements
-          </p>
-          <p className="mt-1 max-w-md text-xs text-muted-foreground">
-            Past about {RENDER_LIMIT.toLocaleString()} SVG elements the browser
-            tab can hang. Pick a coarser rollup or a narrower timeframe, or
-            render anyway.
-          </p>
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={() => setConfirmedSig(renderSig)}
-        >
-          Render anyway
-        </Button>
-      </div>
-    );
-  }
-
-  const commonAxes = (
-    <>
-      <CartesianGrid strokeDasharray="3 3" vertical={false} />
-      <XAxis
-        dataKey="bucket"
-        tickFormatter={(v) => formatBucketTick(v, intervalSec)}
-        tickLine={false}
-        axisLine={false}
-        minTickGap={32}
-      />
-      <YAxis
-        tickFormatter={formatCount}
-        tickLine={false}
-        axisLine={false}
-        width={48}
-      />
-      <ChartTooltip
-        content={
-          <ChartTooltipContent
-            labelFormatter={(v) => new Date(v as string).toLocaleString()}
-          />
+  // Always keep the chart container (and its ref) mounted so the one-time
+  // init effect has a node even when the first render has no data — the
+  // empty state is an overlay, not an early return. Otherwise a mount with
+  // empty series followed by data arriving would never initialize the
+  // instance (the `[]`-deps effect won't re-run). The empty overlay sits on
+  // top of an empty canvas.
+  return (
+    <div className="relative h-[260px] w-full">
+      <div
+        ref={chartRef}
+        className="h-full w-full"
+        style={
+          onBrushSelect
+            ? { userSelect: "none", cursor: "crosshair" }
+            : undefined
         }
       />
-    </>
-  );
-
-  // Shared props for whichever chart variant we render below.
-  const chartProps = {
-    data,
-    margin: { top: 8, right: 8, left: -16, bottom: 0 },
-    onMouseDown: handleMouseDown,
-    onMouseMove: handleMouseMove,
-    onMouseUp: handleMouseUp,
-    onMouseLeave: handleMouseLeave,
-    // Drag-to-select feels wrong with text selection happening underneath.
-    style: onBrushSelect ? { userSelect: "none" as const, cursor: "crosshair" as const } : undefined,
-  };
-
-  const brushHighlight =
-    brushStart !== null && brushCurrent !== null && brushStart !== brushCurrent ? (
-      <ReferenceArea
-        x1={brushStart}
-        x2={brushCurrent}
-        strokeOpacity={0}
-        fill="currentColor"
-        fillOpacity={0.12}
-      />
-    ) : null;
-
-  return (
-    <ChartContainer config={config} className="h-[260px] w-full">
-      {type === "bar" ? (
-        <BarChart {...chartProps}>
-          {commonAxes}
-          {seriesKeys.map(({ key }) => (
-            <Bar
-              key={key}
-              dataKey={key}
-              fill={`var(--color-${key})`}
-              stackId={stackId}
-              radius={[2, 2, 0, 0]}
-            />
-          ))}
-          {brushHighlight}
-        </BarChart>
-      ) : type === "line" ? (
-        <LineChart {...chartProps}>
-          {commonAxes}
-          {seriesKeys.map(({ key }) => (
-            <Line
-              key={key}
-              type="monotone"
-              dataKey={key}
-              stroke={`var(--color-${key})`}
-              strokeWidth={2}
-              dot={false}
-              isAnimationActive={false}
-            />
-          ))}
-          {brushHighlight}
-        </LineChart>
-      ) : (
-        <AreaChart {...chartProps}>
-          {commonAxes}
-          {seriesKeys.map(({ key }) => (
-            <Area
-              key={key}
-              type="monotone"
-              dataKey={key}
-              stroke={`var(--color-${key})`}
-              fill={`var(--color-${key})`}
-              fillOpacity={0.25}
-              stackId={stackId}
-              isAnimationActive={false}
-            />
-          ))}
-          {brushHighlight}
-        </AreaChart>
+      {buckets.length === 0 && (
+        <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">
+          No data in this window
+        </div>
       )}
-    </ChartContainer>
+    </div>
   );
 }

--- a/dashboard/src/components/signals/QueryChart.tsx
+++ b/dashboard/src/components/signals/QueryChart.tsx
@@ -43,6 +43,20 @@ export interface Series {
   points: SeriesPoint[];
 }
 
+/** Per-trace y-scaling behavior (T8), keyed by `seriesLabel(tags)` in the
+ *  widget's settings map. Two mutually-exclusive modes:
+ *   - native: the trace plots on the real-value axis for `axisGroup`; every
+ *     trace sharing a group shares one axis and keeps its true relative
+ *     height (not rescaled against the others).
+ *   - normalize: the trace is min/max-rescaled to [0,1] onto a shared hidden
+ *     axis so its peak reaches the top of the plot regardless of magnitude.
+ *  Default for any unconfigured label = group "1", un-normalized → today's
+ *  exact single-axis behavior. */
+export interface AxisSetting {
+  axisGroup: string;
+  normalize: boolean;
+}
+
 interface QueryChartProps {
   series: Series[];
   type: ChartType;
@@ -64,12 +78,17 @@ interface QueryChartProps {
    *  out / reset) through any one panel — the `connect` group rebroadcasts
    *  to the rest. Additive; standalone charts simply omit it. */
   onReady?: (instance: ECharts | null) => void;
+  /** Per-series y-scaling settings (T8), keyed by series label. Sparse —
+   *  any label absent here falls back to the default (group "1", native).
+   *  When every plotted label is default, the chart collapses to exactly its
+   *  prior single-axis, single-stack rendering. */
+  axisConfig?: Record<string, AxisSetting>;
 }
 
 // Stable, high-contrast palette. Datadog-ish saturated colors that survive
 // dark backgrounds — first slot deliberately matches our existing gr-pink
 // so single-series bars don't change color when you flip into multi-series.
-const PALETTE = [
+export const PALETTE = [
   "#e105a3",
   "#8412fc",
   "#10b981",
@@ -198,6 +217,16 @@ function cssHsl(varName: string, fallback: string, alpha = 1): string {
   return alpha === 1 ? `hsl(${raw})` : `hsl(${raw} / ${alpha})`;
 }
 
+/** Default y-scaling for an unconfigured series label — a single shared
+ *  native group, never normalized. Keeping this in one place guarantees the
+ *  "zero config behaves exactly as today" contract. */
+function settingFor(
+  axisConfig: Record<string, AxisSetting> | undefined,
+  label: string,
+): AxisSetting {
+  return axisConfig?.[label] ?? { axisGroup: "1", normalize: false };
+}
+
 export function QueryChart({
   series,
   type,
@@ -206,6 +235,7 @@ export function QueryChart({
   onBrushSelect,
   groupId,
   onReady,
+  axisConfig,
 }: QueryChartProps) {
   // Top-K rollup before any other shaping; bar/area would stack hundreds
   // of slivers otherwise.
@@ -216,25 +246,67 @@ export function QueryChart({
   // the old "s0", "s1", ... indexing so colors stay stable by position.
   const { buckets, plotSeries } = useMemo(() => {
     const buckets = kept[0]?.points.map((p) => p.bucket) ?? [];
-    const plotSeries = kept.map((s, i) => ({
-      key: `s${i}`,
-      label: seriesLabel(s.tags),
-      color: PALETTE[i % PALETTE.length],
-      // Derived/expression traces render as standalone lines and never join
-      // the stacked bar/area group (a series and its square stacking on top
-      // of each other would be misleading).
-      derived: isDerived(s),
-      // Nulls render as 0, matching the old recharts behavior (it coerced
-      // null → 0 in the pivot).
-      values: buckets.map((_, bi) => s.points[bi]?.value ?? 0),
-    }));
+    const plotSeries = kept.map((s, i) => {
+      const label = seriesLabel(s.tags);
+      const setting = settingFor(axisConfig, label);
+      // Raw (true) values — what the tooltip must always show, and what a
+      // native series plots directly. Nulls render as 0, matching the old
+      // recharts behavior (it coerced null → 0 in the pivot).
+      const raw = buckets.map((_, bi) => s.points[bi]?.value ?? 0);
+      return {
+        key: `s${i}`,
+        label,
+        color: PALETTE[i % PALETTE.length],
+        // Derived/expression traces render as standalone lines and never join
+        // the stacked bar/area group (a series and its square stacking on top
+        // of each other would be misleading).
+        derived: isDerived(s),
+        normalize: setting.normalize,
+        axisGroup: setting.axisGroup,
+        raw,
+      };
+    });
     return { buckets, plotSeries };
-  }, [kept]);
+  }, [kept, axisConfig]);
 
-  // Stacking is decided per-series below; the group is only meaningful when
-  // there are 2+ *base* (non-derived) series and the chart type stacks.
-  const baseCount = plotSeries.filter((s) => !s.derived).length;
-  const stackBase = baseCount > 1 && type !== "line" ? "stack" : undefined;
+  // Distinct native (un-normalized) axis groups, in first-seen order. The
+  // first such group renders visible axis labels/line; any additional groups
+  // get an independent scale but hidden decorations to avoid clutter. A
+  // separate hidden [0,1] axis is appended for normalized traces when any
+  // exist. This collapses to a single y-axis when nothing is grouped or
+  // normalized, preserving today's rendering exactly.
+  const { nativeGroups, hasNormalized } = useMemo(() => {
+    const order: string[] = [];
+    let anyNorm = false;
+    for (const s of plotSeries) {
+      if (s.normalize) {
+        anyNorm = true;
+      } else if (!order.includes(s.axisGroup)) {
+        order.push(s.axisGroup);
+      }
+    }
+    // Guarantee at least one native axis even if every series is normalized,
+    // so the grid always has a y-axis to render against.
+    if (order.length === 0) order.push("1");
+    return { nativeGroups: order, hasNormalized: anyNorm };
+  }, [plotSeries]);
+
+  // The hidden normalized axis (if present) sits after every native axis.
+  const normalizedAxisIndex = hasNormalized ? nativeGroups.length : -1;
+
+  // Stacking only makes sense within ONE shared native axis. To stay simple
+  // and safe we only stack when ALL base (non-derived, non-normalized) series
+  // live in a single native group; any grouping or normalization splits the
+  // scales and we fall back to unstacked. (Stacking across independent scales
+  // would be visually meaningless, and normalized traces never stack.)
+  const stackableBase = plotSeries.filter((s) => !s.derived && !s.normalize);
+  const singleNativeGroup =
+    stackableBase.length > 0 &&
+    stackableBase.every((s) => s.axisGroup === stackableBase[0].axisGroup);
+  const stackBase =
+    stackableBase.length > 1 && singleNativeGroup && type !== "line"
+      ? "stack"
+      : undefined;
 
   const chartRef = useRef<HTMLDivElement | null>(null);
   const instanceRef = useRef<ECharts | null>(null);
@@ -267,6 +339,32 @@ export function QueryChart({
     const splitLineColor = cssHsl("--border", "#27272a");
 
     const echartsSeries = plotSeries.map((s) => {
+      // Resolve which y-axis this series binds to, and the data it actually
+      // plots. Native series plot raw numbers on their group's axis. A
+      // normalized series is min/max-rescaled to [0,1] on the hidden
+      // normalized axis, emitting `{ value, raw }` objects so the tooltip can
+      // still recover the true value (see the tooltip formatter below).
+      const yAxisIndex = s.normalize
+        ? normalizedAxisIndex
+        : nativeGroups.indexOf(s.axisGroup);
+      let data: Array<number | { value: number; raw: number }> = s.raw;
+      if (s.normalize) {
+        let min = Infinity;
+        let max = -Infinity;
+        for (const v of s.raw) {
+          if (v < min) min = v;
+          if (v > max) max = v;
+        }
+        const span = max - min;
+        data = s.raw.map((v) => ({
+          // When the trace is flat (max === min) the [0,1] rescale is
+          // undefined; park it mid-plot (0.5) so a constant line is visible
+          // rather than pinned to an edge. Otherwise standard min/max scaling.
+          value: span === 0 ? 0.5 : (v - min) / span,
+          raw: v,
+        }));
+      }
+
       // Derived traces ignore the widget's chart type and stacking entirely:
       // always a clean, unstacked line so they read as an overlay on top of
       // the raw series.
@@ -274,7 +372,8 @@ export function QueryChart({
         return {
           id: s.key,
           name: s.label,
-          data: s.values,
+          data,
+          yAxisIndex,
           type: "line" as const,
           smooth: true,
           showSymbol: false,
@@ -285,7 +384,8 @@ export function QueryChart({
       const base = {
         id: s.key,
         name: s.label,
-        data: s.values,
+        data,
+        yAxisIndex,
         itemStyle: { color: s.color },
         ...(stackBase ? { stack: stackBase } : {}),
       };
@@ -342,16 +442,27 @@ export function QueryChart({
               seriesName: string;
               value: number;
               marker: string;
+              // Normalized series emit `{ value, raw }` objects; `data` carries
+              // the true (un-rescaled) value so the tooltip never shows the
+              // display-scaled number.
+              data: number | { value: number; raw: number } | null;
             }>
           )
-            .map(
-              (p) =>
+            .map((p) => {
+              const trueValue =
+                p.data !== null &&
+                typeof p.data === "object" &&
+                "raw" in p.data
+                  ? p.data.raw
+                  : p.value;
+              return (
                 `<div style="display:flex;justify-content:space-between;gap:12px">` +
                 `<span>${p.marker}${p.seriesName}</span>` +
                 `<span style="font-variant-numeric:tabular-nums">${formatCount(
-                  p.value,
-                )}</span></div>`,
-            )
+                  trueValue,
+                )}</span></div>`
+              );
+            })
             .join("");
           return `<div style="font-weight:500;margin-bottom:4px">${header}</div>${rows}`;
         },
@@ -368,13 +479,44 @@ export function QueryChart({
           formatter: (v: string) => formatBucketTick(v, intervalSec),
         },
       },
-      yAxis: {
-        type: "value" as const,
-        axisTick: { show: false },
-        axisLine: { show: false },
-        axisLabel: { color: axisLabelColor, formatter: formatCount },
-        splitLine: { lineStyle: { color: splitLineColor, type: "dashed" } },
-      },
+      // One value axis per native group plus (when needed) a hidden [0,1]
+      // axis for normalized traces. The FIRST native axis keeps today's full
+      // decoration (labels, split lines); additional native axes get an
+      // independent scale but hidden labels/line so the plot doesn't fill with
+      // competing tick columns. With no grouping/normalization this is a
+      // single-element array identical to the old single `yAxis`.
+      yAxis: [
+        ...nativeGroups.map((_, gi) => {
+          const primary = gi === 0;
+          return {
+            type: "value" as const,
+            axisTick: { show: false },
+            axisLine: { show: false },
+            axisLabel: primary
+              ? { color: axisLabelColor, formatter: formatCount }
+              : { show: false },
+            splitLine: primary
+              ? { lineStyle: { color: splitLineColor, type: "dashed" } }
+              : { show: false },
+          };
+        }),
+        ...(hasNormalized
+          ? [
+              {
+                // Shared normalized axis: fixed [0,1] so every normalized
+                // trace's own max pins to the top of the plot. Fully hidden —
+                // its tick values are meaningless next to native units.
+                type: "value" as const,
+                min: 0,
+                max: 1,
+                axisTick: { show: false },
+                axisLine: { show: false },
+                axisLabel: { show: false },
+                splitLine: { show: false },
+              },
+            ]
+          : []),
+      ],
       // Client-side zoom over the category (bucket) axis. Mouse-wheel only:
       // the left-drag is owned by the brush-to-select-timeframe handlers, so
       // we turn off drag-panning (`moveOnMouseMove: false`) to avoid stealing
@@ -399,7 +541,16 @@ export function QueryChart({
       ],
       series: echartsSeries,
     };
-  }, [plotSeries, buckets, type, stackBase, intervalSec]);
+  }, [
+    plotSeries,
+    buckets,
+    type,
+    stackBase,
+    intervalSec,
+    nativeGroups,
+    hasNormalized,
+    normalizedAxisIndex,
+  ]);
 
   // Initialize the instance once.
   useEffect(() => {

--- a/dashboard/src/components/signals/QueryChart.tsx
+++ b/dashboard/src/components/signals/QueryChart.tsx
@@ -205,6 +205,26 @@ function topK(series: Series[], max: number): { kept: Series[]; otherCount: numb
   return { kept: [...kept, ...derived], otherCount: tail.length };
 }
 
+/** Map each plotted series' label to the palette color the chart actually
+ *  renders it with — applying the SAME top-K reordering used below — so
+ *  external UI (the axis-controls swatches) matches the on-screen line
+ *  colors. Series folded into the "+N other" rollup aren't individually
+ *  colored and are omitted; callers should fall back to a neutral swatch. */
+export function seriesColorMap(
+  series: Series[],
+  maxSeries = 10,
+): Map<string, string> {
+  const { kept } = topK(series, maxSeries);
+  const map = new Map<string, string>();
+  kept.forEach((s, i) => {
+    // The synthetic "+N other" series isn't a configurable trace — skip it,
+    // but keep `i` so every real series keeps its rendered color index.
+    if (OTHER_KEY in s.tags) return;
+    map.set(seriesLabel(s.tags), PALETTE[i % PALETTE.length]);
+  });
+  return map;
+}
+
 /** Resolve an HSL CSS custom property (stored as "H S% L%") to an
  *  `hsl(...)` string ECharts can consume, with an optional alpha. Falls
  *  back to a sane dark-theme grey if the var is missing (e.g. SSR). */

--- a/dashboard/src/components/signals/QueryChart.tsx
+++ b/dashboard/src/components/signals/QueryChart.tsx
@@ -47,6 +47,11 @@ interface QueryChartProps {
   /** If set, click-and-drag on the chart highlights a range and commits
    *  it on mouse-up. Receives the [start, end) of the brushed window. */
   onBrushSelect?: (start: Date, end: Date) => void;
+  /** If set, joins this chart to an ECharts connection group (via
+   *  `inst.group = groupId` + `echarts.connect`) so the axisPointer cursor
+   *  and tooltip sync across every chart sharing the same id. Additive —
+   *  when absent the chart behaves exactly as before. */
+  groupId?: string;
 }
 
 // Stable, high-contrast palette. Datadog-ish saturated colors that survive
@@ -168,6 +173,7 @@ export function QueryChart({
   intervalSec,
   maxSeries = 10,
   onBrushSelect,
+  groupId,
 }: QueryChartProps) {
   // Top-K rollup before any other shaping; bar/area would stack hundreds
   // of slivers otherwise.
@@ -196,6 +202,10 @@ export function QueryChart({
 
   const chartRef = useRef<HTMLDivElement | null>(null);
   const instanceRef = useRef<ECharts | null>(null);
+  // groupId is read inside the once-only init effect via a ref so the
+  // effect's empty dep array stays honest.
+  const groupIdRef = useRef(groupId);
+  groupIdRef.current = groupId;
   // Brush drag state lives in refs so the native zrender mouse handlers
   // (registered once) always read the latest values without re-binding.
   const brushRef = useRef<{ startIdx: number | null; curIdx: number | null }>({
@@ -257,6 +267,11 @@ export function QueryChart({
       grid: { top: 8, right: 8, bottom: 24, left: 56, containLabel: false },
       tooltip: {
         trigger: "axis",
+        // A shared axisPointer is what `echarts.connect` actually syncs
+        // across grouped charts (it broadcasts the updateAxisPointer
+        // action). Harmless for a standalone chart — it just draws the
+        // hover line that the axis-triggered tooltip already implies.
+        axisPointer: { type: "line" },
         // ECharts handles dark backgrounds itself; nudge styling toward the
         // shadcn tooltip look.
         backgroundColor: cssHsl("--popover", "#18181b"),
@@ -316,6 +331,16 @@ export function QueryChart({
       renderer: "canvas",
     });
     instanceRef.current = inst;
+
+    // Join the sync group (additive — only when a groupId is provided).
+    // `echarts.connect` is idempotent per group id and links axisPointer +
+    // tooltip across every instance sharing the group, so hovering one
+    // panel draws the cursor on all of them. Reading from the closure is
+    // safe: groupId is fixed for the chart's lifetime on the page.
+    if (groupIdRef.current) {
+      inst.group = groupIdRef.current;
+      echarts.connect(groupIdRef.current);
+    }
 
     const ro = new ResizeObserver(() => inst.resize());
     ro.observe(chartRef.current);

--- a/dashboard/src/components/signals/QueryChart.tsx
+++ b/dashboard/src/components/signals/QueryChart.tsx
@@ -82,6 +82,18 @@ function formatBucketTick(iso: string, intervalSec: number): string {
       minute: "2-digit",
     });
   }
+  // Sub-second buckets need millisecond precision — otherwise every tick
+  // in a 50ms rollup reads the same "1:23:45 PM" and they're
+  // indistinguishable. Append the zero-padded milliseconds.
+  if (intervalSec < 1) {
+    const base = d.toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    const ms = d.getMilliseconds().toString().padStart(3, "0");
+    return `${base}.${ms}`;
+  }
   // Sub-minute buckets need seconds — otherwise every tick reads the
   // same "1:23 PM" and the user can't tell them apart.
   return d.toLocaleTimeString(undefined, {

--- a/dashboard/src/components/signals/QueryChart.tsx
+++ b/dashboard/src/components/signals/QueryChart.tsx
@@ -86,6 +86,16 @@ const PALETTE = [
 
 const OTHER_KEY = "__other__";
 
+// Tag key marking a series as a user-defined derived/expression trace. The
+// chart renders these as standalone (non-stacked) lines and never rolls them
+// into the top-K "other" bucket — they're explicit additions by the user.
+// The tag value is the trace's display label.
+export const DERIVED_KEY = "__derived__";
+
+function isDerived(s: Series): boolean {
+  return DERIVED_KEY in s.tags;
+}
+
 function formatBucketTick(iso: string, intervalSec: number): string {
   const d = new Date(iso);
   if (intervalSec >= 24 * 60 * 60) {
@@ -133,8 +143,12 @@ function formatCount(n: number): string {
 }
 
 /** Make a stable label for a series from its tag values. Empty tags →
- *  "value" so the single-series legend reads naturally. */
-function seriesLabel(tags: Record<string, string | null>): string {
+ *  "value" so the single-series legend reads naturally. Derived traces carry
+ *  their display label directly in the reserved tag. Exported so the widget
+ *  can build matching variable aliases (`current_ac` from a `current_ac`
+ *  series) for the derived-trace expression evaluator. */
+export function seriesLabel(tags: Record<string, string | null>): string {
+  if (DERIVED_KEY in tags) return tags[DERIVED_KEY] ?? "derived";
   const entries = Object.entries(tags);
   if (entries.length === 0) return "value";
   return entries.map(([, v]) => v ?? "—").join(" · ");
@@ -148,10 +162,14 @@ function seriesTotal(s: Series): number {
 }
 
 /** Roll any series past `max` into a single "other" bucket so the chart
- *  stays readable when a query produces hundreds of groups. */
+ *  stays readable when a query produces hundreds of groups. Derived traces
+ *  are exempt — the user added them explicitly, so they always survive and
+ *  only the raw base series participate in the top-K ranking/rollup. */
 function topK(series: Series[], max: number): { kept: Series[]; otherCount: number } {
-  if (series.length <= max) return { kept: series, otherCount: 0 };
-  const sorted = [...series].sort((a, b) => seriesTotal(b) - seriesTotal(a));
+  const derived = series.filter(isDerived);
+  const base = series.filter((s) => !isDerived(s));
+  if (base.length <= max) return { kept: [...base, ...derived], otherCount: 0 };
+  const sorted = [...base].sort((a, b) => seriesTotal(b) - seriesTotal(a));
   const kept = sorted.slice(0, max);
   const tail = sorted.slice(max);
   // Build the "other" series by summing point-by-point across the tail.
@@ -164,7 +182,8 @@ function topK(series: Series[], max: number): { kept: Series[]; otherCount: numb
     return { bucket: p.bucket, value: sum };
   });
   kept.push({ tags: { [OTHER_KEY]: `+${tail.length} other` }, points: otherPoints });
-  return { kept, otherCount: tail.length };
+  // Derived traces ride along untouched after the rollup.
+  return { kept: [...kept, ...derived], otherCount: tail.length };
 }
 
 /** Resolve an HSL CSS custom property (stored as "H S% L%") to an
@@ -201,6 +220,10 @@ export function QueryChart({
       key: `s${i}`,
       label: seriesLabel(s.tags),
       color: PALETTE[i % PALETTE.length],
+      // Derived/expression traces render as standalone lines and never join
+      // the stacked bar/area group (a series and its square stacking on top
+      // of each other would be misleading).
+      derived: isDerived(s),
       // Nulls render as 0, matching the old recharts behavior (it coerced
       // null → 0 in the pivot).
       values: buckets.map((_, bi) => s.points[bi]?.value ?? 0),
@@ -208,10 +231,10 @@ export function QueryChart({
     return { buckets, plotSeries };
   }, [kept]);
 
-  const isMulti = plotSeries.length > 1;
-  // Bar/area stack by default in multi-series; line doesn't (lines stacked
-  // on top of each other are unreadable). Single-series never stacks.
-  const stack = isMulti && type !== "line" ? "stack" : undefined;
+  // Stacking is decided per-series below; the group is only meaningful when
+  // there are 2+ *base* (non-derived) series and the chart type stacks.
+  const baseCount = plotSeries.filter((s) => !s.derived).length;
+  const stackBase = baseCount > 1 && type !== "line" ? "stack" : undefined;
 
   const chartRef = useRef<HTMLDivElement | null>(null);
   const instanceRef = useRef<ECharts | null>(null);
@@ -244,12 +267,27 @@ export function QueryChart({
     const splitLineColor = cssHsl("--border", "#27272a");
 
     const echartsSeries = plotSeries.map((s) => {
+      // Derived traces ignore the widget's chart type and stacking entirely:
+      // always a clean, unstacked line so they read as an overlay on top of
+      // the raw series.
+      if (s.derived) {
+        return {
+          id: s.key,
+          name: s.label,
+          data: s.values,
+          type: "line" as const,
+          smooth: true,
+          showSymbol: false,
+          itemStyle: { color: s.color },
+          lineStyle: { width: 2, color: s.color },
+        };
+      }
       const base = {
         id: s.key,
         name: s.label,
         data: s.values,
         itemStyle: { color: s.color },
-        ...(stack ? { stack } : {}),
+        ...(stackBase ? { stack: stackBase } : {}),
       };
       if (type === "bar") {
         return {
@@ -361,7 +399,7 @@ export function QueryChart({
       ],
       series: echartsSeries,
     };
-  }, [plotSeries, buckets, type, stack, intervalSec]);
+  }, [plotSeries, buckets, type, stackBase, intervalSec]);
 
   // Initialize the instance once.
   useEffect(() => {

--- a/dashboard/src/components/signals/QueryChart.tsx
+++ b/dashboard/src/components/signals/QueryChart.tsx
@@ -4,6 +4,7 @@ import {
   GridComponent,
   TooltipComponent,
   MarkAreaComponent,
+  DataZoomInsideComponent,
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 import type {
@@ -23,6 +24,12 @@ echarts.use([
   GridComponent,
   TooltipComponent,
   MarkAreaComponent,
+  // `inside` dataZoom only — mouse-wheel zoom over the (already-fetched)
+  // category axis. This is purely client-side magnification and never
+  // triggers a requery; the brush (zrender left-drag) is what sets the
+  // page timeframe and refetches. We deliberately skip the slider
+  // component to keep the gesture surface clear of the left-drag brush.
+  DataZoomInsideComponent,
   CanvasRenderer,
 ]);
 
@@ -52,6 +59,11 @@ interface QueryChartProps {
    *  and tooltip sync across every chart sharing the same id. Additive —
    *  when absent the chart behaves exactly as before. */
   groupId?: string;
+  /** Called once with the ECharts instance after init (and with `null` on
+   *  teardown). Lets the page dispatch group-wide dataZoom actions (zoom
+   *  out / reset) through any one panel — the `connect` group rebroadcasts
+   *  to the rest. Additive; standalone charts simply omit it. */
+  onReady?: (instance: ECharts | null) => void;
 }
 
 // Stable, high-contrast palette. Datadog-ish saturated colors that survive
@@ -174,6 +186,7 @@ export function QueryChart({
   maxSeries = 10,
   onBrushSelect,
   groupId,
+  onReady,
 }: QueryChartProps) {
   // Top-K rollup before any other shaping; bar/area would stack hundreds
   // of slivers otherwise.
@@ -206,6 +219,10 @@ export function QueryChart({
   // effect's empty dep array stays honest.
   const groupIdRef = useRef(groupId);
   groupIdRef.current = groupId;
+  // Same once-only-effect treatment for onReady: read the latest via a ref
+  // so the init/teardown can notify the page without re-binding.
+  const onReadyRef = useRef(onReady);
+  onReadyRef.current = onReady;
   // Brush drag state lives in refs so the native zrender mouse handlers
   // (registered once) always read the latest values without re-binding.
   const brushRef = useRef<{ startIdx: number | null; curIdx: number | null }>({
@@ -320,6 +337,28 @@ export function QueryChart({
         axisLabel: { color: axisLabelColor, formatter: formatCount },
         splitLine: { lineStyle: { color: splitLineColor, type: "dashed" } },
       },
+      // Client-side zoom over the category (bucket) axis. Mouse-wheel only:
+      // the left-drag is owned by the brush-to-select-timeframe handlers, so
+      // we turn off drag-panning (`moveOnMouseMove: false`) to avoid stealing
+      // it. Zooming never refetches — it just magnifies the buckets we
+      // already have. Because every widget shares the `connect` group,
+      // ECharts broadcasts the dataZoom action so all panels zoom together;
+      // a standalone chart (no groupId) still zooms, just unsynced.
+      dataZoom: [
+        {
+          id: "__inside_zoom__",
+          type: "inside",
+          xAxisIndex: 0,
+          zoomOnMouseWheel: true,
+          moveOnMouseWheel: false,
+          moveOnMouseMove: false,
+          // Preserve the current zoom window across option pushes (data
+          // refreshes) instead of snapping back to the full range.
+          // `filterMode: "none"` keeps out-of-window points so lines/areas
+          // don't get clipped to abrupt edges.
+          filterMode: "none",
+        },
+      ],
       series: echartsSeries,
     };
   }, [plotSeries, buckets, type, stack, intervalSec]);
@@ -341,6 +380,9 @@ export function QueryChart({
       inst.group = groupIdRef.current;
       echarts.connect(groupIdRef.current);
     }
+
+    // Hand the instance to the page so it can drive group-wide dataZoom.
+    onReadyRef.current?.(inst);
 
     const ro = new ResizeObserver(() => inst.resize());
     ro.observe(chartRef.current);
@@ -450,6 +492,7 @@ export function QueryChart({
       zr.off("mousedown", onDown);
       zr.off("mousemove", onMove);
       zr.off("mouseup", commit);
+      onReadyRef.current?.(null);
       inst.dispose();
       instanceRef.current = null;
     };
@@ -461,10 +504,30 @@ export function QueryChart({
   useEffect(() => {
     const inst = instanceRef.current;
     if (!inst) return;
-    const opt = option as { series: unknown[] };
+    // Capture the live zoom window so a `notMerge` rebuild (e.g. a chart-type
+    // toggle) doesn't snap the view back to the full range. Pure zoom
+    // interactions don't run this effect — `option` is referentially stable
+    // unless real inputs change — so this only matters on data/type updates.
+    // `getOption()` returns undefined until the first `setOption`, so guard
+    // it — on the initial mount there's no prior zoom window to preserve.
+    const prevOption = inst.getOption() as
+      | { dataZoom?: Array<{ start?: number; end?: number }> }
+      | undefined;
+    const curZoom = prevOption?.dataZoom?.[0];
+    const opt = option as {
+      series: unknown[];
+      dataZoom: Array<Record<string, unknown>>;
+    };
+    const dataZoom =
+      curZoom &&
+      typeof curZoom.start === "number" &&
+      typeof curZoom.end === "number"
+        ? [{ ...opt.dataZoom[0], start: curZoom.start, end: curZoom.end }]
+        : opt.dataZoom;
     inst.setOption(
       {
         ...opt,
+        dataZoom,
         series: [...opt.series, { id: "__brush__", type: "line", data: [] }],
       },
       { notMerge: true },

--- a/dashboard/src/components/signals/QueryChart.tsx
+++ b/dashboard/src/components/signals/QueryChart.tsx
@@ -51,10 +51,17 @@ export interface Series {
  *   - normalize: the trace is min/max-rescaled to [0,1] onto a shared hidden
  *     axis so its peak reaches the top of the plot regardless of magnitude.
  *  Default for any unconfigured label = group "1", un-normalized → today's
- *  exact single-axis behavior. */
+ *  exact single-axis behavior.
+ *
+ *  `hidden` (T11) drops the trace from the chart while it stays fetched, so a
+ *  signal needed only to feed a derived trace or highlight condition can be
+ *  kept out of the plot. The chart never sees hidden series (the widget filters
+ *  them before passing `series`); this flag lives here only so it persists in
+ *  the same per-label settings map as the scaling choices. */
 export interface AxisSetting {
   axisGroup: string;
   normalize: boolean;
+  hidden?: boolean;
 }
 
 interface QueryChartProps {

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -42,7 +42,16 @@ import {
   serializeQuery,
 } from "@/lib/query";
 import axios from "axios";
-import { Download, Eye, EyeOff, Image, Loader2, Trash2 } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Download,
+  Eye,
+  EyeOff,
+  Image,
+  Loader2,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 // Same as `Rollup` — kept as a separate alias so future "interval" usage
@@ -163,6 +172,11 @@ export function SignalWidget({
   // default — zero-cost and visually identical to today when unused. Local to
   // this widget; never broadcast across panels.
   const [highlights, setHighlights] = useState<Highlight[]>([]);
+  // Whether the Advanced options disclosure (derived traces, y-axis scaling +
+  // visibility, highlights) is expanded (T10). Collapsed by default and local
+  // to this widget, so a plain count() query is just builder + chart until the
+  // user opts into the extra controls.
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [loadingSeries, setLoadingSeries] = useState(false);
   const [seriesMs, setSeriesMs] = useState<number | null>(null);
   const [queryError, setQueryError] = useState<
@@ -325,6 +339,25 @@ export function SignalWidget({
     [visibleSeries],
   );
 
+  // How many advanced editors are actually configured — shown as a badge on the
+  // Advanced options toggle (T10) so collapsing the disclosure never hides
+  // active state silently. Counts non-empty derived traces + highlights, plus
+  // any *currently plotted* trace whose y-axis setting differs from the default
+  // (normalized, hidden, or moved off group "1"). Dormant settings for labels
+  // no longer present don't count.
+  const advancedCount = useMemo(() => {
+    const traces = derivedTraces.filter(
+      (t) => t.expression.trim() !== "",
+    ).length;
+    const bands = highlights.filter((h) => h.expression.trim() !== "").length;
+    let axes = 0;
+    for (const s of plottedSeries) {
+      const st = axisSettings[seriesLabel(s.tags)];
+      if (st && (st.normalize || st.hidden || st.axisGroup !== "1")) axes++;
+    }
+    return traces + bands + axes;
+  }, [derivedTraces, highlights, axisSettings, plottedSeries]);
+
   // Patch one label's setting (merging over its current/default value).
   const updateAxisSetting = (label: string, patch: Partial<AxisSetting>) =>
     setAxisSettings((prev) => ({
@@ -367,24 +400,52 @@ export function SignalWidget({
               signalNames={signalNames}
               error={queryError}
             />
-            <DerivedTraces
-              traces={derivedTraces}
-              onChange={setDerivedTraces}
-              variables={seriesVariables}
-              errors={derivedErrors}
-            />
-            <TraceAxisControls
-              series={plottedSeries}
-              colors={seriesColors}
-              settings={axisSettings}
-              onChange={updateAxisSetting}
-            />
-            <Highlights
-              highlights={highlights}
-              onChange={setHighlights}
-              variables={seriesVariables}
-              errors={highlightErrors}
-            />
+            {/* Advanced options (T10): derived traces, per-trace y-axis
+                scaling + visibility, and highlight bands — tucked behind one
+                collapsed-by-default disclosure so the default widget is just
+                the builder + chart. The badge surfaces how many editors are
+                configured so collapsing never hides active state silently. */}
+            <div className="flex flex-col gap-3">
+              <button
+                type="button"
+                onClick={() => setAdvancedOpen((o) => !o)}
+                className="inline-flex w-fit items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {advancedOpen ? (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronRight className="h-3.5 w-3.5" />
+                )}
+                Advanced options
+                {advancedCount > 0 && (
+                  <span className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary/15 px-1 text-[10px] font-semibold text-primary">
+                    {advancedCount}
+                  </span>
+                )}
+              </button>
+              {advancedOpen && (
+                <div className="flex flex-col gap-3">
+                  <DerivedTraces
+                    traces={derivedTraces}
+                    onChange={setDerivedTraces}
+                    variables={seriesVariables}
+                    errors={derivedErrors}
+                  />
+                  <TraceAxisControls
+                    series={plottedSeries}
+                    colors={seriesColors}
+                    settings={axisSettings}
+                    onChange={updateAxisSetting}
+                  />
+                  <Highlights
+                    highlights={highlights}
+                    onChange={setHighlights}
+                    variables={seriesVariables}
+                    errors={highlightErrors}
+                  />
+                </div>
+              )}
+            </div>
           </div>
           <div className="flex items-center gap-2">
             <ChartTypeToggle value={chartType} onChange={setChartType} />

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -25,6 +25,11 @@ import {
   type Highlight,
 } from "@/components/signals/Highlights";
 import type { DerivedTrace } from "@/lib/expr";
+import {
+  downloadChartPng,
+  downloadText,
+  seriesToCsv,
+} from "@/lib/export";
 import type { ECharts } from "echarts/core";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BACKEND_URL } from "@/consts/config";
@@ -37,8 +42,8 @@ import {
   serializeQuery,
 } from "@/lib/query";
 import axios from "axios";
-import { Eye, EyeOff, Loader2, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { Download, Eye, EyeOff, Image, Loader2, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 // Same as `Rollup` — kept as a separate alias so future "interval" usage
 // (e.g. backend response metadata typing) stays expressive.
@@ -313,6 +318,28 @@ export function SignalWidget({
       [label]: { ...axisSettingFor(prev, label), ...patch },
     }));
 
+  // Keep a local handle on this widget's ECharts instance for PNG export,
+  // while still forwarding to the page's group-zoom registry. The chart hands
+  // us `null` on teardown.
+  const chartInstance = useRef<ECharts | null>(null);
+  const handleChartReady = (instance: ECharts | null) => {
+    chartInstance.current = instance;
+    onChartReady?.(instance);
+  };
+
+  // Whether there's anything to export — the export controls hide entirely
+  // when the widget has no fetched data, so they never produce an empty file.
+  const hasData = plottedSeries.length > 0;
+
+  // Export the plotted series (base + derived traces) as CSV, and the live
+  // chart as a 2x PNG. Both pull from exactly what's on screen.
+  const exportCsv = () =>
+    downloadText(seriesToCsv(plottedSeries), "signals.csv", "text/csv");
+  const exportPng = () => {
+    const inst = chartInstance.current;
+    if (inst) downloadChartPng(inst, "signals.png");
+  };
+
   return (
     <Card>
       <CardHeader className="gap-3">
@@ -345,6 +372,32 @@ export function SignalWidget({
           </div>
           <div className="flex items-center gap-2">
             <ChartTypeToggle value={chartType} onChange={setChartType} />
+            {/* Export the underlying data (CSV) and the chart image (PNG).
+                Hidden when there's nothing plotted so we never export an empty
+                file. PNG needs a live instance, so it's gated on the chart
+                being visible (not collapsed). */}
+            {hasData && (
+              <>
+                <button
+                  type="button"
+                  onClick={exportCsv}
+                  title="Export data as CSV"
+                  className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-foreground"
+                >
+                  <Download className="h-4 w-4" />
+                </button>
+                {!hidden && (
+                  <button
+                    type="button"
+                    onClick={exportPng}
+                    title="Export chart as PNG"
+                    className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-foreground"
+                  >
+                    <Image className="h-4 w-4" />
+                  </button>
+                )}
+              </>
+            )}
             <button
               type="button"
               onClick={onToggleHide}
@@ -399,7 +452,7 @@ export function SignalWidget({
               intervalSec={intervalSec}
               groupId={groupId}
               onBrushSelect={onBrushSelect}
-              onReady={onChartReady}
+              onReady={handleChartReady}
               axisConfig={axisConfig}
               highlights={highlightRanges}
             />

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -4,8 +4,8 @@ import {
 } from "@/components/signals/ChartTypeToggle";
 import { QueryBuilder } from "@/components/signals/QueryBuilder";
 import {
-  PALETTE,
   QueryChart,
+  seriesColorMap,
   seriesLabel,
   type AxisSetting,
   type Series,
@@ -15,7 +15,10 @@ import {
   computeDerivedSeries,
   DerivedTraces,
 } from "@/components/signals/DerivedTraces";
-import { TraceAxisControls } from "@/components/signals/TraceAxisControls";
+import {
+  axisSettingFor,
+  TraceAxisControls,
+} from "@/components/signals/TraceAxisControls";
 import type { DerivedTrace } from "@/lib/expr";
 import type { ECharts } from "echarts/core";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -275,12 +278,19 @@ export function SignalWidget({
     return out;
   }, [plottedSeries, axisSettings]);
 
+  // label → rendered line color, mirroring the chart's top-K reordering so the
+  // controls' swatches match the on-screen lines.
+  const seriesColors = useMemo(
+    () => seriesColorMap(plottedSeries),
+    [plottedSeries],
+  );
+
   // Patch one label's setting (merging over its current/default value).
   const updateAxisSetting = (label: string, patch: Partial<AxisSetting>) =>
-    setAxisSettings((prev) => {
-      const current = prev[label] ?? { axisGroup: "1", normalize: false };
-      return { ...prev, [label]: { ...current, ...patch } };
-    });
+    setAxisSettings((prev) => ({
+      ...prev,
+      [label]: { ...axisSettingFor(prev, label), ...patch },
+    }));
 
   return (
     <Card>
@@ -301,7 +311,7 @@ export function SignalWidget({
             />
             <TraceAxisControls
               series={plottedSeries}
-              palette={PALETTE}
+              colors={seriesColors}
               settings={axisSettings}
               onChange={updateAxisSetting}
             />

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -273,10 +273,23 @@ export function SignalWidget({
     return out;
   }, [derivedResults]);
 
-  // Base series plus any derived traces — what actually gets plotted.
+  // Base series plus any derived traces — every trace the widget knows about.
+  // This is what the trace controls list and what feeds the visibility filter.
   const plottedSeries = useMemo(
     () => [...series, ...derivedSeries],
     [series, derivedSeries],
+  );
+
+  // What actually reaches the chart: drop any trace the user has hidden (T11).
+  // Hidden traces stay fetched and keep feeding derived traces / highlights
+  // (those read the base `series`/`seriesVariables`, not this) — they're just
+  // kept off the plot. A widget with nothing hidden plots exactly as before.
+  const visibleSeries = useMemo(
+    () =>
+      plottedSeries.filter(
+        (s) => !axisSettingFor(axisSettings, seriesLabel(s.tags)).hidden,
+      ),
+    [plottedSeries, axisSettings],
   );
 
   // Evaluate every highlight condition against the fetched base series (the
@@ -297,18 +310,19 @@ export function SignalWidget({
   // reappear (e.g. a requery that brings the same group-by labels back).
   const axisConfig = useMemo(() => {
     const out: Record<string, AxisSetting> = {};
-    for (const s of plottedSeries) {
+    for (const s of visibleSeries) {
       const label = seriesLabel(s.tags);
       if (axisSettings[label]) out[label] = axisSettings[label];
     }
     return out;
-  }, [plottedSeries, axisSettings]);
+  }, [visibleSeries, axisSettings]);
 
   // label → rendered line color, mirroring the chart's top-K reordering so the
-  // controls' swatches match the on-screen lines.
+  // controls' swatches match the on-screen lines. Keyed off the visible set so
+  // a hidden trace (no line) shows a neutral swatch in its control row.
   const seriesColors = useMemo(
-    () => seriesColorMap(plottedSeries),
-    [plottedSeries],
+    () => seriesColorMap(visibleSeries),
+    [visibleSeries],
   );
 
   // Patch one label's setting (merging over its current/default value).
@@ -328,13 +342,15 @@ export function SignalWidget({
   };
 
   // Whether there's anything to export — the export controls hide entirely
-  // when the widget has no fetched data, so they never produce an empty file.
-  const hasData = plottedSeries.length > 0;
+  // when nothing's plotted (no data, or every trace hidden), so they never
+  // produce an empty file.
+  const hasData = visibleSeries.length > 0;
 
-  // Export the plotted series (base + derived traces) as CSV, and the live
-  // chart as a 2x PNG. Both pull from exactly what's on screen.
+  // Export the visible series (base + derived traces, minus hidden ones) as
+  // CSV, and the live chart as a 2x PNG. Both pull from exactly what's on
+  // screen.
   const exportCsv = () =>
-    downloadText(seriesToCsv(plottedSeries), "signals.csv", "text/csv");
+    downloadText(seriesToCsv(visibleSeries), "signals.csv", "text/csv");
   const exportPng = () => {
     const inst = chartInstance.current;
     if (inst) downloadChartPng(inst, "signals.png");
@@ -447,7 +463,7 @@ export function SignalWidget({
             </div>
           ) : (
             <QueryChart
-              series={plottedSeries}
+              series={visibleSeries}
               type={chartType}
               intervalSec={intervalSec}
               groupId={groupId}

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -20,8 +20,7 @@ import {
   TraceAxisControls,
 } from "@/components/signals/TraceAxisControls";
 import {
-  computeHighlightErrors,
-  computeHighlightRanges,
+  evaluateHighlights,
   Highlights,
   type Highlight,
 } from "@/components/signals/Highlights";
@@ -276,18 +275,13 @@ export function SignalWidget({
   );
 
   // Evaluate every highlight condition against the fetched base series (the
-  // same `sN`/friendly variable model the derived traces use), coalescing
-  // contiguous truthy buckets into inclusive index ranges the chart paints as
-  // bands. Recomputes only when the data or the highlight definitions change.
-  const highlightRanges = useMemo(
-    () => computeHighlightRanges(series, highlights),
-    [series, highlights],
-  );
-
-  // Per-highlight compile/unknown-variable errors, surfaced inline in the
-  // editor exactly like derived traces.
-  const highlightErrors = useMemo(
-    () => computeHighlightErrors(series, highlights),
+  // same `sN`/friendly variable model the derived traces use) in a single
+  // pass: contiguous truthy buckets coalesce into inclusive index ranges the
+  // chart paints as bands, and any compile/unknown-variable error is surfaced
+  // inline in the editor (like derived traces). Each condition compiles once.
+  // Recomputes only when the data or the highlight definitions change.
+  const { ranges: highlightRanges, errors: highlightErrors } = useMemo(
+    () => evaluateHighlights(series, highlights),
     [series, highlights],
   );
 

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -3,12 +3,19 @@ import {
   type ChartType,
 } from "@/components/signals/ChartTypeToggle";
 import { QueryBuilder } from "@/components/signals/QueryBuilder";
-import { QueryChart, type Series } from "@/components/signals/QueryChart";
+import {
+  PALETTE,
+  QueryChart,
+  seriesLabel,
+  type AxisSetting,
+  type Series,
+} from "@/components/signals/QueryChart";
 import {
   buildSeriesVariables,
   computeDerivedSeries,
   DerivedTraces,
 } from "@/components/signals/DerivedTraces";
+import { TraceAxisControls } from "@/components/signals/TraceAxisControls";
 import type { DerivedTrace } from "@/lib/expr";
 import type { ECharts } from "echarts/core";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -130,6 +137,14 @@ export function SignalWidget({
   // User-defined derived/expression traces, evaluated in-browser over the
   // fetched series (T5). Empty by default — zero-cost when unused.
   const [derivedTraces, setDerivedTraces] = useState<DerivedTrace[]>([]);
+  // Per-trace y-scaling settings (T8), keyed by series label. Sparse: any
+  // label absent here uses the default (shared group "1", un-normalized), so
+  // an untouched widget renders exactly as it did before this feature.
+  // Labels are stable across requery while the group-by yields the same
+  // labels, so the user's choices persist through a refetch.
+  const [axisSettings, setAxisSettings] = useState<
+    Record<string, AxisSetting>
+  >({});
   const [loadingSeries, setLoadingSeries] = useState(false);
   const [seriesMs, setSeriesMs] = useState<number | null>(null);
   const [queryError, setQueryError] = useState<
@@ -246,6 +261,27 @@ export function SignalWidget({
     [series, derivedSeries],
   );
 
+  // Narrow the (potentially stale) settings map to just the currently plotted
+  // labels before handing it to the chart. The chart already defaults any
+  // missing label, so this is mainly to keep the prop small and intentional;
+  // settings for labels no longer present simply lie dormant until they
+  // reappear (e.g. a requery that brings the same group-by labels back).
+  const axisConfig = useMemo(() => {
+    const out: Record<string, AxisSetting> = {};
+    for (const s of plottedSeries) {
+      const label = seriesLabel(s.tags);
+      if (axisSettings[label]) out[label] = axisSettings[label];
+    }
+    return out;
+  }, [plottedSeries, axisSettings]);
+
+  // Patch one label's setting (merging over its current/default value).
+  const updateAxisSetting = (label: string, patch: Partial<AxisSetting>) =>
+    setAxisSettings((prev) => {
+      const current = prev[label] ?? { axisGroup: "1", normalize: false };
+      return { ...prev, [label]: { ...current, ...patch } };
+    });
+
   return (
     <Card>
       <CardHeader className="gap-3">
@@ -262,6 +298,12 @@ export function SignalWidget({
               onChange={setDerivedTraces}
               variables={seriesVariables}
               errors={derivedErrors}
+            />
+            <TraceAxisControls
+              series={plottedSeries}
+              palette={PALETTE}
+              settings={axisSettings}
+              onChange={updateAxisSetting}
             />
           </div>
           <div className="flex items-center gap-2">
@@ -321,6 +363,7 @@ export function SignalWidget({
               groupId={groupId}
               onBrushSelect={onBrushSelect}
               onReady={onChartReady}
+              axisConfig={axisConfig}
             />
           )}
         </CardContent>

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -19,6 +19,12 @@ import {
   axisSettingFor,
   TraceAxisControls,
 } from "@/components/signals/TraceAxisControls";
+import {
+  computeHighlightErrors,
+  computeHighlightRanges,
+  Highlights,
+  type Highlight,
+} from "@/components/signals/Highlights";
 import type { DerivedTrace } from "@/lib/expr";
 import type { ECharts } from "echarts/core";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -148,6 +154,11 @@ export function SignalWidget({
   const [axisSettings, setAxisSettings] = useState<
     Record<string, AxisSetting>
   >({});
+  // Per-widget highlight conditions (T6), evaluated in-browser over the fetched
+  // series to shade the bucket ranges where each condition holds. Empty by
+  // default — zero-cost and visually identical to today when unused. Local to
+  // this widget; never broadcast across panels.
+  const [highlights, setHighlights] = useState<Highlight[]>([]);
   const [loadingSeries, setLoadingSeries] = useState(false);
   const [seriesMs, setSeriesMs] = useState<number | null>(null);
   const [queryError, setQueryError] = useState<
@@ -264,6 +275,22 @@ export function SignalWidget({
     [series, derivedSeries],
   );
 
+  // Evaluate every highlight condition against the fetched base series (the
+  // same `sN`/friendly variable model the derived traces use), coalescing
+  // contiguous truthy buckets into inclusive index ranges the chart paints as
+  // bands. Recomputes only when the data or the highlight definitions change.
+  const highlightRanges = useMemo(
+    () => computeHighlightRanges(series, highlights),
+    [series, highlights],
+  );
+
+  // Per-highlight compile/unknown-variable errors, surfaced inline in the
+  // editor exactly like derived traces.
+  const highlightErrors = useMemo(
+    () => computeHighlightErrors(series, highlights),
+    [series, highlights],
+  );
+
   // Narrow the (potentially stale) settings map to just the currently plotted
   // labels before handing it to the chart. The chart already defaults any
   // missing label, so this is mainly to keep the prop small and intentional;
@@ -314,6 +341,12 @@ export function SignalWidget({
               colors={seriesColors}
               settings={axisSettings}
               onChange={updateAxisSetting}
+            />
+            <Highlights
+              highlights={highlights}
+              onChange={setHighlights}
+              variables={seriesVariables}
+              errors={highlightErrors}
             />
           </div>
           <div className="flex items-center gap-2">
@@ -374,6 +407,7 @@ export function SignalWidget({
               onBrushSelect={onBrushSelect}
               onReady={onChartReady}
               axisConfig={axisConfig}
+              highlights={highlightRanges}
             />
           )}
         </CardContent>

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -4,6 +4,12 @@ import {
 } from "@/components/signals/ChartTypeToggle";
 import { QueryBuilder } from "@/components/signals/QueryBuilder";
 import { QueryChart, type Series } from "@/components/signals/QueryChart";
+import {
+  buildSeriesVariables,
+  computeDerivedSeries,
+  DerivedTraces,
+} from "@/components/signals/DerivedTraces";
+import type { DerivedTrace } from "@/lib/expr";
 import type { ECharts } from "echarts/core";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BACKEND_URL } from "@/consts/config";
@@ -121,6 +127,9 @@ export function SignalWidget({
   const [queryAst, setQueryAst] = useState<Query>(DEFAULT_QUERY);
   const [chartType, setChartType] = useState<ChartType>("bar");
   const [series, setSeries] = useState<Series[]>([]);
+  // User-defined derived/expression traces, evaluated in-browser over the
+  // fetched series (T5). Empty by default — zero-cost when unused.
+  const [derivedTraces, setDerivedTraces] = useState<DerivedTrace[]>([]);
   const [loadingSeries, setLoadingSeries] = useState(false);
   const [seriesMs, setSeriesMs] = useState<number | null>(null);
   const [queryError, setQueryError] = useState<
@@ -201,16 +210,58 @@ export function SignalWidget({
     return acc;
   }, [series]);
 
+  // Variable hint table (s0 = current_ac, …) shown in the derived-traces UI.
+  const seriesVariables = useMemo(
+    () => buildSeriesVariables(series),
+    [series],
+  );
+
+  // Evaluate every derived trace against the fetched series. Returns the
+  // computed Series alongside any per-trace parse/eval error. Recomputes only
+  // when the data or the trace definitions change.
+  const derivedResults = useMemo(
+    () => computeDerivedSeries(series, derivedTraces),
+    [series, derivedTraces],
+  );
+
+  // Split the results: successful series get appended to the chart input;
+  // errors are surfaced inline under their row.
+  const derivedSeries = useMemo(
+    () =>
+      derivedResults
+        .map((r) => r.series)
+        .filter((s): s is Series => s !== undefined),
+    [derivedResults],
+  );
+
+  const derivedErrors = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const r of derivedResults) if (r.error) out[r.id] = r.error;
+    return out;
+  }, [derivedResults]);
+
+  // Base series plus any derived traces — what actually gets plotted.
+  const plottedSeries = useMemo(
+    () => [...series, ...derivedSeries],
+    [series, derivedSeries],
+  );
+
   return (
     <Card>
       <CardHeader className="gap-3">
         <div className="flex items-start justify-between gap-3">
-          <div className="flex-1">
+          <div className="flex flex-1 flex-col gap-3">
             <QueryBuilder
               value={queryAst}
               onChange={setQueryAst}
               signalNames={signalNames}
               error={queryError}
+            />
+            <DerivedTraces
+              traces={derivedTraces}
+              onChange={setDerivedTraces}
+              variables={seriesVariables}
+              errors={derivedErrors}
             />
           </div>
           <div className="flex items-center gap-2">
@@ -264,7 +315,7 @@ export function SignalWidget({
             </div>
           ) : (
             <QueryChart
-              series={series}
+              series={plottedSeries}
               type={chartType}
               intervalSec={intervalSec}
               groupId={groupId}

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -4,6 +4,7 @@ import {
 } from "@/components/signals/ChartTypeToggle";
 import { QueryBuilder } from "@/components/signals/QueryBuilder";
 import { QueryChart, type Series } from "@/components/signals/QueryChart";
+import type { ECharts } from "echarts/core";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BACKEND_URL } from "@/consts/config";
 import { getAxiosErrorMessage } from "@/lib/axios-error-handler";
@@ -94,6 +95,10 @@ export interface SignalWidgetProps {
   /** Brush-select on this widget's chart bubbles up to set the shared
    *  page timeframe. */
   onBrushSelect: (start: Date, end: Date) => void;
+  /** Receives this widget's ECharts instance on ready (and `null` on
+   *  teardown) so the page can dispatch group-wide dataZoom (zoom out /
+   *  reset) through any live panel. */
+  onChartReady?: (instance: ECharts | null) => void;
 }
 
 export function SignalWidget({
@@ -108,6 +113,7 @@ export function SignalWidget({
   onToggleHide,
   onDelete,
   onBrushSelect,
+  onChartReady,
 }: SignalWidgetProps) {
   // Chart-side state: the structured query AST, the result series, the
   // chosen chart type, and a query-execution error surfaced under the
@@ -263,6 +269,7 @@ export function SignalWidget({
               intervalSec={intervalSec}
               groupId={groupId}
               onBrushSelect={onBrushSelect}
+              onReady={onChartReady}
             />
           )}
         </CardContent>

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -1,0 +1,272 @@
+import {
+  ChartTypeToggle,
+  type ChartType,
+} from "@/components/signals/ChartTypeToggle";
+import { QueryBuilder } from "@/components/signals/QueryBuilder";
+import { QueryChart, type Series } from "@/components/signals/QueryChart";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BACKEND_URL } from "@/consts/config";
+import { getAxiosErrorMessage } from "@/lib/axios-error-handler";
+import { notify } from "@/lib/notify";
+import {
+  DEFAULT_QUERY,
+  type Query,
+  type Rollup,
+  serializeQuery,
+} from "@/lib/query";
+import axios from "axios";
+import { Eye, EyeOff, Loader2, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+// Same as `Rollup` — kept as a separate alias so future "interval" usage
+// (e.g. backend response metadata typing) stays expressive.
+type Interval = Rollup;
+
+function authHeader() {
+  return {
+    Authorization: `Bearer ${localStorage.getItem("sentinel_access_token")}`,
+  };
+}
+
+// Auto-pick a bucket width based on the selected range. Targets roughly
+// 24–168 bars so the chart stays legible whether the user picks 15min or
+// 1 week. Backend's INTERVALS dict caps us at 1m on the small end and 1d
+// on the large end.
+function autoInterval(rangeSeconds: number): Interval {
+  if (rangeSeconds <= 60 * 60)          return "1m";   // ≤ 1h     → 60 bars
+  if (rangeSeconds <= 4 * 60 * 60)      return "5m";   // ≤ 4h     → 48 bars
+  if (rangeSeconds <= 24 * 60 * 60)     return "15m";  // ≤ 1d     → 96 bars
+  if (rangeSeconds <= 3 * 24 * 60 * 60) return "1h";   // ≤ 3d     → 72 bars
+  if (rangeSeconds <= 7 * 24 * 60 * 60) return "2h";   // ≤ 1w     → 84 bars
+  return "1d";
+}
+
+function intervalToSeconds(i: Interval): number {
+  switch (i) {
+    case "16ms":  return 0.016;
+    case "50ms":  return 0.05;
+    case "100ms": return 0.1;
+    case "500ms": return 0.5;
+    case "1s":  return 1;
+    case "10s": return 10;
+    case "30s": return 30;
+    case "1m":  return 60;
+    case "5m":  return 5 * 60;
+    case "15m": return 15 * 60;
+    case "30m": return 30 * 60;
+    case "1h":  return 60 * 60;
+    case "2h":  return 2 * 60 * 60;
+    case "6h":  return 6 * 60 * 60;
+    case "1d":  return 24 * 60 * 60;
+  }
+}
+
+function formatCount(n: number): string {
+  if (n < 1_000) return n.toString();
+  if (n < 1_000_000) return `${(n / 1_000).toFixed(1)}k`;
+  return `${(n / 1_000_000).toFixed(2)}M`;
+}
+
+function formatLatency(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+export interface SignalWidgetProps {
+  /** Page-level vehicle scope. */
+  vehicleId: string;
+  /** Re-run the query when the vehicle type flips (different fleet/schema). */
+  vehicleType: string;
+  /** Signal names for builder autocomplete. */
+  signalNames: string[];
+  /** Shared page timeframe — every widget plots the same window. */
+  startIso: string;
+  endIso: string;
+  rangeSeconds: number;
+  /** ECharts connection group — all widgets pass the same id so the hover
+   *  cursor + tooltip sync across panels. */
+  groupId: string;
+  /** Collapse the chart body while keeping the query config. */
+  hidden: boolean;
+  onToggleHide: () => void;
+  /** Remove this widget from the page. */
+  onDelete: () => void;
+  /** Brush-select on this widget's chart bubbles up to set the shared
+   *  page timeframe. */
+  onBrushSelect: (start: Date, end: Date) => void;
+}
+
+export function SignalWidget({
+  vehicleId,
+  vehicleType,
+  signalNames,
+  startIso,
+  endIso,
+  rangeSeconds,
+  groupId,
+  hidden,
+  onToggleHide,
+  onDelete,
+  onBrushSelect,
+}: SignalWidgetProps) {
+  // Chart-side state: the structured query AST, the result series, the
+  // chosen chart type, and a query-execution error surfaced under the
+  // builder. Each widget owns its own copy.
+  const [queryAst, setQueryAst] = useState<Query>(DEFAULT_QUERY);
+  const [chartType, setChartType] = useState<ChartType>("bar");
+  const [series, setSeries] = useState<Series[]>([]);
+  const [loadingSeries, setLoadingSeries] = useState(false);
+  const [seriesMs, setSeriesMs] = useState<number | null>(null);
+  const [queryError, setQueryError] = useState<
+    { message: string; position?: number } | null
+  >(null);
+
+  // Don't fire a request while a filter chip is still empty — the
+  // serialized query (`... where name = ""`) is technically valid but
+  // returns nothing useful, and it bombards the backend on every
+  // chip-add. Skip until every filter has a value.
+  const queryIsRunnable = queryAst.filters.every((f) => f.value.trim() !== "");
+
+  const serializedQuery = useMemo(() => serializeQuery(queryAst), [queryAst]);
+
+  // Effective interval = explicit rollup on the AST if present, else
+  // auto-picked from the timeframe width. The backend honors the same
+  // precedence; we mirror it client-side so the bucket label in the
+  // subtitle and the x-axis formatting are right *before* the response
+  // arrives (avoids a one-render flicker on rollup changes).
+  const interval = useMemo(
+    () => queryAst.rollup ?? autoInterval(rangeSeconds),
+    [queryAst.rollup, rangeSeconds],
+  );
+
+  const intervalSec = intervalToSeconds(interval);
+
+  const runQuery = async () => {
+    setLoadingSeries(true);
+    // performance.now() is monotonic and sub-ms — accurate for short
+    // requests where Date.now()'s 1ms quantization would round to 0.
+    const startedAt = performance.now();
+    try {
+      const res = await axios.post(
+        `${BACKEND_URL}/query/run`,
+        {
+          query: serializedQuery,
+          vehicle_id: vehicleId,
+          start: startIso,
+          end: endIso,
+          interval,
+        },
+        { headers: authHeader() },
+      );
+      setSeries(res.data.data?.series ?? []);
+      setSeriesMs(Math.round(performance.now() - startedAt));
+      setQueryError(null);
+    } catch (e) {
+      // Parser errors come back 400 with {message, position}; surface them
+      // under the query field and leave the previous series visible so the
+      // user can compare iterations.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const body: any = (e as any)?.response?.data?.data;
+      if (body && typeof body.message === "string") {
+        setQueryError({ message: body.message, position: body.position });
+      } else {
+        notify.error(getAxiosErrorMessage(e));
+        setQueryError({ message: getAxiosErrorMessage(e) });
+      }
+      setSeriesMs(null);
+    } finally {
+      setLoadingSeries(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!vehicleId) return;
+    if (!queryIsRunnable) return;
+    runQuery();
+    // Serialized form is the wire representation; depending on it (rather
+    // than the AST object) means the effect only fires when the query
+    // actually changes, not on every reference identity change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vehicleId, vehicleType, rangeSeconds, serializedQuery, queryIsRunnable, startIso, endIso]);
+
+  const totalSeriesValue = useMemo(() => {
+    let acc = 0;
+    for (const s of series) for (const p of s.points) acc += p.value ?? 0;
+    return acc;
+  }, [series]);
+
+  return (
+    <Card>
+      <CardHeader className="gap-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex-1">
+            <QueryBuilder
+              value={queryAst}
+              onChange={setQueryAst}
+              signalNames={signalNames}
+              error={queryError}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <ChartTypeToggle value={chartType} onChange={setChartType} />
+            <button
+              type="button"
+              onClick={onToggleHide}
+              title={hidden ? "Show chart" : "Hide chart"}
+              className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              {hidden ? (
+                <EyeOff className="h-4 w-4" />
+              ) : (
+                <Eye className="h-4 w-4" />
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={onDelete}
+              title="Delete widget"
+              className="rounded-md p-2 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+        {!hidden && (
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base">
+              {series.length > 1 ? `${series.length} series` : "Query result"}
+            </CardTitle>
+            <div className="text-sm text-muted-foreground">
+              {loadingSeries
+                ? "Loading…"
+                : [
+                    `${formatCount(totalSeriesValue)} total`,
+                    `${interval} buckets`,
+                    seriesMs !== null && formatLatency(seriesMs),
+                  ]
+                    .filter(Boolean)
+                    .join(" · ")}
+            </div>
+          </div>
+        )}
+      </CardHeader>
+      {!hidden && (
+        <CardContent>
+          {loadingSeries ? (
+            <div className="flex h-[260px] items-center justify-center">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <QueryChart
+              series={series}
+              type={chartType}
+              intervalSec={intervalSec}
+              groupId={groupId}
+              onBrushSelect={onBrushSelect}
+            />
+          )}
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/dashboard/src/components/signals/TraceAxisControls.tsx
+++ b/dashboard/src/components/signals/TraceAxisControls.tsx
@@ -1,5 +1,6 @@
 import { seriesLabel, type AxisSetting, type Series } from "./QueryChart";
 import { cn } from "@/lib/utils";
+import { Eye, EyeOff } from "lucide-react";
 
 // ---------------------------------------------------------------------------
 // Per-trace y-axis controls (T8)
@@ -27,7 +28,7 @@ export function axisSettingFor(
   settings: Record<string, AxisSetting>,
   label: string,
 ): AxisSetting {
-  return settings[label] ?? { axisGroup: "1", normalize: false };
+  return settings[label] ?? { axisGroup: "1", normalize: false, hidden: false };
 }
 
 interface TraceAxisControlsProps {
@@ -67,60 +68,97 @@ export function TraceAxisControls({
         // Match the chart's actual color (post top-K). A label rolled into
         // the "+N other" bucket has no individual line — show a neutral chip.
         const color = colors.get(label);
+        const hidden = setting.hidden ?? false;
         return (
           <div key={label} className="flex items-center gap-2">
             <span
               className={cn(
                 "h-2.5 w-2.5 shrink-0 rounded-sm",
                 !color && "bg-muted-foreground/30",
+                hidden && "opacity-40",
               )}
               style={color ? { backgroundColor: color } : undefined}
               aria-hidden
             />
-            <span className="w-32 truncate font-mono text-xs text-foreground">
+            <span
+              className={cn(
+                "w-32 truncate font-mono text-xs text-foreground",
+                hidden && "text-muted-foreground line-through",
+              )}
+            >
               {label}
             </span>
 
-            {/* Normalize toggle — when on, the row's group picker is hidden
-                since the trace lives on the shared [0,1] axis. */}
+            {/* Visibility toggle (T11) — hide the trace from the chart while it
+                stays fetched, so a signal needed only to feed a derived trace or
+                highlight can be kept out of the plot. Sits with the scaling
+                controls since it's another per-trace display choice. */}
             <button
               type="button"
-              onClick={() => onChange(label, { normalize: !setting.normalize })}
+              onClick={() => onChange(label, { hidden: !hidden })}
               className={cn(
-                "inline-flex h-6 items-center rounded-md border px-2 text-xs font-medium transition-colors",
-                setting.normalize
-                  ? "border-primary/50 bg-accent text-foreground"
-                  : "border-dashed bg-transparent text-muted-foreground hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
+                "inline-flex h-6 w-6 items-center justify-center rounded-md border transition-colors",
+                hidden
+                  ? "border-dashed border-primary/40 bg-transparent text-muted-foreground hover:bg-accent/40 hover:text-foreground"
+                  : "border-primary/50 bg-accent text-foreground",
               )}
-              title="Rescale this trace to fill the plot (min/max → 0..1)"
+              title={hidden ? "Show this trace on the chart" : "Hide this trace from the chart (keeps it for derived traces / highlights)"}
             >
-              normalize
+              {hidden ? (
+                <EyeOff className="h-3.5 w-3.5" />
+              ) : (
+                <Eye className="h-3.5 w-3.5" />
+              )}
             </button>
 
-            {/* Group picker — only meaningful for native (un-normalized)
-                traces. Hidden for normalized rows to keep the row honest. */}
-            {!setting.normalize ? (
-              <div className="flex items-center gap-1">
-                <span className="select-none text-xs text-muted-foreground/70">
-                  group
-                </span>
-                {GROUP_IDS.map((g) => (
-                  <button
-                    key={g}
-                    type="button"
-                    onClick={() => onChange(label, { axisGroup: g })}
-                    className={cn(
-                      "inline-flex h-6 w-6 items-center justify-center rounded-md border text-xs font-medium transition-colors",
-                      setting.axisGroup === g
-                        ? "border-primary/50 bg-accent text-foreground"
-                        : "border-dashed bg-transparent text-muted-foreground hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
-                    )}
-                  >
-                    {g}
-                  </button>
-                ))}
-              </div>
-            ) : null}
+            {/* Scaling controls only matter for a visible trace — drop them for
+                a hidden row to keep it honest about what applies. */}
+            {!hidden && (
+              <>
+                {/* Normalize toggle — when on, the row's group picker is hidden
+                    since the trace lives on the shared [0,1] axis. */}
+                <button
+                  type="button"
+                  onClick={() =>
+                    onChange(label, { normalize: !setting.normalize })
+                  }
+                  className={cn(
+                    "inline-flex h-6 items-center rounded-md border px-2 text-xs font-medium transition-colors",
+                    setting.normalize
+                      ? "border-primary/50 bg-accent text-foreground"
+                      : "border-dashed bg-transparent text-muted-foreground hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
+                  )}
+                  title="Rescale this trace to fill the plot (min/max → 0..1)"
+                >
+                  normalize
+                </button>
+
+                {/* Group picker — only meaningful for native (un-normalized)
+                    traces. Hidden for normalized rows to keep the row honest. */}
+                {!setting.normalize ? (
+                  <div className="flex items-center gap-1">
+                    <span className="select-none text-xs text-muted-foreground/70">
+                      group
+                    </span>
+                    {GROUP_IDS.map((g) => (
+                      <button
+                        key={g}
+                        type="button"
+                        onClick={() => onChange(label, { axisGroup: g })}
+                        className={cn(
+                          "inline-flex h-6 w-6 items-center justify-center rounded-md border text-xs font-medium transition-colors",
+                          setting.axisGroup === g
+                            ? "border-primary/50 bg-accent text-foreground"
+                            : "border-dashed bg-transparent text-muted-foreground hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
+                        )}
+                      >
+                        {g}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+              </>
+            )}
           </div>
         );
       })}

--- a/dashboard/src/components/signals/TraceAxisControls.tsx
+++ b/dashboard/src/components/signals/TraceAxisControls.tsx
@@ -34,8 +34,10 @@ interface TraceAxisControlsProps {
   /** The currently plotted series (base + derived), in palette order. The
    *  index gives each row its swatch color (mirrors QueryChart's PALETTE). */
   series: Series[];
-  /** Palette used by the chart, so swatches match the rendered lines. */
-  palette: string[];
+  /** label → rendered line color, from QueryChart's `seriesColorMap`, so each
+   *  row's swatch matches the actual on-screen line *after* top-K reordering.
+   *  Labels folded into "+N other" are absent and get a neutral swatch. */
+  colors: Map<string, string>;
   /** Current per-label settings map (sparse — missing labels are default). */
   settings: Record<string, AxisSetting>;
   /** Patch one label's setting. */
@@ -47,7 +49,7 @@ interface TraceAxisControlsProps {
  *  to configure. */
 export function TraceAxisControls({
   series,
-  palette,
+  colors,
   settings,
   onChange,
 }: TraceAxisControlsProps) {
@@ -59,15 +61,20 @@ export function TraceAxisControls({
         Y-axis scaling
       </span>
 
-      {series.map((s, i) => {
+      {series.map((s) => {
         const label = seriesLabel(s.tags);
         const setting = axisSettingFor(settings, label);
-        const color = palette[i % palette.length];
+        // Match the chart's actual color (post top-K). A label rolled into
+        // the "+N other" bucket has no individual line — show a neutral chip.
+        const color = colors.get(label);
         return (
           <div key={label} className="flex items-center gap-2">
             <span
-              className="h-2.5 w-2.5 shrink-0 rounded-sm"
-              style={{ backgroundColor: color }}
+              className={cn(
+                "h-2.5 w-2.5 shrink-0 rounded-sm",
+                !color && "bg-muted-foreground/30",
+              )}
+              style={color ? { backgroundColor: color } : undefined}
               aria-hidden
             />
             <span className="w-32 truncate font-mono text-xs text-foreground">

--- a/dashboard/src/components/signals/TraceAxisControls.tsx
+++ b/dashboard/src/components/signals/TraceAxisControls.tsx
@@ -1,0 +1,122 @@
+import { seriesLabel, type AxisSetting, type Series } from "./QueryChart";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Per-trace y-axis controls (T8)
+//
+// Each plotted series (base + derived) gets a row letting the user pick one of
+// two y-scaling behaviors:
+//   - a shared-scale *group* (native units) — every trace in the same group id
+//     shares ONE real-value axis and keeps its true relative height, or
+//   - *normalize*, which min/max-rescales just that trace to [0,1] so its peak
+//     reaches the top of the plot regardless of the other traces' magnitudes.
+//
+// Styled to match DerivedTraces' chip/sentence language: a muted section
+// label, compact rows, and a small swatch echoing the chart palette so the
+// user can tie a row back to its line.
+// ---------------------------------------------------------------------------
+
+// A small fixed set of group ids is plenty — past a handful of distinct
+// native scales the chart is unreadable anyway. These are the buttons offered
+// in each row's group picker.
+const GROUP_IDS = ["1", "2", "3"] as const;
+
+/** Resolve a series' current setting, falling back to the default (shared
+ *  group "1", un-normalized) so an untouched widget reads as today. */
+export function axisSettingFor(
+  settings: Record<string, AxisSetting>,
+  label: string,
+): AxisSetting {
+  return settings[label] ?? { axisGroup: "1", normalize: false };
+}
+
+interface TraceAxisControlsProps {
+  /** The currently plotted series (base + derived), in palette order. The
+   *  index gives each row its swatch color (mirrors QueryChart's PALETTE). */
+  series: Series[];
+  /** Palette used by the chart, so swatches match the rendered lines. */
+  palette: string[];
+  /** Current per-label settings map (sparse — missing labels are default). */
+  settings: Record<string, AxisSetting>;
+  /** Patch one label's setting. */
+  onChange: (label: string, patch: Partial<AxisSetting>) => void;
+}
+
+/** Compact editor for per-trace normalization + axis grouping. Lives below
+ *  the DerivedTraces editor. Renders nothing until there's at least one series
+ *  to configure. */
+export function TraceAxisControls({
+  series,
+  palette,
+  settings,
+  onChange,
+}: TraceAxisControlsProps) {
+  if (series.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="select-none text-xs font-medium text-muted-foreground">
+        Y-axis scaling
+      </span>
+
+      {series.map((s, i) => {
+        const label = seriesLabel(s.tags);
+        const setting = axisSettingFor(settings, label);
+        const color = palette[i % palette.length];
+        return (
+          <div key={label} className="flex items-center gap-2">
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-sm"
+              style={{ backgroundColor: color }}
+              aria-hidden
+            />
+            <span className="w-32 truncate font-mono text-xs text-foreground">
+              {label}
+            </span>
+
+            {/* Normalize toggle — when on, the row's group picker is hidden
+                since the trace lives on the shared [0,1] axis. */}
+            <button
+              type="button"
+              onClick={() => onChange(label, { normalize: !setting.normalize })}
+              className={cn(
+                "inline-flex h-6 items-center rounded-md border px-2 text-xs font-medium transition-colors",
+                setting.normalize
+                  ? "border-primary/50 bg-accent text-foreground"
+                  : "border-dashed bg-transparent text-muted-foreground hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
+              )}
+              title="Rescale this trace to fill the plot (min/max → 0..1)"
+            >
+              normalize
+            </button>
+
+            {/* Group picker — only meaningful for native (un-normalized)
+                traces. Hidden for normalized rows to keep the row honest. */}
+            {!setting.normalize ? (
+              <div className="flex items-center gap-1">
+                <span className="select-none text-xs text-muted-foreground/70">
+                  group
+                </span>
+                {GROUP_IDS.map((g) => (
+                  <button
+                    key={g}
+                    type="button"
+                    onClick={() => onChange(label, { axisGroup: g })}
+                    className={cn(
+                      "inline-flex h-6 w-6 items-center justify-center rounded-md border text-xs font-medium transition-colors",
+                      setting.axisGroup === g
+                        ? "border-primary/50 bg-accent text-foreground"
+                        : "border-dashed bg-transparent text-muted-foreground hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
+                    )}
+                  >
+                    {g}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/lib/export.ts
+++ b/dashboard/src/lib/export.ts
@@ -1,0 +1,64 @@
+import type { ECharts } from "echarts/core";
+import { seriesLabel, type Series } from "@/components/signals/QueryChart";
+
+// Trigger a browser download for an in-memory payload. Works for both a Blob
+// (CSV text) and a ready-made data URL (the PNG ECharts hands back). Object
+// URLs are revoked on the next tick so the click has time to start.
+function triggerDownload(href: string, filename: string, isObjectUrl: boolean) {
+  const a = document.createElement("a");
+  a.href = href;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  if (isObjectUrl) setTimeout(() => URL.revokeObjectURL(href), 0);
+}
+
+/** Download arbitrary text (here, CSV) as a file via a transient object URL. */
+export function downloadText(text: string, filename: string, mime: string) {
+  const blob = new Blob([text], { type: mime });
+  triggerDownload(URL.createObjectURL(blob), filename, true);
+}
+
+// Escape one CSV field: wrap in quotes and double any embedded quotes when the
+// value contains a comma, quote, or newline (RFC 4180). Plain values pass
+// through untouched so numeric columns stay clean.
+function csvField(value: string): string {
+  if (/[",\n\r]/.test(value)) return `"${value.replace(/"/g, '""')}"`;
+  return value;
+}
+
+/** Shape the plotted series into a CSV string: a leading `time` column (the
+ *  shared, server-aligned bucket ISO axis) followed by one column per series,
+ *  labeled exactly as the chart legend reads it (`seriesLabel`). The values are
+ *  the true, un-normalized bucket values — normalization is a display-only
+ *  rescale, so the export always carries real numbers. Null buckets render as
+ *  empty cells. Base series and derived/expression traces are columns alike.
+ *
+ *  Every series shares the same bucket axis (the backend zero-fills), so the
+ *  first series' buckets define the rows and the rest index-align onto them. */
+export function seriesToCsv(series: Series[]): string {
+  const buckets = series[0]?.points.map((p) => p.bucket) ?? [];
+  const header = ["time", ...series.map((s) => seriesLabel(s.tags))];
+  const rows = buckets.map((bucket, bi) => {
+    const cells = [bucket];
+    for (const s of series) {
+      const v = s.points[bi]?.value;
+      cells.push(v === null || v === undefined ? "" : String(v));
+    }
+    return cells.map(csvField).join(",");
+  });
+  return [header.map(csvField).join(","), ...rows].join("\n");
+}
+
+/** Export an ECharts instance as a PNG download. `getDataURL` renders the
+ *  current on-screen chart to a data URL at 2x for a crisp image; a white
+ *  background keeps it legible outside the app's dark theme. */
+export function downloadChartPng(instance: ECharts, filename: string) {
+  const url = instance.getDataURL({
+    type: "png",
+    pixelRatio: 2,
+    backgroundColor: "#fff",
+  });
+  triggerDownload(url, filename, false);
+}

--- a/dashboard/src/lib/expr.ts
+++ b/dashboard/src/lib/expr.ts
@@ -1,0 +1,422 @@
+// Safe expression evaluator for derived/expression traces.
+//
+// This file is intentionally free of any React or DOM imports — it's pure
+// logic so it can be unit-tested in isolation. It implements a hand-written
+// tokenizer + recursive-descent parser that compiles an expression *once*
+// into a reusable evaluator. We compile-then-evaluate because the bucket
+// axis can run to tens of thousands of points: parsing per-bucket would be
+// wasteful, but evaluating a small AST per-bucket is cheap.
+//
+// SECURITY: there is deliberately NO use of `eval`, `new Function`, or
+// `with` anywhere here. The only things an expression can reference are the
+// variables we hand it and the whitelisted functions below — nothing can
+// reach the host environment.
+
+/** A user-defined trace computed in-browser from already-fetched series. */
+export interface DerivedTrace {
+  /** Stable id (for React keys / state updates). */
+  id: string;
+  /** Display label — becomes the trace's legend/tooltip name. */
+  label: string;
+  /** The math expression over base-series variables (e.g. `current_ac^2`). */
+  expression: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer
+// ---------------------------------------------------------------------------
+
+type TokenType =
+  | "number"
+  | "ident"
+  | "op"
+  | "lparen"
+  | "rparen"
+  | "comma"
+  | "eof";
+
+interface Token {
+  type: TokenType;
+  value: string;
+  /** Column (0-based) where the token starts — used for error reporting. */
+  pos: number;
+}
+
+/** Thrown internally on a malformed expression; carries a column so the UI
+ *  can point at the offending character. Callers see this as a returned
+ *  error string, never an exception (see `compileExpression`). */
+class ParseError extends Error {
+  pos: number;
+  constructor(message: string, pos: number) {
+    super(message);
+    this.name = "ParseError";
+    this.pos = pos;
+  }
+}
+
+function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  const n = input.length;
+
+  while (i < n) {
+    const c = input[i];
+
+    // Whitespace is insignificant.
+    if (c === " " || c === "\t" || c === "\n" || c === "\r") {
+      i++;
+      continue;
+    }
+
+    // Numbers: integer or decimal. We don't support exponent notation
+    // (1e3) — it'd collide visually with the `^` operator and isn't needed
+    // for these expressions.
+    if ((c >= "0" && c <= "9") || c === ".") {
+      const start = i;
+      let seenDot = false;
+      while (i < n) {
+        const d = input[i];
+        if (d >= "0" && d <= "9") {
+          i++;
+        } else if (d === ".") {
+          if (seenDot) throw new ParseError("Malformed number", start);
+          seenDot = true;
+          i++;
+        } else {
+          break;
+        }
+      }
+      const text = input.slice(start, i);
+      if (text === ".") throw new ParseError("Malformed number", start);
+      tokens.push({ type: "number", value: text, pos: start });
+      continue;
+    }
+
+    // Identifiers: variable names and function names share the same lexical
+    // shape; the parser decides which is which by the following `(`.
+    if ((c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || c === "_") {
+      const start = i;
+      while (i < n) {
+        const d = input[i];
+        if (
+          (d >= "a" && d <= "z") ||
+          (d >= "A" && d <= "Z") ||
+          (d >= "0" && d <= "9") ||
+          d === "_"
+        ) {
+          i++;
+        } else {
+          break;
+        }
+      }
+      tokens.push({ type: "ident", value: input.slice(start, i), pos: start });
+      continue;
+    }
+
+    // Single-char operators / punctuation.
+    if (c === "+" || c === "-" || c === "*" || c === "/" || c === "^") {
+      tokens.push({ type: "op", value: c, pos: i });
+      i++;
+      continue;
+    }
+    if (c === "(") {
+      tokens.push({ type: "lparen", value: c, pos: i });
+      i++;
+      continue;
+    }
+    if (c === ")") {
+      tokens.push({ type: "rparen", value: c, pos: i });
+      i++;
+      continue;
+    }
+    if (c === ",") {
+      tokens.push({ type: "comma", value: c, pos: i });
+      i++;
+      continue;
+    }
+
+    throw new ParseError(`Unexpected character '${c}'`, i);
+  }
+
+  tokens.push({ type: "eof", value: "", pos: n });
+  return tokens;
+}
+
+// ---------------------------------------------------------------------------
+// AST
+// ---------------------------------------------------------------------------
+
+type Node =
+  | { kind: "num"; value: number }
+  | { kind: "var"; name: string; pos: number }
+  | { kind: "neg"; operand: Node }
+  | { kind: "bin"; op: "+" | "-" | "*" | "/" | "^"; left: Node; right: Node }
+  | { kind: "call"; name: string; args: Node[]; pos: number };
+
+/** Whitelisted functions and their arity. Anything not in here is a parse
+ *  error — there's no path to an arbitrary global. */
+const FUNCTIONS: Record<string, { arity: number; fn: (...a: number[]) => number }> = {
+  abs:   { arity: 1, fn: (x) => Math.abs(x) },
+  sqrt:  { arity: 1, fn: (x) => Math.sqrt(x) },
+  log:   { arity: 1, fn: (x) => Math.log10(x) },
+  ln:    { arity: 1, fn: (x) => Math.log(x) },
+  exp:   { arity: 1, fn: (x) => Math.exp(x) },
+  floor: { arity: 1, fn: (x) => Math.floor(x) },
+  ceil:  { arity: 1, fn: (x) => Math.ceil(x) },
+  round: { arity: 1, fn: (x) => Math.round(x) },
+  min:   { arity: 2, fn: (a, b) => Math.min(a, b) },
+  max:   { arity: 2, fn: (a, b) => Math.max(a, b) },
+  pow:   { arity: 2, fn: (a, b) => Math.pow(a, b) },
+};
+
+// ---------------------------------------------------------------------------
+// Parser (recursive descent)
+//
+// Grammar (lowest to highest precedence):
+//   expr    := term (('+' | '-') term)*
+//   term    := unary (('*' | '/') unary)*
+//   unary   := '-' unary | power
+//   power   := primary ('^' unary)?        // right-associative
+//   primary := number | ident | ident '(' args ')' | '(' expr ')'
+// ---------------------------------------------------------------------------
+
+class Parser {
+  private tokens: Token[];
+  private idx = 0;
+
+  constructor(tokens: Token[]) {
+    this.tokens = tokens;
+  }
+
+  private peek(): Token {
+    return this.tokens[this.idx];
+  }
+
+  private next(): Token {
+    return this.tokens[this.idx++];
+  }
+
+  parse(): Node {
+    const node = this.parseExpr();
+    const tok = this.peek();
+    if (tok.type !== "eof") {
+      throw new ParseError(`Unexpected '${tok.value}'`, tok.pos);
+    }
+    return node;
+  }
+
+  private parseExpr(): Node {
+    let left = this.parseTerm();
+    while (this.peek().type === "op" && (this.peek().value === "+" || this.peek().value === "-")) {
+      const op = this.next().value as "+" | "-";
+      const right = this.parseTerm();
+      left = { kind: "bin", op, left, right };
+    }
+    return left;
+  }
+
+  private parseTerm(): Node {
+    let left = this.parseUnary();
+    while (this.peek().type === "op" && (this.peek().value === "*" || this.peek().value === "/")) {
+      const op = this.next().value as "*" | "/";
+      const right = this.parseUnary();
+      left = { kind: "bin", op, left, right };
+    }
+    return left;
+  }
+
+  private parseUnary(): Node {
+    if (this.peek().type === "op" && this.peek().value === "-") {
+      this.next();
+      return { kind: "neg", operand: this.parseUnary() };
+    }
+    // A leading unary plus is a harmless no-op; accept it for symmetry.
+    if (this.peek().type === "op" && this.peek().value === "+") {
+      this.next();
+      return this.parseUnary();
+    }
+    return this.parsePower();
+  }
+
+  private parsePower(): Node {
+    const base = this.parsePrimary();
+    if (this.peek().type === "op" && this.peek().value === "^") {
+      this.next();
+      // Right-associative: the exponent itself parses as a unary so
+      // `2^-3` and `2^2^3` (= 2^(2^3)) work as expected.
+      const exponent = this.parseUnary();
+      return { kind: "bin", op: "^", left: base, right: exponent };
+    }
+    return base;
+  }
+
+  private parsePrimary(): Node {
+    const tok = this.peek();
+
+    if (tok.type === "number") {
+      this.next();
+      return { kind: "num", value: parseFloat(tok.value) };
+    }
+
+    if (tok.type === "lparen") {
+      this.next();
+      const inner = this.parseExpr();
+      const close = this.peek();
+      if (close.type !== "rparen") {
+        throw new ParseError("Expected ')'", close.pos);
+      }
+      this.next();
+      return inner;
+    }
+
+    if (tok.type === "ident") {
+      this.next();
+      // Function call if immediately followed by '('. Otherwise a variable.
+      if (this.peek().type === "lparen") {
+        const spec = FUNCTIONS[tok.value];
+        if (!spec) {
+          throw new ParseError(`Unknown function '${tok.value}'`, tok.pos);
+        }
+        this.next(); // consume '('
+        const args: Node[] = [];
+        if (this.peek().type !== "rparen") {
+          args.push(this.parseExpr());
+          while (this.peek().type === "comma") {
+            this.next();
+            args.push(this.parseExpr());
+          }
+        }
+        const close = this.peek();
+        if (close.type !== "rparen") {
+          throw new ParseError("Expected ')'", close.pos);
+        }
+        this.next();
+        if (args.length !== spec.arity) {
+          throw new ParseError(
+            `${tok.value}() takes ${spec.arity} argument${spec.arity === 1 ? "" : "s"}, got ${args.length}`,
+            tok.pos,
+          );
+        }
+        return { kind: "call", name: tok.value, args, pos: tok.pos };
+      }
+      return { kind: "var", name: tok.value, pos: tok.pos };
+    }
+
+    throw new ParseError(
+      tok.type === "eof" ? "Unexpected end of expression" : `Unexpected '${tok.value}'`,
+      tok.pos,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation
+// ---------------------------------------------------------------------------
+
+function evalNode(node: Node, vars: Record<string, number>): number {
+  switch (node.kind) {
+    case "num":
+      return node.value;
+    case "var": {
+      const v = vars[node.name];
+      // Unknown variable → NaN, which the chart renders as null/0. We can't
+      // catch this at compile time because the available variable set isn't
+      // known to the evaluator; the widget surfaces undefined refs instead.
+      return v === undefined ? NaN : v;
+    }
+    case "neg":
+      return -evalNode(node.operand, vars);
+    case "bin": {
+      const l = evalNode(node.left, vars);
+      const r = evalNode(node.right, vars);
+      switch (node.op) {
+        case "+": return l + r;
+        case "-": return l - r;
+        case "*": return l * r;
+        // Division by zero yields Infinity/NaN — left as-is and surfaced as
+        // a non-finite result (the compiled wrapper normalizes it).
+        case "/": return l / r;
+        case "^": return Math.pow(l, r);
+      }
+      return NaN;
+    }
+    case "call":
+      return FUNCTIONS[node.name].fn(...node.args.map((a) => evalNode(a, vars)));
+  }
+}
+
+/** A compiled, reusable expression. `variables` lists every identifier the
+ *  expression references (deduped) so callers can validate them up-front. */
+export interface CompiledExpression {
+  variables: string[];
+  /** Evaluate against a variable map. Non-finite results (div-by-zero,
+   *  unknown var, log of a negative, ...) come back as `NaN` so the chart's
+   *  null→0 handling kicks in instead of throwing. */
+  evaluate: (vars: Record<string, number>) => number;
+}
+
+export interface CompileResult {
+  ok: boolean;
+  /** Present when `ok`. */
+  compiled?: CompiledExpression;
+  /** Present when `!ok` — human-readable message and (0-based) column. */
+  error?: { message: string; position: number };
+}
+
+/** Walk the AST once to collect the set of referenced variable names. */
+function collectVars(node: Node, out: Set<string>): void {
+  switch (node.kind) {
+    case "var":
+      out.add(node.name);
+      break;
+    case "neg":
+      collectVars(node.operand, out);
+      break;
+    case "bin":
+      collectVars(node.left, out);
+      collectVars(node.right, out);
+      break;
+    case "call":
+      for (const a of node.args) collectVars(a, out);
+      break;
+    case "num":
+      break;
+  }
+}
+
+/** Compile an expression once into a reusable evaluator. Returns a result
+ *  object (never throws) — `{ ok: true, compiled }` on success or
+ *  `{ ok: false, error }` with a message + column on a parse error. */
+export function compileExpression(expression: string): CompileResult {
+  try {
+    const tokens = tokenize(expression);
+    const ast = new Parser(tokens).parse();
+
+    // An empty expression (just whitespace) tokenizes to a lone EOF; the
+    // parser rejects it as "unexpected end", which is the right message.
+
+    const varSet = new Set<string>();
+    collectVars(ast, varSet);
+
+    const compiled: CompiledExpression = {
+      variables: [...varSet],
+      evaluate: (vars) => {
+        const result = evalNode(ast, vars);
+        // Normalize ±Infinity to NaN so the chart treats every degenerate
+        // result uniformly (it coerces null/NaN → 0). Finite results pass
+        // through untouched.
+        return Number.isFinite(result) ? result : NaN;
+      },
+    };
+    return { ok: true, compiled };
+  } catch (e) {
+    if (e instanceof ParseError) {
+      return { ok: false, error: { message: e.message, position: e.pos } };
+    }
+    // Defensive — shouldn't happen, but never let a non-ParseError escape.
+    return {
+      ok: false,
+      error: { message: e instanceof Error ? e.message : "Invalid expression", position: 0 },
+    };
+  }
+}

--- a/dashboard/src/lib/expr.ts
+++ b/dashboard/src/lib/expr.ts
@@ -11,6 +11,13 @@
 // `with` anywhere here. The only things an expression can reference are the
 // variables we hand it and the whitelisted functions below — nothing can
 // reach the host environment.
+//
+// Beyond arithmetic, the grammar also supports comparison (`== != > >= < <=`,
+// with bare `=` accepted as equality) and logical (`and`/`or`, or the `&&`/`||`
+// aliases) operators that yield `1` (true) / `0` (false). These power boolean
+// *conditions* — e.g. highlight bands where `throttle = 100` — while reusing the
+// very same evaluator: a condition is just an expression whose result is read as
+// truthy (`!= 0`). NaN (div-by-zero, unknown var, …) is falsey.
 
 /** A user-defined trace computed in-browser from already-fetched series. */
 export interface DerivedTrace {
@@ -113,7 +120,35 @@ function tokenize(input: string): Token[] {
       continue;
     }
 
-    // Single-char operators / punctuation.
+    // Multi-char comparison / logical operators. Check the two-char forms
+    // before the single-char ones so `>=` doesn't lex as `>` then `=`.
+    const two = input.slice(i, i + 2);
+    if (
+      two === "==" ||
+      two === "!=" ||
+      two === ">=" ||
+      two === "<=" ||
+      two === "&&" ||
+      two === "||"
+    ) {
+      tokens.push({ type: "op", value: two, pos: i });
+      i += 2;
+      continue;
+    }
+
+    // Single-char operators / punctuation. A lone `=` is accepted as equality
+    // (friendlier for "throttle = 100") and normalized to `==` here so the
+    // parser only deals with one spelling.
+    if (c === "=") {
+      tokens.push({ type: "op", value: "==", pos: i });
+      i++;
+      continue;
+    }
+    if (c === ">" || c === "<") {
+      tokens.push({ type: "op", value: c, pos: i });
+      i++;
+      continue;
+    }
     if (c === "+" || c === "-" || c === "*" || c === "/" || c === "^") {
       tokens.push({ type: "op", value: c, pos: i });
       i++;
@@ -146,11 +181,28 @@ function tokenize(input: string): Token[] {
 // AST
 // ---------------------------------------------------------------------------
 
+/** Comparison and logical operators fold into the same `bin` node as the
+ *  arithmetic ones; `evalNode` switches on `op` to pick the semantics. */
+type BinOp =
+  | "+"
+  | "-"
+  | "*"
+  | "/"
+  | "^"
+  | "=="
+  | "!="
+  | ">"
+  | ">="
+  | "<"
+  | "<="
+  | "and"
+  | "or";
+
 type Node =
   | { kind: "num"; value: number }
   | { kind: "var"; name: string; pos: number }
   | { kind: "neg"; operand: Node }
-  | { kind: "bin"; op: "+" | "-" | "*" | "/" | "^"; left: Node; right: Node }
+  | { kind: "bin"; op: BinOp; left: Node; right: Node }
   | { kind: "call"; name: string; args: Node[]; pos: number };
 
 /** Whitelisted functions and their arity. Anything not in here is a parse
@@ -173,11 +225,21 @@ const FUNCTIONS: Record<string, { arity: number; fn: (...a: number[]) => number 
 // Parser (recursive descent)
 //
 // Grammar (lowest to highest precedence):
-//   expr    := term (('+' | '-') term)*
+//   expr    := or
+//   or      := and (('or' | '||') and)*
+//   and     := compare (('and' | '&&') compare)*
+//   compare := sum (('==' | '!=' | '>' | '>=' | '<' | '<=') sum)*
+//   sum     := term (('+' | '-') term)*
 //   term    := unary (('*' | '/') unary)*
 //   unary   := '-' unary | power
 //   power   := primary ('^' unary)?        // right-associative
 //   primary := number | ident | ident '(' args ')' | '(' expr ')'
+//
+// `and`/`or` are spelled as identifiers (the tokenizer can't tell a keyword
+// from a variable), so the parser recognizes them by value at the `or`/`and`
+// levels; `&&`/`||` are the operator-token aliases. Comparisons left-fold,
+// which is good enough for these expressions (chained `a < b < c` is unusual
+// and reads as `(a < b) < c`, matching most calculator behavior).
 // ---------------------------------------------------------------------------
 
 class Parser {
@@ -205,7 +267,59 @@ class Parser {
     return node;
   }
 
+  // The top of the precedence chain. `expr` simply enters at the lowest
+  // binding level (logical `or`) and everything cascades down from there.
   private parseExpr(): Node {
+    return this.parseOr();
+  }
+
+  /** True when the current token is the keyword `ident` (`and`/`or`). These
+   *  arrive as `ident` tokens, so we match on type+value rather than `op`. */
+  private isKeyword(word: string): boolean {
+    const t = this.peek();
+    return t.type === "ident" && t.value === word;
+  }
+
+  private parseOr(): Node {
+    let left = this.parseAnd();
+    // `or` (keyword) and `||` (operator alias) are equivalent.
+    while (this.isKeyword("or") || (this.peek().type === "op" && this.peek().value === "||")) {
+      this.next();
+      const right = this.parseAnd();
+      left = { kind: "bin", op: "or", left, right };
+    }
+    return left;
+  }
+
+  private parseAnd(): Node {
+    let left = this.parseComparison();
+    while (this.isKeyword("and") || (this.peek().type === "op" && this.peek().value === "&&")) {
+      this.next();
+      const right = this.parseComparison();
+      left = { kind: "bin", op: "and", left, right };
+    }
+    return left;
+  }
+
+  private parseComparison(): Node {
+    let left = this.parseSum();
+    while (
+      this.peek().type === "op" &&
+      (this.peek().value === "==" ||
+        this.peek().value === "!=" ||
+        this.peek().value === ">" ||
+        this.peek().value === ">=" ||
+        this.peek().value === "<" ||
+        this.peek().value === "<=")
+    ) {
+      const op = this.next().value as "==" | "!=" | ">" | ">=" | "<" | "<=";
+      const right = this.parseSum();
+      left = { kind: "bin", op, left, right };
+    }
+    return left;
+  }
+
+  private parseSum(): Node {
     let left = this.parseTerm();
     while (this.peek().type === "op" && (this.peek().value === "+" || this.peek().value === "-")) {
       const op = this.next().value as "+" | "-";
@@ -337,6 +451,19 @@ function evalNode(node: Node, vars: Record<string, number>): number {
         // a non-finite result (the compiled wrapper normalizes it).
         case "/": return l / r;
         case "^": return Math.pow(l, r);
+        // Comparisons / logicals yield 1 (true) or 0 (false). A NaN operand
+        // makes any comparison false (NaN compares false to everything),
+        // which is the behavior we want — an undefined condition isn't a hit.
+        case "==": return l === r ? 1 : 0;
+        case "!=": return l !== r ? 1 : 0;
+        case ">":  return l > r ? 1 : 0;
+        case ">=": return l >= r ? 1 : 0;
+        case "<":  return l < r ? 1 : 0;
+        case "<=": return l <= r ? 1 : 0;
+        // Truthiness = value `!= 0`. NaN is falsey (NaN !== 0 is true, so guard
+        // it explicitly). Logicals always return a clean 0/1, never the operand.
+        case "and": return l !== 0 && !Number.isNaN(l) && r !== 0 && !Number.isNaN(r) ? 1 : 0;
+        case "or":  return (l !== 0 && !Number.isNaN(l)) || (r !== 0 && !Number.isNaN(r)) ? 1 : 0;
       }
       return NaN;
     }

--- a/dashboard/src/lib/query.ts
+++ b/dashboard/src/lib/query.ts
@@ -46,6 +46,7 @@ export type GroupColumn = (typeof GROUPABLE_COLUMNS)[number];
 /** Allowed `.rollup(<interval>)` values — mirror of ROLLUP_INTERVALS in
  *  the Python parser. Order is the display order in the builder dropdown. */
 export const ROLLUP_INTERVALS = [
+  "16ms", "50ms", "100ms", "500ms",
   "1s", "10s", "30s",
   "1m", "5m", "15m", "30m",
   "1h", "2h", "6h",

--- a/dashboard/src/pages/signals/SignalsPage.tsx
+++ b/dashboard/src/pages/signals/SignalsPage.tsx
@@ -22,6 +22,7 @@ import { notify } from "@/lib/notify";
 import { useVehicle } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import axios from "axios";
+import type { ECharts } from "echarts/core";
 import Fuse from "fuse.js";
 import {
   ArrowDown,
@@ -30,8 +31,9 @@ import {
   Loader2,
   Plus,
   Search,
+  ZoomOut,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 type SortKey = "name" | "count" | "first_seen" | "last_seen";
 type SortDir = "asc" | "desc";
@@ -141,6 +143,64 @@ function SignalsPage() {
   // Single ECharts connection group shared by every widget on the page —
   // joining it syncs the hover cursor + tooltip across all panels.
   const SYNC_GROUP_ID = "signals-page";
+
+  // Live chart instances, keyed by their DOM id so add/hide/delete keep the
+  // set accurate. We dispatch group-wide dataZoom (zoom out / reset) through
+  // any one of them — `echarts.connect` rebroadcasts the action to the rest,
+  // so a single dispatch zooms every synced panel. Purely client-side: it
+  // magnifies the already-fetched buckets and fires no `/query/run`.
+  const chartInstances = useRef<Set<ECharts>>(new Set());
+
+  const onChartReady = useCallback((inst: ECharts | null) => {
+    // QueryChart calls this with the instance on init; we can't get `null`
+    // back with the same reference on teardown, so each chart re-registers
+    // on mount and we prune disposed instances at dispatch time.
+    if (inst) chartInstances.current.add(inst);
+  }, []);
+
+  // Read the current zoom window from any live chart. All synced panels share
+  // the same window, so the first non-disposed instance is authoritative.
+  const liveInstance = (): ECharts | null => {
+    for (const inst of chartInstances.current) {
+      if (inst.isDisposed()) {
+        chartInstances.current.delete(inst);
+        continue;
+      }
+      return inst;
+    }
+    return null;
+  };
+
+  // Dispatch a dataZoom window [start, end] (percent 0–100) to the group.
+  // One dispatchAction on any grouped instance is rebroadcast to all.
+  const dispatchZoom = (start: number, end: number) => {
+    const inst = liveInstance();
+    if (!inst) return;
+    inst.dispatchAction({ type: "dataZoom", start, end });
+  };
+
+  // Step the window back out: widen the current [start, end] by 2x around its
+  // center, clamped to [0, 100]. Repeated clicks walk all the way back out.
+  const zoomOut = () => {
+    const inst = liveInstance();
+    if (!inst) return;
+    const dz = (
+      inst.getOption() as {
+        dataZoom?: Array<{ start?: number; end?: number }>;
+      }
+    ).dataZoom?.[0];
+    const start = typeof dz?.start === "number" ? dz.start : 0;
+    const end = typeof dz?.end === "number" ? dz.end : 100;
+    const center = (start + end) / 2;
+    const halfWidth = (end - start) / 2;
+    const newHalf = Math.min(halfWidth * 2, 50);
+    const newStart = Math.max(0, center - newHalf);
+    const newEnd = Math.min(100, center + newHalf);
+    dispatchZoom(newStart, newEnd);
+  };
+
+  // Snap back to the full fetched window.
+  const resetZoom = () => dispatchZoom(0, 100);
 
   const addWidget = () => {
     setWidgetIds((prev) => [...prev, nextWidgetId.current++]);
@@ -282,7 +342,30 @@ function SignalsPage() {
               selected timeframe.
             </p>
           </div>
-          <TimeframePicker value={timeframe} onChange={setTimeframe} />
+          <div className="flex items-center gap-2">
+            {/* Client-side zoom controls. These magnify the already-fetched
+                buckets via ECharts dataZoom across every synced panel — no
+                requery. The brush (drag on a chart) still sets the timeframe
+                and refetches for true resolution. */}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={zoomOut}
+              title="Zoom out (widen the current view)"
+            >
+              <ZoomOut className="mr-2 h-4 w-4" />
+              Zoom out
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={resetZoom}
+              title="Reset zoom to the full queried window"
+            >
+              Reset zoom
+            </Button>
+            <TimeframePicker value={timeframe} onChange={setTimeframe} />
+          </div>
         </div>
 
         {widgetIds.map((id) => (
@@ -299,6 +382,7 @@ function SignalsPage() {
             onToggleHide={() => toggleHide(id)}
             onDelete={() => deleteWidget(id)}
             onBrushSelect={onBrushSelect}
+            onChartReady={onChartReady}
           />
         ))}
 

--- a/dashboard/src/pages/signals/SignalsPage.tsx
+++ b/dashboard/src/pages/signals/SignalsPage.tsx
@@ -80,6 +80,10 @@ function authHeader() {
 
 function intervalToSeconds(i: Interval): number {
   switch (i) {
+    case "16ms":  return 0.016;
+    case "50ms":  return 0.05;
+    case "100ms": return 0.1;
+    case "500ms": return 0.5;
     case "1s":  return 1;
     case "10s": return 10;
     case "30s": return 30;

--- a/dashboard/src/pages/signals/SignalsPage.tsx
+++ b/dashboard/src/pages/signals/SignalsPage.tsx
@@ -1,15 +1,11 @@
 import Layout from "@/components/Layout";
-import {
-  ChartTypeToggle,
-  type ChartType,
-} from "@/components/signals/ChartTypeToggle";
-import { QueryBuilder } from "@/components/signals/QueryBuilder";
-import { QueryChart, type Series } from "@/components/signals/QueryChart";
+import { SignalWidget } from "@/components/signals/SignalWidget";
 import {
   defaultTimeframe,
   type Timeframe,
   TimeframePicker,
 } from "@/components/signals/TimeframePicker";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
@@ -23,22 +19,19 @@ import {
 import { BACKEND_URL } from "@/consts/config";
 import { getAxiosErrorMessage } from "@/lib/axios-error-handler";
 import { notify } from "@/lib/notify";
-import {
-  DEFAULT_QUERY,
-  type Query,
-  type Rollup,
-  serializeQuery,
-} from "@/lib/query";
 import { useVehicle } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import axios from "axios";
 import Fuse from "fuse.js";
-import { ArrowDown, ArrowUp, ArrowUpDown, Loader2, Search } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-
-// Same as `Rollup` — kept as a separate alias so future "interval" usage
-// (e.g. backend response metadata typing) stays expressive.
-type Interval = Rollup;
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Loader2,
+  Plus,
+  Search,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type SortKey = "name" | "count" | "first_seen" | "last_seen";
 type SortDir = "asc" | "desc";
@@ -51,19 +44,6 @@ const DEFAULT_DIR: Record<SortKey, SortDir> = {
   first_seen: "desc",
   last_seen: "desc",
 };
-
-// Auto-pick a bucket width based on the selected range. Targets roughly
-// 24–168 bars so the chart stays legible whether the user picks 15min or
-// 1 week. Backend's INTERVALS dict caps us at 1m on the small end and 1d
-// on the large end.
-function autoInterval(rangeSeconds: number): Interval {
-  if (rangeSeconds <= 60 * 60)          return "1m";   // ≤ 1h     → 60 bars
-  if (rangeSeconds <= 4 * 60 * 60)      return "5m";   // ≤ 4h     → 48 bars
-  if (rangeSeconds <= 24 * 60 * 60)     return "15m";  // ≤ 1d     → 96 bars
-  if (rangeSeconds <= 3 * 24 * 60 * 60) return "1h";   // ≤ 3d     → 72 bars
-  if (rangeSeconds <= 7 * 24 * 60 * 60) return "2h";   // ≤ 1w     → 84 bars
-  return "1d";
-}
 
 interface SignalRow {
   name: string;
@@ -78,35 +58,10 @@ function authHeader() {
   };
 }
 
-function intervalToSeconds(i: Interval): number {
-  switch (i) {
-    case "16ms":  return 0.016;
-    case "50ms":  return 0.05;
-    case "100ms": return 0.1;
-    case "500ms": return 0.5;
-    case "1s":  return 1;
-    case "10s": return 10;
-    case "30s": return 30;
-    case "1m":  return 60;
-    case "5m":  return 5 * 60;
-    case "15m": return 15 * 60;
-    case "30m": return 30 * 60;
-    case "1h":  return 60 * 60;
-    case "2h":  return 2 * 60 * 60;
-    case "6h":  return 6 * 60 * 60;
-    case "1d":  return 24 * 60 * 60;
-  }
-}
-
 function formatCount(n: number): string {
   if (n < 1_000) return n.toString();
   if (n < 1_000_000) return `${(n / 1_000).toFixed(1)}k`;
   return `${(n / 1_000_000).toFixed(2)}M`;
-}
-
-function formatLatency(ms: number): string {
-  if (ms < 1000) return `${ms}ms`;
-  return `${(ms / 1000).toFixed(2)}s`;
 }
 
 function formatAbsolute(iso: string | null): string {
@@ -172,39 +127,46 @@ function SignalsPage() {
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
-  // Chart-side state: the structured query AST, the result series, the
-  // chosen chart type, and a query-execution error surfaced under the
-  // builder.
-  const [queryAst, setQueryAst] = useState<Query>(DEFAULT_QUERY);
-  const [chartType, setChartType] = useState<ChartType>("bar");
-  const [series, setSeries] = useState<Series[]>([]);
-  const [loadingSeries, setLoadingSeries] = useState(false);
-  const [seriesMs, setSeriesMs] = useState<number | null>(null);
-  const [queryError, setQueryError] = useState<
-    { message: string; position?: number } | null
-  >(null);
+  // Stacked chart widgets. Each descriptor is just an identity — all of
+  // the per-chart state (query AST, chart type, fetched series, loading /
+  // error / latency) lives inside the SignalWidget component. Seed with one
+  // so the page opens to exactly the old single-chart experience.
+  const [widgetIds, setWidgetIds] = useState<number[]>(() => [0]);
+  const [hiddenIds, setHiddenIds] = useState<Set<number>>(() => new Set());
+  // Monotonic counter for stable widget keys across add/delete. A ref (not
+  // state) so it never goes stale within a render and double-clicks can't
+  // mint the same id.
+  const nextWidgetId = useRef(1);
 
-  // Don't fire a request while a filter chip is still empty — the
-  // serialized query (`... where name = ""`) is technically valid but
-  // returns nothing useful, and it bombards the backend on every
-  // chip-add. Skip until every filter has a value.
-  const queryIsRunnable =
-    queryAst.filters.every((f) => f.value.trim() !== "");
+  // Single ECharts connection group shared by every widget on the page —
+  // joining it syncs the hover cursor + tooltip across all panels.
+  const SYNC_GROUP_ID = "signals-page";
 
-  const serializedQuery = useMemo(() => serializeQuery(queryAst), [queryAst]);
+  const addWidget = () => {
+    setWidgetIds((prev) => [...prev, nextWidgetId.current++]);
+  };
+
+  const deleteWidget = (id: number) => {
+    setWidgetIds((prev) => prev.filter((w) => w !== id));
+    setHiddenIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  };
+
+  const toggleHide = (id: number) => {
+    setHiddenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   const rangeSeconds = useMemo(
     () => (timeframe.end.getTime() - timeframe.start.getTime()) / 1000,
     [timeframe],
-  );
-  // Effective interval = explicit rollup on the AST if present, else
-  // auto-picked from the timeframe width. The backend honors the same
-  // precedence; we mirror it client-side so the bucket label in the
-  // subtitle and the x-axis formatting are right *before* the response
-  // arrives (avoids a one-render flicker on rollup changes).
-  const interval = useMemo(
-    () => queryAst.rollup ?? autoInterval(rangeSeconds),
-    [queryAst.rollup, rangeSeconds],
   );
 
   // ISO strings drive the fetch effects; deriving via Date.getTime() means
@@ -213,27 +175,20 @@ function SignalsPage() {
   const startIso = useMemo(() => timeframe.start.toISOString(), [timeframe]);
   const endIso = useMemo(() => timeframe.end.toISOString(), [timeframe]);
 
-  // Brush-select callback for the chart. Always lands as "Custom" since
-  // the user drew it themselves; presets re-snap to now when clicked.
+  // Brush-select callback shared by every widget's chart. Whichever panel
+  // the user drags on sets the page timeframe and all widgets refetch.
+  // Always lands as "Custom" since the user drew it themselves; presets
+  // re-snap to now when clicked.
   const onBrushSelect = (start: Date, end: Date) => {
     setTimeframe({ start, end, label: "Custom" });
   };
 
-  // Two independent effects so the table doesn't refetch every time the
-  // user iterates on the query or scrubs the timeframe.
+  // The table doesn't refetch every time the user iterates on a query or
+  // scrubs the timeframe — only on vehicle change.
   useEffect(() => {
     if (!vehicle.id) return;
     fetchSignals();
   }, [vehicle.id, vehicle.type]);
-
-  useEffect(() => {
-    if (!vehicle.id) return;
-    if (!queryIsRunnable) return;
-    runQuery();
-    // Serialized form is the wire representation; depending on it (rather
-    // than the AST object) means the effect only fires when the query
-    // actually changes, not on every reference identity change.
-  }, [vehicle.id, vehicle.type, rangeSeconds, serializedQuery, queryIsRunnable]);
 
   // Kerbecs wraps every upstream response in
   //   { status, ping, gateway, service, timestamp, data: <upstream-body> }
@@ -258,52 +213,6 @@ function SignalsPage() {
       setLoadingSignals(false);
     }
   };
-
-  const runQuery = async () => {
-    setLoadingSeries(true);
-    // performance.now() is monotonic and sub-ms — accurate for short
-    // requests where Date.now()'s 1ms quantization would round to 0.
-    const startedAt = performance.now();
-    try {
-      const res = await axios.post(
-        `${BACKEND_URL}/query/run`,
-        {
-          query: serializedQuery,
-          vehicle_id: vehicle.id,
-          start: startIso,
-          end: endIso,
-          interval,
-        },
-        { headers: authHeader() },
-      );
-      setSeries(res.data.data?.series ?? []);
-      setSeriesMs(Math.round(performance.now() - startedAt));
-      setQueryError(null);
-    } catch (e) {
-      // Parser errors come back 400 with {message, position}; surface them
-      // under the query field and leave the previous series visible so the
-      // user can compare iterations.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const body: any = (e as any)?.response?.data?.data;
-      if (body && typeof body.message === "string") {
-        setQueryError({ message: body.message, position: body.position });
-      } else {
-        notify.error(getAxiosErrorMessage(e));
-        setQueryError({ message: getAxiosErrorMessage(e) });
-      }
-      setSeriesMs(null);
-    } finally {
-      setLoadingSeries(false);
-    }
-  };
-
-  const intervalSec = intervalToSeconds(interval);
-
-  const totalSeriesValue = useMemo(() => {
-    let acc = 0;
-    for (const s of series) for (const p of s.points) acc += p.value ?? 0;
-    return acc;
-  }, [series]);
 
   // Rebuild the Fuse index only when the signal list changes — searching
   // is cheap, indexing isn't. Threshold 0.3 forgives typos and missing
@@ -376,53 +285,29 @@ function SignalsPage() {
           <TimeframePicker value={timeframe} onChange={setTimeframe} />
         </div>
 
-        <Card>
-          <CardHeader className="gap-3">
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex-1">
-                <QueryBuilder
-                  value={queryAst}
-                  onChange={setQueryAst}
-                  signalNames={signals.map((s) => s.name)}
-                  error={queryError}
-                />
-              </div>
-              <ChartTypeToggle value={chartType} onChange={setChartType} />
-            </div>
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-base">
-                {series.length > 1
-                  ? `${series.length} series`
-                  : "Query result"}
-              </CardTitle>
-              <div className="text-sm text-muted-foreground">
-                {loadingSeries
-                  ? "Loading…"
-                  : [
-                      `${formatCount(totalSeriesValue)} total`,
-                      `${interval} buckets`,
-                      seriesMs !== null && formatLatency(seriesMs),
-                    ]
-                      .filter(Boolean)
-                      .join(" · ")}
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {loadingSeries ? (
-              <div className="flex h-[260px] items-center justify-center">
-                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-              </div>
-            ) : (
-              <QueryChart
-                series={series}
-                type={chartType}
-                intervalSec={intervalSec}
-                onBrushSelect={onBrushSelect}
-              />
-            )}
-          </CardContent>
-        </Card>
+        {widgetIds.map((id) => (
+          <SignalWidget
+            key={id}
+            vehicleId={vehicle.id}
+            vehicleType={vehicle.type}
+            signalNames={signals.map((s) => s.name)}
+            startIso={startIso}
+            endIso={endIso}
+            rangeSeconds={rangeSeconds}
+            groupId={SYNC_GROUP_ID}
+            hidden={hiddenIds.has(id)}
+            onToggleHide={() => toggleHide(id)}
+            onDelete={() => deleteWidget(id)}
+            onBrushSelect={onBrushSelect}
+          />
+        ))}
+
+        <div>
+          <Button variant="outline" onClick={addWidget}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add widget
+          </Button>
+        </div>
 
         <Card>
           <CardHeader>

--- a/query/query/service/query_exec.py
+++ b/query/query/service/query_exec.py
@@ -95,7 +95,7 @@ def run_query(
             f"must be one of {list(INTERVALS)}"
         )
 
-    interval_expr, step_seconds = INTERVALS[effective_interval]
+    interval_expr, step_ms = INTERVALS[effective_interval]
 
     agg_sql = _FN_SQL[q.fn].format(field=q.field)
 
@@ -136,7 +136,7 @@ def run_query(
         group_by=q.group_by,
         start=start,
         end=end,
-        step_seconds=step_seconds,
+        step_ms=step_ms,
     )
     return {"series": series, "interval": effective_interval}
 
@@ -146,7 +146,7 @@ def _shape_response(
     group_by: tuple[str, ...],
     start: datetime,
     end: datetime,
-    step_seconds: int,
+    step_ms: int,
 ) -> list[dict[str, Any]]:
     """Pivot ClickHouse rows into the multi-series response shape.
 
@@ -158,7 +158,7 @@ def _shape_response(
     """
     # Quantize start/end to bucket boundaries so the fill axis lines up
     # with whatever ClickHouse returned.
-    expected_buckets = _bucket_axis(start, end, step_seconds)
+    expected_buckets = _bucket_axis(start, end, step_ms)
 
     # Group rows by their series tags
     by_series: dict[tuple, dict[datetime, float]] = {}
@@ -194,15 +194,18 @@ def _shape_response(
 
 
 def _bucket_axis(
-    start: datetime, end: datetime, step_seconds: int
+    start: datetime, end: datetime, step_ms: int
 ) -> list[datetime]:
-    step = timedelta(seconds=step_seconds)
+    # Work in integer milliseconds since the epoch so sub-second steps
+    # (down to 16 ms) stay exact — float seconds would drift and collapse
+    # adjacent buckets. This mirrors toStartOfInterval's flooring.
+    step = timedelta(milliseconds=step_ms)
+    epoch = datetime(1970, 1, 1, tzinfo=start.tzinfo)
     # Round `start` down to the nearest bucket boundary so the first
     # bucket in our axis matches what ClickHouse produced.
-    epoch = datetime(1970, 1, 1, tzinfo=start.tzinfo)
-    offset = (start - epoch).total_seconds()
-    aligned_offset = int(offset // step_seconds) * step_seconds
-    aligned = epoch + timedelta(seconds=aligned_offset)
+    offset_ms = (start - epoch).total_seconds() * 1000
+    aligned_offset_ms = (int(offset_ms) // step_ms) * step_ms
+    aligned = epoch + timedelta(milliseconds=aligned_offset_ms)
 
     buckets: list[datetime] = []
     t = aligned

--- a/query/query/service/query_lang.py
+++ b/query/query/service/query_lang.py
@@ -53,6 +53,7 @@ GROUPABLE_COLUMNS = {"name"}
 # because the grammar references them — the executor's INTERVALS map keys
 # off this list to wire each name to its ClickHouse INTERVAL clause.
 ROLLUP_INTERVALS: tuple[str, ...] = (
+    "16ms", "50ms", "100ms", "500ms",
     "1s", "10s", "30s",
     "1m", "5m", "15m", "30m",
     "1h", "2h", "6h",
@@ -96,7 +97,7 @@ _TOKEN_RX = re.compile(
     r"""
       (?P<ws>\s+)
     | (?P<string>"(?:[^"\\]|\\.)*")
-    | (?P<interval>\d+[smhd])
+    | (?P<interval>\d+(?:ms|[smhd]))
     | (?P<ident>[A-Za-z_][A-Za-z0-9_]*)
     | (?P<punct>[().=,])
     """,

--- a/query/query/service/signals.py
+++ b/query/query/service/signals.py
@@ -34,20 +34,33 @@ def utc_iso(dt: datetime | None) -> str | None:
 # Bucket widths offered by /signals/counts. The value is the ClickHouse
 # INTERVAL spec that's plugged into both toStartOfInterval and toInterval*.
 # Picking a sensible default for a given timeframe is the caller's job.
+#
+# Step is stored in *milliseconds* (int) rather than seconds so sub-second
+# rollups (down to one 60 Hz sample, ~16 ms) stay exact integers — a float
+# `step_seconds` would round-trip badly through the WITH FILL step and the
+# Python zero-fill axis. Consumers that want seconds divide by 1000.0.
+#
+# produced_at is DateTime64(6, 'UTC') (microsecond precision), so
+# toStartOfInterval(produced_at, INTERVAL n MILLISECOND) buckets at
+# sub-second resolution natively — no intDiv-on-epoch fallback needed.
 INTERVALS: dict[str, tuple[str, int]] = {
-    # name: (INTERVAL clause, step seconds). Order is significant — used
-    # by the frontend to render the rollup dropdown in ascending order.
-    "1s":  ("INTERVAL 1 SECOND",   1),
-    "10s": ("INTERVAL 10 SECOND",  10),
-    "30s": ("INTERVAL 30 SECOND",  30),
-    "1m":  ("INTERVAL 1 MINUTE",   60),
-    "5m":  ("INTERVAL 5 MINUTE",   5 * 60),
-    "15m": ("INTERVAL 15 MINUTE",  15 * 60),
-    "30m": ("INTERVAL 30 MINUTE",  30 * 60),
-    "1h":  ("INTERVAL 1 HOUR",     60 * 60),
-    "2h":  ("INTERVAL 2 HOUR",     2 * 60 * 60),
-    "6h":  ("INTERVAL 6 HOUR",     6 * 60 * 60),
-    "1d":  ("INTERVAL 1 DAY",      24 * 60 * 60),
+    # name: (INTERVAL clause, step milliseconds). Order is significant —
+    # used by the frontend to render the rollup dropdown in ascending order.
+    "16ms":  ("INTERVAL 16 MILLISECOND",  16),
+    "50ms":  ("INTERVAL 50 MILLISECOND",  50),
+    "100ms": ("INTERVAL 100 MILLISECOND", 100),
+    "500ms": ("INTERVAL 500 MILLISECOND", 500),
+    "1s":  ("INTERVAL 1 SECOND",   1_000),
+    "10s": ("INTERVAL 10 SECOND",  10_000),
+    "30s": ("INTERVAL 30 SECOND",  30_000),
+    "1m":  ("INTERVAL 1 MINUTE",   60_000),
+    "5m":  ("INTERVAL 5 MINUTE",   5 * 60_000),
+    "15m": ("INTERVAL 15 MINUTE",  15 * 60_000),
+    "30m": ("INTERVAL 30 MINUTE",  30 * 60_000),
+    "1h":  ("INTERVAL 1 HOUR",     60 * 60_000),
+    "2h":  ("INTERVAL 2 HOUR",     2 * 60 * 60_000),
+    "6h":  ("INTERVAL 6 HOUR",     6 * 60 * 60_000),
+    "1d":  ("INTERVAL 1 DAY",      24 * 60 * 60_000),
 }
 
 
@@ -107,7 +120,7 @@ def signal_counts(
             f"invalid interval '{interval}', must be one of {list(INTERVALS)}"
         )
 
-    interval_expr, step_seconds = INTERVALS[interval]
+    interval_expr, step_ms = INTERVALS[interval]
     where = [
         "vehicle_id = {vehicle_id:String}",
         "produced_at >= {start:DateTime64(6)}",
@@ -132,7 +145,7 @@ def signal_counts(
         ORDER BY bucket WITH FILL
             FROM toStartOfInterval({{start:DateTime64(6)}}, {interval_expr})
             TO   toStartOfInterval({{end:DateTime64(6)}},   {interval_expr})
-            STEP toIntervalSecond({step_seconds})
+            STEP toIntervalMillisecond({step_ms})
     """
     result = get_clickhouse().query(sql, parameters=params)
     return [


### PR DESCRIPTION
## Signals Page Overhaul

Rebuilds the Signals page into a multi-panel, ECharts-based analysis surface. **Additive** — all existing behavior (chip grouping, bar/line/area toggle, brush-select timeframe, top-K rollup, signal discovery table) keeps working. Locked decisions: ECharts (canvas), cleaner chip builder over the same MQL AST, frontend-computed derived traces + highlights, stacked panels with a shared/synced time axis.

### What's in it (one commit per task)
- **T1 — Sub-second binning** (`0cc4601`): adds 16/50/100/500ms rollups; backend uses native CH `INTERVAL n MILLISECOND` / ms-epoch `intDiv`, frontend mirror + auto-interval picker.
- **T2 — Recharts → ECharts** (`1660347`): canvas renderer; preserves bar/line/area, brush-select, top-K "+N other", tooltip, palette, null handling; drops the 20k-point confirm gate.
- **T3 — Stacked multi-widget layout** (`dc32f0d`): one chart → ordered list of widgets, each owning its own query; add/delete/hide; synced cursor + brush via `echarts.connect`.
- **T4 — Cleaner chip query builder** (`94458f6`): sentence-style clauses (Show…of…where…grouped by…every…), same MQL AST, no grammar change.
- **T9 — Client-side zoom / reset** (`ea79fdc`): in-chart wheel `dataZoom` with zoom-out / reset, synced across panels, no requery.
- **T5 — Derived/expression traces** (`ba116c9`): safe in-browser evaluator (`lib/expr.ts`, no `eval`); derived series render as non-stacked lines, exempt from stack + top-K.
- **T8 — Per-trace normalization + shared-scale groups** (`787264d`): y-scale groups, normalize-to-fit per trace, multiple `yAxis`; tooltip still shows true values.
- **T6 — Highlight regions** (`e83a1ea`): condition-based `markArea` bands spanning the stacked panels, shared compile pass with traces.
- **T7 — Export** (`3f97aa1`): per-widget CSV (true values) + PNG via `getDataURL`.
- **T11 — Per-trace visibility toggle** (`92efee3`): hide a fetched signal from the chart while keeping it available for derived traces / highlights.
- **T10 — Advanced options disclosure** (`cfbde70`): tucks derived/normalize/highlights editors behind one collapsed-by-default toggle with an "active" count badge; builder + chart-type + export + hide/delete stay visible.

### Testing
`tsc` / `eslint` clean throughout. Frontend tasks still want a live-ClickHouse browser smoke test (per-row notes in `SIGNALS-OVERHAUL.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
