### PR TITLE
feat(signals): integrate sessions and polish chart controls

### DIFF
--- a/dashboard/src/components/signals/ChartTypeToggle.tsx
+++ b/dashboard/src/components/signals/ChartTypeToggle.tsx
@@ -5,12 +5,10 @@ import {
 } from "@/components/ui/popover";
 import {
   CHART_TYPES,
-  CHART_TYPE_MAP,
-  INLINE_CHART_TYPES,
   type ChartType,
 } from "@/components/signals/chartTypes";
 import { cn } from "@/lib/utils";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Shapes } from "lucide-react";
 import { useState } from "react";
 
 export type { ChartType };
@@ -21,93 +19,58 @@ interface ChartTypeSelectProps {
   className?: string;
 }
 
-/** The chart-type picker: the primary types (bar/line/area) render as inline
- *  icon buttons; a chevron opens a popover listing EVERY type (the inline three
- *  included) as a grid of labeled icons. The chevron shows the active dropdown
- *  type's icon so a non-inline selection stays visible without opening it. */
+/** The chart-type picker: a single labeled "Traces" trigger opens a popover
+ *  listing EVERY type as a grid of labeled icons. */
 export function ChartTypeSelect({
   value,
   onChange,
   className,
 }: ChartTypeSelectProps) {
   const [open, setOpen] = useState(false);
-  const activeDef = CHART_TYPE_MAP[value];
-  const dropdownActive = !activeDef.inline;
-  const TriggerIcon = dropdownActive ? activeDef.icon : ChevronDown;
 
   return (
-    <div
-      className={cn(
-        "inline-flex items-center gap-0.5 rounded-md border bg-background p-1",
-        className,
-      )}
-      role="group"
-    >
-      {INLINE_CHART_TYPES.map(({ type, icon: Icon, label }) => {
-        const active = value === type;
-        return (
-          <button
-            key={type}
-            type="button"
-            title={label}
-            onClick={() => onChange(type)}
-            className={cn(
-              "flex h-7 w-8 items-center justify-center rounded-sm text-muted-foreground transition-colors",
-              active
-                ? "bg-accent text-foreground"
-                : "hover:bg-accent/50 hover:text-foreground",
-            )}
-          >
-            <Icon className="h-4 w-4" />
-          </button>
-        );
-      })}
-
-      <div className="mx-0.5 h-5 w-px bg-border" aria-hidden />
-
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            title="More chart types"
-            className={cn(
-              "flex h-7 w-8 items-center justify-center rounded-sm text-muted-foreground outline-none transition-colors focus-visible:ring-1 focus-visible:ring-ring",
-              dropdownActive
-                ? "bg-accent text-foreground"
-                : "hover:bg-accent/50 hover:text-foreground",
-            )}
-          >
-            <TriggerIcon className="h-4 w-4" />
-          </button>
-        </PopoverTrigger>
-        <PopoverContent className="w-auto p-2" align="end">
-          <div className="grid grid-cols-4 gap-1">
-            {CHART_TYPES.map(({ type, icon: Icon, label }) => {
-              const active = value === type;
-              return (
-                <button
-                  key={type}
-                  type="button"
-                  title={label}
-                  onClick={() => {
-                    onChange(type);
-                    setOpen(false);
-                  }}
-                  className={cn(
-                    "flex h-16 w-16 flex-col items-center justify-center gap-1.5 rounded-md text-[11px] font-medium leading-none text-muted-foreground transition-colors",
-                    active
-                      ? "bg-accent text-foreground"
-                      : "hover:bg-accent/50 hover:text-foreground",
-                  )}
-                >
-                  <Icon className="h-5 w-5 shrink-0" />
-                  <span>{label}</span>
-                </button>
-              );
-            })}
-          </div>
-        </PopoverContent>
-      </Popover>
-    </div>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          title="Chart type"
+          className={cn(
+            "inline-flex h-8 items-center gap-1 rounded-md border bg-background px-2.5 text-xs font-medium text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring",
+            className,
+          )}
+        >
+          <Shapes className="h-4 w-4" />
+          <span>Traces</span>
+          <ChevronDown className="h-3 w-3 opacity-50" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-2" align="end">
+        <div className="grid grid-cols-4 gap-1">
+          {CHART_TYPES.map(({ type, icon: Icon, label }) => {
+            const active = value === type;
+            return (
+              <button
+                key={type}
+                type="button"
+                title={label}
+                onClick={() => {
+                  onChange(type);
+                  setOpen(false);
+                }}
+                className={cn(
+                  "flex h-16 w-16 flex-col items-center justify-center gap-1.5 rounded-md text-[11px] font-medium leading-none text-muted-foreground transition-colors",
+                  active
+                    ? "bg-accent text-foreground"
+                    : "hover:bg-accent/50 hover:text-foreground",
+                )}
+              >
+                <Icon className="h-5 w-5 shrink-0" />
+                <span>{label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/dashboard/src/components/signals/DerivedTraces.tsx
+++ b/dashboard/src/components/signals/DerivedTraces.tsx
@@ -61,9 +61,19 @@ export interface SeriesEvaluator {
   evalAt?: (bucketIndex: number) => number;
 }
 
+/** An additional per-bucket variable source merged into the evaluator's vars,
+ *  beyond the base-series aliases. Its `names` are added to the known-variable
+ *  set (so referencing them passes validation) and `valueAt(i)` supplies their
+ *  values at bucket index `i`. Powers the `lap` pseudo-variable in highlights. */
+export interface ExtraVariables {
+  names: string[];
+  valueAt: (bucketIndex: number) => Record<string, number>;
+}
+
 export function compileAgainstSeries(
   expression: string,
   series: Series[],
+  extra?: ExtraVariables,
 ): SeriesEvaluator {
   const result = compileExpression(expression);
   if (!result.ok || !result.compiled) {
@@ -85,6 +95,7 @@ export function compileAgainstSeries(
     known.add(v.index);
     if (v.friendly) known.add(v.friendly);
   }
+  if (extra) for (const name of extra.names) known.add(name);
   const unknown = result.compiled.variables.filter((v) => !known.has(v));
   if (unknown.length > 0) {
     return {
@@ -103,6 +114,7 @@ export function compileAgainstSeries(
       const friendly = variables[si].friendly;
       if (friendly) vars[friendly] = value;
     }
+    if (extra) Object.assign(vars, extra.valueAt(i));
     return compiled.evaluate(vars);
   };
 

--- a/dashboard/src/components/signals/ExportDialog.tsx
+++ b/dashboard/src/components/signals/ExportDialog.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { Series } from "@/components/signals/QueryChart";
+import { seriesLabel, type Series } from "@/components/signals/QueryChart";
 import {
   copyChartToClipboard,
   downloadChartPng,
@@ -78,11 +78,24 @@ export function ExportDialog({
   const [bg, setBg] = useState<BgKey>("light");
   const [scale, setScale] = useState("2");
   const [includeHidden, setIncludeHidden] = useState(false);
+  const [includeHeaders, setIncludeHeaders] = useState(true);
+  const [includeLabels, setIncludeLabels] = useState(false);
 
   // Image export needs a live instance, which a collapsed chart doesn't have.
   const imageDisabled = chartHidden || !getInstance();
 
   const safeName = filename.trim() || defaultFilename;
+
+  // Title is the export filename; x is the shared time bucket axis, and y is
+  // the lone series label when unambiguous, else a generic "value".
+  const chartLabels = () => ({
+    title: safeName,
+    xName: "time",
+    yName:
+      visibleSeries.length === 1
+        ? seriesLabel(visibleSeries[0].tags)
+        : "value",
+  });
 
   const downloadPng = () => {
     const inst = getInstance();
@@ -90,16 +103,21 @@ export function ExportDialog({
     downloadChartPng(inst, `${safeName}.png`, {
       backgroundColor: resolveBackground(bg),
       pixelRatio: Number(scale),
+      labels: includeLabels ? chartLabels() : undefined,
     });
   };
 
   const dataSeries = includeHidden ? allSeries : visibleSeries;
 
   const downloadCsv = () =>
-    downloadText(seriesToCsv(dataSeries), `${safeName}.csv`, "text/csv");
+    downloadText(
+      seriesToCsv(dataSeries, includeHeaders),
+      `${safeName}.csv`,
+      "text/csv",
+    );
   const downloadJson = () =>
     downloadText(
-      seriesToJson(dataSeries),
+      seriesToJson(dataSeries, includeHeaders),
       `${safeName}.json`,
       "application/json",
     );
@@ -110,6 +128,7 @@ export function ExportDialog({
     try {
       await copyChartToClipboard(inst, {
         backgroundColor: resolveBackground(bg),
+        labels: includeLabels ? chartLabels() : undefined,
       });
       toast.success("Chart copied to clipboard");
     } catch {
@@ -200,6 +219,16 @@ export function ExportDialog({
                 Copy to clipboard
               </Button>
             </div>
+            <label className="flex w-fit cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={includeLabels}
+                onChange={(e) => setIncludeLabels(e.target.checked)}
+                disabled={imageDisabled}
+                className="h-4 w-4 rounded border-input accent-primary"
+              />
+              Include title &amp; axis labels
+            </label>
             {imageDisabled && (
               <div className="text-xs text-muted-foreground">
                 Show the chart to export or copy its image.
@@ -218,6 +247,15 @@ export function ExportDialog({
                 className="h-4 w-4 rounded border-input accent-primary"
               />
               Include hidden traces
+            </label>
+            <label className="flex w-fit cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={includeHeaders}
+                onChange={(e) => setIncludeHeaders(e.target.checked)}
+                className="h-4 w-4 rounded border-input accent-primary"
+              />
+              Include header row
             </label>
             <div className="flex flex-wrap gap-2">
               <Button variant="outline" onClick={downloadCsv}>

--- a/dashboard/src/components/signals/Highlights.tsx
+++ b/dashboard/src/components/signals/Highlights.tsx
@@ -2,10 +2,49 @@ import { Input } from "@/components/ui/input";
 import { type Series } from "./QueryChart";
 import {
   compileAgainstSeries,
+  type ExtraVariables,
   type SeriesVariable,
 } from "./DerivedTraces";
+import type { Lap } from "@/models/session";
 import { cn } from "@/lib/utils";
 import { Plus, X } from "lucide-react";
+
+/** The pseudo-variable name exposed to highlight conditions when laps are
+ *  available, e.g. `lap % 2 = 1`. */
+export const LAP_VAR = "lap";
+
+/** Build a per-bucket `lap` extra-variable from a session's laps. Maps each
+ *  bucket index to the lap_number whose [start_time, end_time] contains the
+ *  bucket's timestamp. Bucket timestamps are sorted ascending, so a single
+ *  pointer advances over the (lap_number-ordered) laps — O(buckets + laps).
+ *  Buckets outside any lap resolve to NaN, so `lap % 2 = 1` is simply false
+ *  there (no band). */
+function buildLapExtra(series: Series[], laps: Lap[]): ExtraVariables | null {
+  const buckets = series[0]?.points ?? [];
+  if (buckets.length === 0 || laps.length === 0) return null;
+
+  const ordered = [...laps].sort((a, b) => a.lap_number - b.lap_number);
+  const lapByBucket = new Array<number>(buckets.length).fill(NaN);
+
+  let lapIdx = 0;
+  for (let i = 0; i < buckets.length; i++) {
+    const t = new Date(buckets[i].bucket).getTime();
+    // Advance past laps that ended before this bucket's timestamp.
+    while (lapIdx < ordered.length && new Date(ordered[lapIdx].end_time).getTime() < t) {
+      lapIdx++;
+    }
+    if (lapIdx >= ordered.length) break;
+    const lap = ordered[lapIdx];
+    if (t >= new Date(lap.start_time).getTime()) {
+      lapByBucket[i] = lap.lap_number;
+    }
+  }
+
+  return {
+    names: [LAP_VAR],
+    valueAt: (i) => ({ [LAP_VAR]: lapByBucket[i] }),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Highlight regions (T6)
@@ -58,11 +97,16 @@ export interface HighlightRanges {
 export function evaluateHighlights(
   series: Series[],
   highlights: Highlight[],
+  laps?: Lap[] | null,
 ): { ranges: HighlightRanges[]; errors: Record<string, string> } {
   // Shared bucket axis (server zero-fills every series), so the first series
   // defines how many bucket indices there are to walk.
   const bucketCount = series[0]?.points.length ?? 0;
   const errors: Record<string, string> = {};
+
+  // When laps are present, expose a per-bucket `lap` pseudo-variable so
+  // conditions like `lap % 2 = 1` (alternate by lap) work.
+  const lapExtra = laps && laps.length > 0 ? buildLapExtra(series, laps) : null;
 
   const ranges = highlights.map((h): HighlightRanges => {
     if (h.expression.trim() === "") {
@@ -70,7 +114,7 @@ export function evaluateHighlights(
       return { id: h.id, color: h.color, ranges: [] };
     }
 
-    const evaluator = compileAgainstSeries(h.expression, series);
+    const evaluator = compileAgainstSeries(h.expression, series, lapExtra ?? undefined);
     if (!evaluator.ok || !evaluator.evalAt) {
       // Compile / unknown-variable error → no bands; surface why in the editor.
       if (evaluator.error) errors[h.id] = evaluator.error;
@@ -117,6 +161,9 @@ interface HighlightsProps {
   variables: SeriesVariable[];
   /** Per-highlight parse/unknown-variable errors keyed by id. */
   errors: Record<string, string>;
+  /** When true, the `lap` pseudo-variable is available: show the
+   *  "alternate by lap" shortcut and list `lap` in the vars hint. */
+  lapsAvailable?: boolean;
 }
 
 /** Compact editor for highlight regions, styled to match the derived-traces /
@@ -126,13 +173,14 @@ export function Highlights({
   onChange,
   variables,
   errors,
+  lapsAvailable = false,
 }: HighlightsProps) {
-  function add() {
+  function add(expression = "") {
     onChange([
       ...highlights,
       {
         id: newHighlightId(),
-        expression: "",
+        expression,
         color: DEFAULT_HIGHLIGHT_COLOR,
       },
     ]);
@@ -214,7 +262,7 @@ export function Highlights({
       <div className="flex items-center gap-2">
         <button
           type="button"
-          onClick={add}
+          onClick={() => add()}
           className={cn(
             "inline-flex h-7 items-center gap-1 rounded-md border border-dashed bg-transparent px-2 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
           )}
@@ -222,9 +270,22 @@ export function Highlights({
           <Plus className="h-3 w-3" />
           highlight
         </button>
+        {lapsAvailable ? (
+          <button
+            type="button"
+            onClick={() => add(`${LAP_VAR} % 2 = 1`)}
+            title="Highlight every other lap"
+            className={cn(
+              "inline-flex h-7 items-center gap-1 rounded-md border border-dashed bg-transparent px-2 text-xs font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-accent/40 hover:text-foreground",
+            )}
+          >
+            <Plus className="h-3 w-3" />
+            alternate by lap
+          </button>
+        ) : null}
       </div>
 
-      {variables.length > 0 ? (
+      {variables.length > 0 || lapsAvailable ? (
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px] text-muted-foreground/70">
           <span className="uppercase tracking-wider">vars</span>
           {variables.map((v) => (
@@ -232,6 +293,7 @@ export function Highlights({
               {v.friendly ? `${v.index} = ${v.friendly}` : v.index}
             </code>
           ))}
+          {lapsAvailable ? <code className="font-mono">{LAP_VAR}</code> : null}
         </div>
       ) : null}
     </div>

--- a/dashboard/src/components/signals/PlotChart.tsx
+++ b/dashboard/src/components/signals/PlotChart.tsx
@@ -3,7 +3,6 @@ import { ScatterChart, LineChart, PieChart, BarChart } from "echarts/charts";
 import {
   GridComponent,
   TooltipComponent,
-  VisualMapComponent,
   LegendComponent,
 } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
@@ -26,7 +25,6 @@ echarts.use([
   BarChart,
   GridComponent,
   TooltipComponent,
-  VisualMapComponent,
   LegendComponent,
   Scatter3DChart,
   Grid3DComponent,
@@ -41,7 +39,7 @@ export type PlotKind = Extract<
 >;
 
 /** Sparse config driving the chart. Which fields matter depends on `kind`:
- *  - scatter/path: xSignal + ySignals (one or more), optional colorBy.
+ *  - scatter/path: xSignal + ySignals (one or more).
  *  - scatter3d: xSignal + ySignals[0] (y) + zSignal (z).
  *  - catbar/pie: neither — those read the categorical `/query/run` series. */
 export interface PlotConfig {
@@ -49,9 +47,6 @@ export interface PlotConfig {
   xSignal?: string;
   ySignals: string[];
   zSignal?: string;
-  /** "time" colors points along the row order (time), or a signal name colors
-   *  by that signal's value. Only meaningful for scatter/path. */
-  colorBy?: "time" | string;
 }
 
 /** Resolve an HSL CSS custom property to an `hsl(...)` string (mirrors
@@ -203,26 +198,14 @@ export function PlotChart({
 
     // --- scatter / path: XY from /query/pairs ---
     const x = config.xSignal;
-    const colorBy = config.colorBy;
-    const colorBySignal =
-      colorBy && colorBy !== "time" ? colorBy : undefined;
-
-    // colorBy tags each point with a 3rd dim the visualMap reads: row index
-    // (time proxy — rows are in produced_at order) or a signal's value.
-    const colorDim = colorBy ? 2 : undefined;
 
     const series = config.ySignals.map((ySig, si) => {
       const pts: number[][] = [];
-      pairs.rows.forEach((r, ri) => {
+      pairs.rows.forEach((r) => {
         const xv = num(r, x);
         const yv = num(r, ySig);
         if (xv === null || yv === null) return;
-        if (colorBy === "time") pts.push([xv, yv, ri]);
-        else if (colorBySignal) {
-          const cv = num(r, colorBySignal);
-          if (cv === null) return;
-          pts.push([xv, yv, cv]);
-        } else pts.push([xv, yv]);
+        pts.push([xv, yv]);
       });
       const color = PALETTE[si % PALETTE.length];
       if (config.kind === "path") {
@@ -245,26 +228,10 @@ export function PlotChart({
       };
     });
 
-    // visualMap color range over every plotted point's color dimension.
-    let cMin = Infinity;
-    let cMax = -Infinity;
-    if (colorDim !== undefined) {
-      for (const s of series) {
-        for (const p of s.data) {
-          const c = p[colorDim];
-          if (typeof c === "number") {
-            if (c < cMin) cMin = c;
-            if (c > cMax) cMax = c;
-          }
-        }
-      }
-    }
-    const hasColor = colorDim !== undefined && cMin <= cMax;
-
     return {
       animation: false,
       tooltip: { trigger: "item", ...baseTooltip },
-      grid: { top: 16, right: hasColor ? 72 : 16, bottom: 40, left: 56 },
+      grid: { top: 16, right: 16, bottom: 40, left: 56 },
       xAxis: {
         type: "value",
         name: x,
@@ -285,24 +252,6 @@ export function PlotChart({
         axisLabel: { color: axisLabelColor },
         splitLine: { lineStyle: { color: splitLineColor, type: "dashed" } },
       },
-      ...(hasColor
-        ? {
-            visualMap: {
-              type: "continuous" as const,
-              dimension: colorDim,
-              min: cMin,
-              max: cMax,
-              calculable: true,
-              right: 8,
-              top: "center",
-              text: [colorBySignal ?? "late", colorBySignal ? "" : "early"],
-              textStyle: { color: axisLabelColor },
-              inRange: {
-                color: ["#3b82f6", "#10b981", "#f59e0b", "#ef4444"],
-              },
-            },
-          }
-        : {}),
       series,
     };
   }, [config, pairs, categorical]);

--- a/dashboard/src/components/signals/QueryBuilder.tsx
+++ b/dashboard/src/components/signals/QueryBuilder.tsx
@@ -28,6 +28,17 @@ import Fuse from "fuse.js";
 import { ChevronDown, Plus, X } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
+/** Per-series summary of the raw samples a `.reject(...)` clause cut before
+ *  aggregation. One entry per series (single entry with empty `tags` when the
+ *  query has no group-by). Returned by /query/run as `reject_stats`. */
+export interface RejectStatsEntry {
+  tags: Record<string, string | null>;
+  cut_count: number;
+  min: number | null;
+  max: number | null;
+  avg: number | null;
+}
+
 interface QueryBuilderProps {
   value: Query;
   onChange: (next: Query) => void;
@@ -35,6 +46,8 @@ interface QueryBuilderProps {
   signalNames: string[];
   /** Parser/execution error from the most recent run, shown under the preview. */
   error?: { message: string; position?: number } | null;
+  /** Cut-summary from the most recent run, shown in the reject chip popover. */
+  rejectStats?: RejectStatsEntry[] | null;
   /** Opt-in editable MQL line: when provided, the preview becomes a controlled
    *  `<input>` that calls `onMqlChange` for the parent to re-parse. */
   onMqlChange?: (mql: string) => void;
@@ -49,6 +62,7 @@ export function QueryBuilder({
   onChange,
   signalNames,
   error,
+  rejectStats,
   onMqlChange,
   onMqlFocus,
   onMqlBlur,
@@ -204,7 +218,11 @@ export function QueryBuilder({
         </Clause>
 
         <Clause keyword="reject">
-          <RejectChip value={value.reject} onChange={setReject} />
+          <RejectChip
+            value={value.reject}
+            onChange={setReject}
+            stats={rejectStats ?? null}
+          />
         </Clause>
 
         <Clause keyword="fill">
@@ -315,7 +333,7 @@ function Hint({ children }: { children: ReactNode }) {
 // ---------------------------------------------------------------------------
 
 const CHIP_BASE =
-  "inline-flex h-7 items-center gap-1 rounded-md border bg-background px-2.5 text-xs font-mono transition-colors";
+  "inline-flex h-7 items-center gap-1 whitespace-nowrap rounded-md border bg-background px-2.5 text-xs font-mono transition-colors";
 
 function SelectChip({
   label,
@@ -658,12 +676,29 @@ function rejectSummary(ui: RejectUiState): string | null {
   return parts.length ? parts.join(" · ") : null;
 }
 
+/** Compact, null-safe number for the cut summary (≤2 decimals, no trailing
+ *  zeros). */
+function formatCutNumber(n: number | null): string {
+  if (n === null || Number.isNaN(n)) return "–";
+  return Number.isInteger(n) ? String(n) : String(Number(n.toFixed(2)));
+}
+
+/** Series label for a cut-summary entry — the `name` tag, else the first tag
+ *  value, else "all" (an empty-tags entry means the query has no group-by). */
+function cutEntryLabel(tags: Record<string, string | null>): string {
+  if (tags.name) return tags.name;
+  for (const v of Object.values(tags)) if (v) return v;
+  return "all";
+}
+
 function RejectChip({
   value,
   onChange,
+  stats,
 }: {
   value: RejectNode | undefined;
   onChange: (next: RejectNode | undefined) => void;
+  stats: RejectStatsEntry[] | null;
 }) {
   const [open, setOpen] = useState(false);
   const ui = rejectToUi(value);
@@ -736,6 +771,30 @@ function RejectChip({
               className="h-7 flex-1 font-mono text-xs"
             />
           </div>
+
+          {/* Read-only cut summary from the most recent run. */}
+          {stats && stats.length > 0 ? (
+            <>
+              <div className="border-t" />
+              <div className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">samples cut</span>
+                {stats.map((s, i) => (
+                  <div key={i} className="text-xs text-muted-foreground">
+                    <span className="font-mono text-foreground/80">
+                      {cutEntryLabel(s.tags)}
+                    </span>
+                    {" — cut "}
+                    {formatCutNumber(s.cut_count)}
+                    {" · range "}
+                    {formatCutNumber(s.min)}–{formatCutNumber(s.max)}
+                    {" (avg "}
+                    {formatCutNumber(s.avg)}
+                    {")"}
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : null}
         </div>
       </PopoverContent>
     </Popover>

--- a/dashboard/src/components/signals/SignalWidget.tsx
+++ b/dashboard/src/components/signals/SignalWidget.tsx
@@ -10,13 +10,9 @@ import {
 import { PlotChart, type PlotConfig } from "@/components/signals/PlotChart";
 import { fetchPairs, pairsToSeries, type PairsResponse } from "@/lib/pairs";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { QueryBuilder } from "@/components/signals/QueryBuilder";
+  QueryBuilder,
+  type RejectStatsEntry,
+} from "@/components/signals/QueryBuilder";
 import {
   QueryChart,
   seriesColorMap,
@@ -43,6 +39,7 @@ import {
   type Highlight,
 } from "@/components/signals/Highlights";
 import { ExportDialog } from "@/components/signals/ExportDialog";
+import type { Lap } from "@/models/session";
 import type { ECharts } from "echarts/core";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { BACKEND_URL } from "@/consts/config";
@@ -166,6 +163,8 @@ type FetchResult = {
   series: Series[];
   /** Per-statement parse/run error in the backend's {message, position} shape. */
   error?: { message: string; position?: number };
+  /** Cut-summary from `.reject(...)`; null when the query has no reject clause. */
+  rejectStats?: RejectStatsEntry[] | null;
   ms: number | null;
 };
 
@@ -191,6 +190,9 @@ export interface SignalWidgetProps {
   onChartReady?: (instance: ECharts | null) => void;
   /** Left-drag mode: "select" brushes a timeframe, "pan" slides the zoom. */
   interactionMode?: "select" | "pan";
+  /** Laps of the currently-selected session, enabling the `lap` highlight
+   *  pseudo-variable + the "alternate by lap" shortcut. */
+  laps?: Lap[] | null;
 }
 
 export function SignalWidget({
@@ -207,6 +209,7 @@ export function SignalWidget({
   onBrushSelect,
   onChartReady,
   interactionMode,
+  laps,
 }: SignalWidgetProps) {
   // Ordered list of MQL trace statements, classified at render via
   // `looksLikeFetchQuery`: fetch statements hit /query/run; expression
@@ -241,8 +244,6 @@ export function SignalWidget({
     columns: ["produced_at"],
     rows: [],
   });
-  // Render option for scatter/path: "none", "time", or a signal name.
-  const [colorBy, setColorBy] = useState<string>("none");
 
   // Reset the trace list to the target's default MQL when the current MQL can't
   // carry across (crossing into/out of the pairs path).
@@ -339,6 +340,7 @@ export function SignalWidget({
             return {
               id: p.id,
               series: res.data.data?.series ?? [],
+              rejectStats: res.data.data?.reject_stats ?? null,
               ms: Math.round(performance.now() - startedAt),
             };
           } catch (e) {
@@ -391,18 +393,11 @@ export function SignalWidget({
     path === "pairs" &&
     (chartType === "scatter3d" ? pairNames.length >= 3 : pairNames.length >= 2);
 
-  // Axis signals plus any color-by signal, deduped.
+  // Axis signals, deduped.
   const pairFetchSignals = useMemo(() => {
     if (path !== "pairs") return [];
-    const set = new Set(pairNames);
-    if (
-      (chartType === "scatter" || chartType === "path") &&
-      colorBy !== "none" &&
-      colorBy !== "time"
-    )
-      set.add(colorBy);
-    return [...set];
-  }, [path, pairNames, chartType, colorBy]);
+    return [...new Set(pairNames)];
+  }, [path, pairNames]);
 
   // Debounce the pairs refetch too — axis signals come from live-edited lines.
   const debouncedPairKey = useDebouncedValue(pairFetchSignals.join(","), 350);
@@ -441,7 +436,6 @@ export function SignalWidget({
 
   // PlotConfig assembled from the resolved axis signals (by trace position).
   const plotConfig = useMemo<PlotConfig>(() => {
-    const colorByOpt = colorBy === "none" ? undefined : colorBy;
     const x = pairNames[0];
     if (chartType === "scatter3d") {
       return {
@@ -456,7 +450,6 @@ export function SignalWidget({
         kind: "path",
         xSignal: x,
         ySignals: pairNames[1] ? [pairNames[1]] : [],
-        colorBy: colorByOpt,
       };
     }
     if (chartType === "scatter") {
@@ -464,12 +457,11 @@ export function SignalWidget({
         kind: "scatter",
         xSignal: x,
         ySignals: pairNames.slice(1),
-        colorBy: colorByOpt,
       };
     }
     // categorical: axes unused, data comes from runSeries.
     return { kind: chartType === "pie" ? "pie" : "catbar", ySignals: [] };
-  }, [chartType, pairNames, colorBy]);
+  }, [chartType, pairNames]);
 
   // Every fetched series concatenated in trace order. Derived expressions read
   // s0, s1, … from here by position.
@@ -496,6 +488,13 @@ export function SignalWidget({
     for (const r of fetchResults) if (r.error) out[r.id] = r.error;
     return out;
   }, [classified, fetchResults]);
+
+  // Per-statement cut-summaries keyed by statement id, for the reject chip.
+  const rejectStatsById = useMemo(() => {
+    const out: Record<string, RejectStatsEntry[] | null> = {};
+    for (const r of fetchResults) if (r.rejectStats) out[r.id] = r.rejectStats;
+    return out;
+  }, [fetchResults]);
 
   // Subtitle latency: sum across every fetch statement.
   const seriesMs = useMemo(() => {
@@ -575,8 +574,8 @@ export function SignalWidget({
   );
 
   const { ranges: highlightRanges, errors: highlightErrors } = useMemo(
-    () => evaluateHighlights(baseSeries, highlights),
-    [baseSeries, highlights],
+    () => evaluateHighlights(baseSeries, highlights, laps),
+    [baseSeries, highlights, laps],
   );
 
   // Narrow the (possibly stale) settings map to just the plotted labels.
@@ -744,6 +743,7 @@ export function SignalWidget({
                             onMqlBlur={() => setEditingRow(null)}
                             signalNames={signalNames}
                             error={fetchErrors[id] ?? null}
+                            rejectStats={rejectStatsById[id] ?? null}
                           />
                         </QueryRow>
                       );
@@ -842,6 +842,7 @@ export function SignalWidget({
                     onChange={setHighlights}
                     variables={seriesVariables}
                     errors={highlightErrors}
+                    lapsAvailable={!!laps?.length}
                   />
                 </div>
               )}
@@ -849,23 +850,6 @@ export function SignalWidget({
             )}
           </div>
           <div className="flex items-center gap-2">
-            {/* Color-by (scatter/path only) — a render option, not MQL. */}
-            {(chartType === "scatter" || chartType === "path") && (
-              <Select value={colorBy} onValueChange={setColorBy}>
-                <SelectTrigger className="h-8 w-[150px]" title="Color points by">
-                  <SelectValue placeholder="Color by" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">No color</SelectItem>
-                  <SelectItem value="time">Color: time</SelectItem>
-                  {signalNames.map((n) => (
-                    <SelectItem key={n} value={n}>
-                      Color: {n}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
             <ChartTypeSelect value={chartType} onChange={changeChartType} />
             {hasData && (
               <button

--- a/dashboard/src/components/signals/TimeframePicker.tsx
+++ b/dashboard/src/components/signals/TimeframePicker.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Input } from "@/components/ui/input";
 import {
@@ -6,9 +7,12 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import { fetchSessions } from "@/lib/sessions/api";
+import type { Session } from "@/models/session";
 import { format } from "date-fns";
+import Fuse from "fuse.js";
 import { CalendarDays, Clock } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { DateRange } from "react-day-picker";
 
 /** The page-level time window — always absolute; presets snap to a now-anchored
@@ -237,40 +241,148 @@ function CalendarRangePicker({
           selected={range}
           onSelect={setRange}
           defaultMonth={value.start}
+          className="p-3 pb-0"
         />
-        <div className="flex flex-col gap-2 border-t p-3">
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-            Start time
-            <Input
-              type="time"
-              value={startTime}
-              onChange={(e) => setStartTime(e.target.value)}
-              className="h-9"
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground">
-            End time
-            <Input
-              type="time"
-              value={endTime}
-              onChange={(e) => setEndTime(e.target.value)}
-              className="h-9"
-            />
-          </label>
-          <button
-            type="button"
-            onClick={apply}
-            disabled={!range?.from}
-            className={cn(
-              "h-9 w-full rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground",
-              "hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50",
-            )}
-          >
-            Apply
-          </button>
+        <div className="flex flex-col gap-3 border-t p-3">
+          <div className="grid grid-cols-2 gap-3">
+            <label className="flex flex-col gap-1.5 text-xs text-muted-foreground">
+              Start time
+              <Input
+                type="time"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                className="h-8"
+              />
+            </label>
+            <label className="flex flex-col gap-1.5 text-xs text-muted-foreground">
+              End time
+              <Input
+                type="time"
+                value={endTime}
+                onChange={(e) => setEndTime(e.target.value)}
+                className="h-8"
+              />
+            </label>
+          </div>
+          <div className="flex justify-end">
+            <Button size="sm" onClick={apply} disabled={!range?.from}>
+              Apply
+            </Button>
+          </div>
         </div>
       </PopoverContent>
     </Popover>
+  );
+}
+
+/** Compact human label for a session row's secondary line: start date + run
+ *  duration. */
+function formatSessionMeta(session: Session): string {
+  const start = new Date(session.start_time);
+  const ms = new Date(session.end_time).getTime() - start.getTime();
+  const date = format(start, "MMM d, h:mm a");
+  const seconds = Math.max(0, Math.round(ms / 1000));
+  return `${date} · ${formatDuration(seconds)}`;
+}
+
+/** Sessions section of the editing dropdown: lazily-loaded, Fuse-filtered list.
+ *  Picking a session commits its window as a Timeframe and notifies the page. */
+function SessionPicker({
+  vehicleId,
+  selectedSessionId,
+  onPick,
+}: {
+  vehicleId: string;
+  selectedSessionId?: string;
+  onPick: (session: Session) => void;
+}) {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState("");
+  // Cache by vehicleId so re-opening the dropdown doesn't refetch.
+  const loadedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!vehicleId || loadedFor.current === vehicleId) return;
+    let cancelled = false;
+    setLoading(true);
+    fetchSessions(vehicleId, { limit: 200 })
+      .then((rows) => {
+        if (cancelled) return;
+        setSessions(rows);
+        // Mark loaded only on success, so StrictMode's mount→cleanup→remount
+        // (which cancels the first fetch) still refetches on the second mount
+        // instead of early-returning with `loading` stuck true. A failed fetch
+        // also stays unmarked, allowing a retry on the next open.
+        loadedFor.current = vehicleId;
+      })
+      .catch(() => {
+        if (!cancelled) setSessions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vehicleId]);
+
+  const fuse = useMemo(
+    () => new Fuse(sessions, { keys: ["name"], threshold: 0.3, ignoreLocation: true }),
+    [sessions],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim();
+    if (!q) return sessions;
+    return fuse.search(q).map((r) => r.item);
+  }, [sessions, fuse, query]);
+
+  return (
+    <div className="border-t pt-1">
+      <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        Sessions
+      </div>
+      <div className="px-2 pb-1">
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onMouseDown={(e) => e.stopPropagation()}
+          placeholder="Search sessions…"
+          className="h-8 text-xs"
+        />
+      </div>
+      <div className="max-h-[160px] overflow-auto">
+        {loading ? (
+          <div className="px-3 py-2 text-xs text-muted-foreground">Loading…</div>
+        ) : filtered.length === 0 ? (
+          <div className="px-3 py-2 text-xs text-muted-foreground">
+            {sessions.length === 0 ? "No sessions" : "No matches"}
+          </div>
+        ) : (
+          filtered.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              // Mousedown (not click) to beat the document-level close handler.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onPick(s);
+              }}
+              className={cn(
+                "flex w-full flex-col items-start px-3 py-1.5 text-left hover:bg-accent",
+                s.id === selectedSessionId && "bg-accent",
+              )}
+            >
+              <span className="truncate text-sm">{s.name}</span>
+              <span className="truncate text-xs text-muted-foreground">
+                {formatSessionMeta(s)}
+              </span>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -278,12 +390,21 @@ interface TimeframePickerProps {
   value: Timeframe;
   onChange: (next: Timeframe) => void;
   className?: string;
+  /** Vehicle to scope the sessions list to. */
+  vehicleId: string;
+  /** Called when a session is picked (so the page can load its laps). */
+  onSelectSession?: (session: Session) => void;
+  /** Currently-selected session id, for highlighting its row. */
+  selectedSessionId?: string;
 }
 
 export function TimeframePicker({
   value,
   onChange,
   className,
+  vehicleId,
+  onSelectSession,
+  selectedSessionId,
 }: TimeframePickerProps) {
   const [editing, setEditing] = useState(false);
   const [input, setInput] = useState("");
@@ -338,6 +459,15 @@ export function TimeframePicker({
   function commitRangeString(rangeString: string) {
     const parsed = parseTimeframeInput(rangeString);
     if (parsed) commit(parsed);
+  }
+
+  function pickSession(session: Session) {
+    commit({
+      start: new Date(session.start_time),
+      end: new Date(session.end_time),
+      label: session.name,
+    });
+    onSelectSession?.(session);
   }
 
   if (!editing) {
@@ -408,6 +538,11 @@ export function TimeframePicker({
           </button>
         ))}
         <CalendarRangePicker value={value} onApply={commitRangeString} />
+        <SessionPicker
+          vehicleId={vehicleId}
+          selectedSessionId={selectedSessionId}
+          onPick={pickSession}
+        />
       </div>
     </div>
   );

--- a/dashboard/src/components/signals/chartTypes.ts
+++ b/dashboard/src/components/signals/chartTypes.ts
@@ -73,8 +73,6 @@ export const CHART_TYPE_MAP: Record<ChartType, ChartTypeDef> = Object.fromEntrie
   CHART_TYPES.map((d) => [d.type, d]),
 ) as Record<ChartType, ChartTypeDef>;
 
-export const INLINE_CHART_TYPES = CHART_TYPES.filter((d) => d.inline);
-
 export function dataPath(type: ChartType): DataPath {
   return CHART_TYPE_MAP[type].path;
 }

--- a/dashboard/src/lib/export.ts
+++ b/dashboard/src/lib/export.ts
@@ -28,7 +28,7 @@ function csvField(value: string): string {
 /** Plotted series → CSV: a leading `time` column (the shared bucket axis) plus
  *  one column per series, labeled as the legend reads it. Values are the true
  *  un-normalized numbers; null buckets are empty cells. */
-export function seriesToCsv(series: Series[]): string {
+export function seriesToCsv(series: Series[], headers = true): string {
   const buckets = series[0]?.points.map((p) => p.bucket) ?? [];
   const header = ["time", ...series.map((s) => seriesLabel(s.tags))];
   const rows = buckets.map((bucket, bi) => {
@@ -39,14 +39,24 @@ export function seriesToCsv(series: Series[]): string {
     }
     return cells.map(csvField).join(",");
   });
-  return [header.map(csvField).join(","), ...rows].join("\n");
+  return (headers ? [header.map(csvField).join(","), ...rows] : rows).join("\n");
 }
 
-/** Plotted series → JSON: one row object per bucket, keyed `time` plus one
- *  entry per series. Same semantics as `seriesToCsv`; null buckets → `null`. */
-export function seriesToJson(series: Series[]): string {
+/** Plotted series → JSON. Same semantics as `seriesToCsv`; null buckets → `null`.
+ *  Shape depends on `headers`:
+ *   - `true`  → array of objects keyed `time` plus one entry per series label.
+ *   - `false` → array of value-arrays, each `[time, ...values]` (no labels). */
+export function seriesToJson(series: Series[], headers = true): string {
   const buckets = series[0]?.points.map((p) => p.bucket) ?? [];
   const rows = buckets.map((bucket, bi) => {
+    if (!headers) {
+      const cells: (string | number | null)[] = [bucket];
+      for (const s of series) {
+        const v = s.points[bi]?.value;
+        cells.push(v === undefined ? null : v);
+      }
+      return cells;
+    }
     const row: Record<string, string | number | null> = { time: bucket };
     for (const s of series) {
       const v = s.points[bi]?.value;
@@ -57,11 +67,64 @@ export function seriesToJson(series: Series[]): string {
   return JSON.stringify(rows, null, 2);
 }
 
+export interface ChartLabels {
+  title?: string;
+  xName?: string;
+  yName?: string;
+}
+
 export interface ChartPngOptions {
   /** Any CSS color or "transparent". */
   backgroundColor?: string;
   /** Raster scale for hi-DPI crispness. */
   pixelRatio?: number;
+  /** When set, the rasterized PNG temporarily gains a chart title and
+   *  x/y axis name labels that the live chart normally hides. */
+  labels?: ChartLabels;
+}
+
+/** Rasterize the chart with the data URL captured while the optional title /
+ *  axis labels are applied, then restore the original option. The temporary
+ *  option is always rolled back, even if `getDataURL` throws.
+ *
+ *  `setOption` is synchronous, so the canvas reflects the labels by the time
+ *  `getDataURL` reads it. The app's `xAxis` is a single object while `yAxis`
+ *  may be an array (QueryChart) or a single object (PlotChart), so both forms
+ *  are patched defensively. */
+function rasterizeWithLabels(
+  instance: ECharts,
+  labels: ChartLabels | undefined,
+  read: () => string,
+): string {
+  if (!labels) return read();
+
+  const prev = instance.getOption();
+  const applyName = (
+    axis: unknown,
+    name: string | undefined,
+  ): unknown => {
+    if (name === undefined) return axis;
+    if (Array.isArray(axis)) {
+      return axis.map((a, i) =>
+        i === 0 ? { ...(a as object), name } : a,
+      );
+    }
+    return { ...(axis as object), name };
+  };
+
+  try {
+    instance.setOption(
+      {
+        title: { text: labels.title ?? "", left: "center" },
+        xAxis: applyName(prev.xAxis, labels.xName),
+        yAxis: applyName(prev.yAxis, labels.yName),
+      },
+      { lazyUpdate: false },
+    );
+    return read();
+  } finally {
+    instance.setOption(prev, { notMerge: true, lazyUpdate: false });
+  }
 }
 
 /** Export an ECharts instance as a PNG download (white bg at 2x by default). */
@@ -70,8 +133,10 @@ export function downloadChartPng(
   filename: string,
   opts: ChartPngOptions = {},
 ) {
-  const { backgroundColor = "#fff", pixelRatio = 2 } = opts;
-  const url = instance.getDataURL({ type: "png", pixelRatio, backgroundColor });
+  const { backgroundColor = "#fff", pixelRatio = 2, labels } = opts;
+  const url = rasterizeWithLabels(instance, labels, () =>
+    instance.getDataURL({ type: "png", pixelRatio, backgroundColor }),
+  );
   triggerDownload(url, filename, false);
 }
 
@@ -79,10 +144,12 @@ export function downloadChartPng(
  *  so the caller can surface a toast. */
 export async function copyChartToClipboard(
   instance: ECharts,
-  opts: { backgroundColor?: string } = {},
+  opts: { backgroundColor?: string; labels?: ChartLabels } = {},
 ): Promise<void> {
-  const { backgroundColor = "#fff" } = opts;
-  const url = instance.getDataURL({ type: "png", pixelRatio: 2, backgroundColor });
+  const { backgroundColor = "#fff", labels } = opts;
+  const url = rasterizeWithLabels(instance, labels, () =>
+    instance.getDataURL({ type: "png", pixelRatio: 2, backgroundColor }),
+  );
   const blob = await (await fetch(url)).blob();
   await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
 }

--- a/dashboard/src/lib/expr.ts
+++ b/dashboard/src/lib/expr.ts
@@ -149,7 +149,7 @@ function tokenize(input: string): Token[] {
       i++;
       continue;
     }
-    if (c === "+" || c === "-" || c === "*" || c === "/" || c === "^") {
+    if (c === "+" || c === "-" || c === "*" || c === "/" || c === "%" || c === "^") {
       tokens.push({ type: "op", value: c, pos: i });
       i++;
       continue;
@@ -188,6 +188,7 @@ type BinOp =
   | "-"
   | "*"
   | "/"
+  | "%"
   | "^"
   | "=="
   | "!="
@@ -230,7 +231,7 @@ const FUNCTIONS: Record<string, { arity: number; fn: (...a: number[]) => number 
 //   and     := compare (('and' | '&&') compare)*
 //   compare := sum (('==' | '!=' | '>' | '>=' | '<' | '<=') sum)*
 //   sum     := term (('+' | '-') term)*
-//   term    := unary (('*' | '/') unary)*
+//   term    := unary (('*' | '/' | '%') unary)*
 //   unary   := '-' unary | power
 //   power   := primary ('^' unary)?        // right-associative
 //   primary := number | ident | ident '(' args ')' | '(' expr ')'
@@ -331,8 +332,11 @@ class Parser {
 
   private parseTerm(): Node {
     let left = this.parseUnary();
-    while (this.peek().type === "op" && (this.peek().value === "*" || this.peek().value === "/")) {
-      const op = this.next().value as "*" | "/";
+    while (
+      this.peek().type === "op" &&
+      (this.peek().value === "*" || this.peek().value === "/" || this.peek().value === "%")
+    ) {
+      const op = this.next().value as "*" | "/" | "%";
       const right = this.parseUnary();
       left = { kind: "bin", op, left, right };
     }
@@ -450,6 +454,7 @@ function evalNode(node: Node, vars: Record<string, number>): number {
         // Division by zero yields Infinity/NaN — left as-is and surfaced as
         // a non-finite result (the compiled wrapper normalizes it).
         case "/": return l / r;
+        case "%": return l % r;
         case "^": return Math.pow(l, r);
         // Comparisons / logicals yield 1 (true) or 0 (false). A NaN operand
         // makes any comparison false (NaN compares false to everything),

--- a/dashboard/src/pages/signals/SignalsPage.tsx
+++ b/dashboard/src/pages/signals/SignalsPage.tsx
@@ -19,6 +19,8 @@ import {
 import { BACKEND_URL } from "@/consts/config";
 import { getAxiosErrorMessage } from "@/lib/axios-error-handler";
 import { notify } from "@/lib/notify";
+import { fetchSessionLaps } from "@/lib/sessions/api";
+import type { Lap, Session } from "@/models/session";
 import { useVehicle } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import axios from "axios";
@@ -120,6 +122,29 @@ function SortHeader({
 function SignalsPage() {
   const vehicle = useVehicle();
   const [timeframe, setTimeframe] = useState<Timeframe>(defaultTimeframe);
+  // The session whose window currently drives the timeframe, plus its laps
+  // (for the `lap` highlight pseudo-variable). Cleared whenever the timeframe
+  // moves off the session window (preset, brush, calendar, manual edit).
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
+    null,
+  );
+  const [sessionLaps, setSessionLaps] = useState<Lap[] | null>(null);
+
+  // Any timeframe change not originating from a session pick drops the session
+  // selection + its laps.
+  const changeTimeframe = useCallback((next: Timeframe) => {
+    setTimeframe(next);
+    setSelectedSessionId(null);
+    setSessionLaps(null);
+  }, []);
+
+  const onSelectSession = useCallback((session: Session) => {
+    setSelectedSessionId(session.id);
+    setSessionLaps(null);
+    fetchSessionLaps(session.id)
+      .then(setSessionLaps)
+      .catch(() => setSessionLaps(null));
+  }, []);
   const [signals, setSignals] = useState<SignalRow[]>([]);
   const [loadingSignals, setLoadingSignals] = useState(false);
   const [search, setSearch] = useState("");
@@ -205,7 +230,7 @@ function SignalsPage() {
 
   // A user-drawn brush always lands as "Custom" (presets re-snap to now).
   const onBrushSelect = (start: Date, end: Date) => {
-    setTimeframe({ start, end, label: "Custom" });
+    changeTimeframe({ start, end, label: "Custom" });
   };
 
   // The table refetches only on vehicle change, not on query/timeframe edits.
@@ -328,7 +353,13 @@ function SignalsPage() {
             >
               Reset zoom
             </Button>
-            <TimeframePicker value={timeframe} onChange={setTimeframe} />
+            <TimeframePicker
+              value={timeframe}
+              onChange={changeTimeframe}
+              vehicleId={vehicle.id}
+              onSelectSession={onSelectSession}
+              selectedSessionId={selectedSessionId ?? undefined}
+            />
           </div>
         </div>
 
@@ -349,6 +380,7 @@ function SignalsPage() {
             onBrushSelect={onBrushSelect}
             onChartReady={onChartReady}
             interactionMode={interactionMode}
+            laps={sessionLaps}
           />
         ))}
 

--- a/query/query/routes/query_run.py
+++ b/query/query/routes/query_run.py
@@ -126,6 +126,9 @@ async def post_query_run(
             status_code=200,
             content={
                 "series": result["series"],
+                # Per-series summary of raw samples a `.reject(...)` clause cut;
+                # null when the query has no reject.
+                "reject_stats": result.get("reject_stats"),
                 "metadata": {
                     "query": body.query,
                     "start": utc_iso(start_dt),

--- a/query/query/service/query_exec.py
+++ b/query/query/service/query_exec.py
@@ -183,6 +183,12 @@ def run_query(
     }
     where.extend(_build_filter_sql(q.filters, params))
 
+    # Snapshot the base filters/params (vehicle_id, time window, q.filters)
+    # before the reject branches append reject thresholds, so the companion
+    # reject-stats query can build an independent, non-colliding predicate.
+    where_base = list(where)
+    base_params = dict(params)
+
     group_by_cols = ["bucket"] + [f"series_{c}" for c in q.group_by]
 
     # Reject matching RAW samples before GROUP BY so a spike can't skew a bucket
@@ -238,7 +244,103 @@ def run_query(
         step_ms=step_ms,
         label=q.label,
     )
-    return {"series": series, "interval": effective_interval}
+
+    reject_stats = None
+    if q.reject is not None:
+        reject_stats = _run_reject_stats(
+            q=q,
+            base_where=where_base,
+            base_params=base_params,
+        )
+
+    return {
+        "series": series,
+        "interval": effective_interval,
+        "reject_stats": reject_stats,
+    }
+
+
+def _run_reject_stats(
+    q: Query,
+    base_where: list[str],
+    base_params: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Stats over the raw samples the reject WOULD CUT (the inverse predicate).
+
+    Mirrors the main query's series grouping so each entry maps to one series.
+    Uses its own params copy so the reject thresholds bound here can't collide
+    with the param keys already bound by the main query.
+    """
+    assert q.reject is not None
+    # Field the reject targets numerically; `count(signal)` has no numeric field
+    # so fall back to `value`, mirroring the executor's sigma_col logic.
+    field = q.field if q.field in ("value", "raw_value") else "value"
+
+    params = dict(base_params)
+    where = list(base_where)
+
+    select_parts: list[str] = []
+    for col in q.group_by:
+        select_parts.append(f"{col} AS series_{col}")
+    select_parts.extend(
+        [
+            "count() AS cut_count",
+            f"min({field}) AS cut_min",
+            f"max({field}) AS cut_max",
+            f"avg({field}) AS cut_avg",
+        ]
+    )
+    group_by_cols = [f"series_{c}" for c in q.group_by]
+
+    if _reject_uses_sigma(q.reject):
+        if q.group_by:
+            partition = "PARTITION BY " + ", ".join(q.group_by)
+        else:
+            partition = ""
+        reject_expr = _build_reject_sql(q.reject, params, sigma_col=field)
+        inner_select = (
+            f"SELECT *, produced_at, "
+            f"avg({field}) OVER ({partition}) AS _mean, "
+            f"stddevPop({field}) OVER ({partition}) AS _std "
+            f"FROM signal WHERE {' AND '.join(where)}"
+        )
+        # Keep the rows the reject matches (no NOT): coalesce so a degenerate
+        # group's NULL comparison counts as "not cut", matching the main query.
+        sql = f"""
+            SELECT {', '.join(select_parts)}
+            FROM ({inner_select})
+            WHERE coalesce(({reject_expr}), 0)
+            {("GROUP BY " + ", ".join(group_by_cols)) if group_by_cols else ""}
+        """
+    else:
+        reject_expr = _build_reject_sql(q.reject, params, sigma_col="value")
+        where.append(f"({reject_expr})")
+        sql = f"""
+            SELECT {', '.join(select_parts)}
+            FROM signal
+            WHERE {' AND '.join(where)}
+            {("GROUP BY " + ", ".join(group_by_cols)) if group_by_cols else ""}
+        """
+
+    rows = get_clickhouse().query(sql, parameters=params).result_rows
+    n_groups = len(q.group_by)
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        group_vals = tuple(row[0:n_groups])
+        cut_count, cut_min, cut_max, cut_avg = row[n_groups:n_groups + 4]
+        if not cut_count:
+            continue
+        tags = {col: group_vals[i] for i, col in enumerate(q.group_by)}
+        out.append(
+            {
+                "tags": tags,
+                "cut_count": _coerce_number(cut_count),
+                "min": _coerce_number(cut_min),
+                "max": _coerce_number(cut_max),
+                "avg": _coerce_number(cut_avg),
+            }
+        )
+    return out
 
 
 def _shape_response(


### PR DESCRIPTION
Integrates sessions into the signals page and clears a set of UX papercuts from the last couple PRs.

### Sessions & laps
- Searchable (Fuse.js) **session picker** in the timeframe popover — picking a session sets the plot window and loads its laps
- **Highlight by lap**: added `%` modulo to the expression evaluator, inject a per-bucket `lap` pseudo-variable into the highlight engine, and an "alternate by lap" one-click shortcut (`lap % 2 = 1`)
- Fixed a StrictMode loading deadlock that left the session list stuck on "Loading…"

### Chart controls & polish
- Replaced the 3 inline chart-type icons with a single **"Traces" dropdown** opening the full type grid
- Removed the non-working **color/heatmap** option from scatter & path
- Restyled the **calendar range picker** to match the page (side-by-side time inputs, shared Button)
- Fixed **"is not" filter chip** wrapping (`whitespace-nowrap`)

### Data
- **Outlier rejection summary**: backend companion query returns `reject_stats` (count/min/max/avg of cut samples per series), surfaced read-only in the reject chip
- **Export**: CSV/JSON header-row toggle and a PNG title/axis-label option

### Verification
- `tsc --noEmit` clean; `npm run build` succeeds
- Query service changes are syntax-verified only (no test harness in `query/`)
- App not run live yet — manual verification pending