### PR TITLE
feat(sessions): GPS outlier removal and lat/lon signal autofill

### DIFF
--- a/dashboard/src/lib/sessions/outliers.ts
+++ b/dashboard/src/lib/sessions/outliers.ts
@@ -1,0 +1,88 @@
+// GPS outlier detection for the lap editor. Lat/lon telemetry occasionally
+// carries "bus noise" — numeric, in-range readings that sit far from the real
+// track. Both normalization modes (geo.ts) derive their frame from the data, so
+// one far-off point collapses the path and shoots a stray line out to it. We
+// flag those points client-side before normalization, mirroring the signals
+// page's rejection model (z-score beyond N sigma OR outside a hard limit).
+
+import { GeoPoint } from "@/models/session";
+
+export interface OutlierConfig {
+  sigmaOn: boolean;
+  sigmaN: number;
+  maxDistanceM: number | null; // null = max-distance limit off
+}
+
+export const DEFAULT_OUTLIER_CONFIG: OutlierConfig = {
+  sigmaOn: true,
+  sigmaN: 3,
+  maxDistanceM: null,
+};
+
+// Same lat-scaled degree factors used by geo.ts localCartesian.
+const M_PER_DEG_LAT = 111_132.0;
+const M_PER_DEG_LON_EQ = 111_320.0;
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+// Population mean + standard deviation, matching the signals page's stddevPop.
+function meanStd(values: number[]): { mean: number; std: number } {
+  const n = values.length;
+  const mean = values.reduce((s, v) => s + v, 0) / n;
+  const variance =
+    values.reduce((s, v) => s + (v - mean) * (v - mean), 0) / n;
+  return { mean, std: Math.sqrt(variance) };
+}
+
+// Returns a boolean[] parallel to `points` (true = outlier).
+export function detectOutliers(
+  points: GeoPoint[],
+  cfg: OutlierConfig,
+): boolean[] {
+  const flags = new Array(points.length).fill(false);
+  if (points.length === 0) return flags;
+  if (!cfg.sigmaOn && cfg.maxDistanceM == null) return flags;
+
+  const lats = points.map((p) => p.lat);
+  const lons = points.map((p) => p.lon);
+
+  const latStat = cfg.sigmaOn ? meanStd(lats) : null;
+  const lonStat = cfg.sigmaOn ? meanStd(lons) : null;
+
+  // Robust center for the distance limit; meters scaled at that latitude.
+  const useDistance = cfg.maxDistanceM != null && cfg.maxDistanceM > 0;
+  const latC = useDistance ? median(lats) : 0;
+  const lonC = useDistance ? median(lons) : 0;
+  const mPerDegLon = M_PER_DEG_LON_EQ * Math.cos((latC * Math.PI) / 180);
+
+  for (let i = 0; i < points.length; i++) {
+    const p = points[i];
+
+    if (latStat && lonStat) {
+      // std === 0 means a degenerate axis (all identical) — not an outlier,
+      // matching the signals page's nullIf(_std, 0) guard.
+      const zLat = latStat.std > 0 ? Math.abs(p.lat - latStat.mean) / latStat.std : 0;
+      const zLon = lonStat.std > 0 ? Math.abs(p.lon - lonStat.mean) / lonStat.std : 0;
+      if (zLat > cfg.sigmaN || zLon > cfg.sigmaN) {
+        flags[i] = true;
+        continue;
+      }
+    }
+
+    if (useDistance) {
+      const dx = (p.lon - lonC) * mPerDegLon;
+      const dy = (p.lat - latC) * M_PER_DEG_LAT;
+      if (Math.hypot(dx, dy) > (cfg.maxDistanceM as number)) {
+        flags[i] = true;
+      }
+    }
+  }
+
+  return flags;
+}

--- a/dashboard/src/pages/sessions/SessionEditorPage.tsx
+++ b/dashboard/src/pages/sessions/SessionEditorPage.tsx
@@ -22,6 +22,11 @@ import {
 } from "@/models/session";
 import { SegmentManager } from "@/lib/sessions/segments";
 import { normalizeCoordinates } from "@/lib/sessions/geo";
+import {
+  DEFAULT_OUTLIER_CONFIG,
+  OutlierConfig,
+  detectOutliers,
+} from "@/lib/sessions/outliers";
 import { processLaps } from "@/lib/sessions/lapEngine";
 import { Vec2 } from "@/lib/sessions/intersect";
 import {
@@ -39,6 +44,7 @@ import {
 import { cn } from "@/lib/utils";
 import TrackCanvas, { BaseMap } from "./editor/TrackCanvas";
 import SignalPicker from "./editor/SignalPicker";
+import OutlierControls from "./editor/OutlierControls";
 import SignalTimeChart from "./editor/SignalTimeChart";
 import CalibrationControls from "./editor/CalibrationControls";
 import TimelineCrop from "./editor/TimelineCrop";
@@ -49,6 +55,12 @@ import DateSelector, { dayKey } from "./editor/DateSelector";
 // Convert a point's epoch-seconds timestamp into an ISO string for the API.
 function tsToIso(tsSeconds: number): string {
   return new Date(tsSeconds * 1000).toISOString();
+}
+
+// First signal whose name matches `re` (e.g. /latitude/i), or "" if none. Used
+// to autofill the lat/lon pickers when a session has no saved analysis.
+function matchSignal(names: string[], re: RegExp): string {
+  return names.find((n) => re.test(n)) ?? "";
 }
 
 // Derive the persisted lap shape from the lap-engine result. `crossingIndices`
@@ -138,6 +150,8 @@ export function SessionEditorPage() {
   const [latField, setLatField] = useState("");
   const [lonField, setLonField] = useState("");
   const [normMode, setNormMode] = useState<NormMode>(NormMode.LocalCartesian);
+  const [outlierCfg, setOutlierCfg] =
+    useState<OutlierConfig>(DEFAULT_OUTLIER_CONFIG);
 
   const [rawGeo, setRawGeo] = useState<GeoPoint[]>([]);
   const [allPoints, setAllPoints] = useState<Point[]>([]);
@@ -193,7 +207,8 @@ export function SessionEditorPage() {
       setActiveSeg(1);
 
       const analysis = target.session?.analysis;
-      if (hasAnalysis(analysis)) {
+      const restoredFromAnalysis = hasAnalysis(analysis);
+      if (restoredFromAnalysis) {
         setLatField(analysis.lat_field || "");
         setLonField(analysis.lon_field || "");
         setNormMode((analysis.norm_mode as NormMode) || NormMode.LocalCartesian);
@@ -217,6 +232,12 @@ export function SessionEditorPage() {
           target.endTime,
         );
         setSignalNames(names);
+        // No saved analysis: autofill the lat/lon pickers from the first
+        // matching signal so the user need not reselect them every time.
+        if (!restoredFromAnalysis) {
+          setLatField(matchSignal(names, /latitude/i));
+          setLonField(matchSignal(names, /longitude/i));
+        }
         setStatus(`${names.length} signals available`);
       } catch (e) {
         setStatus("Failed to fetch signal names");
@@ -326,13 +347,29 @@ export function SessionEditorPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [latField, lonField, windowStart, windowEnd, vehicleId]);
 
+  // -- Outlier detection: split raw GPS into inliers / excluded --------------
+  // Runs before normalization so a far-off "bus noise" point can't collapse the
+  // track. Recomputed reactively; not persisted.
+  const outlierFlags = useMemo(
+    () => detectOutliers(rawGeo, outlierCfg),
+    [rawGeo, outlierCfg],
+  );
+  const inlierGeo = useMemo(
+    () => rawGeo.filter((_, i) => !outlierFlags[i]),
+    [rawGeo, outlierFlags],
+  );
+  const excludedGeo = useMemo(
+    () => rawGeo.filter((_, i) => outlierFlags[i]),
+    [rawGeo, outlierFlags],
+  );
+
   // -- Normalize whenever raw data or norm mode changes ----------------------
   useEffect(() => {
-    if (rawGeo.length === 0) {
+    if (inlierGeo.length === 0) {
       setAllPoints([]);
       return;
     }
-    const pts = normalizeCoordinates(rawGeo, normMode);
+    const pts = normalizeCoordinates(inlierGeo, normMode);
     setAllPoints(pts);
 
     const tsMin = pts[0].ts;
@@ -348,7 +385,7 @@ export function SessionEditorPage() {
       setCropStartTs(tsMin);
       setCropEndTs(tsMax);
     }
-  }, [rawGeo, normMode]);
+  }, [inlierGeo, normMode]);
 
   // -- Calibration: fetch selected signals over the window -------------------
   useEffect(() => {
@@ -406,7 +443,7 @@ export function SessionEditorPage() {
       maxLat = -Infinity,
       minLon = Infinity,
       maxLon = -Infinity;
-    for (const p of rawGeo) {
+    for (const p of inlierGeo) {
       if (p.ts < cropStartTs || p.ts > cropEndTs) continue;
       if (p.lat < minLat) minLat = p.lat;
       if (p.lat > maxLat) maxLat = p.lat;
@@ -415,7 +452,7 @@ export function SessionEditorPage() {
     }
     if (!isFinite(minLat)) return null;
     return { minLat, maxLat, minLon, maxLon };
-  }, [rawGeo, cropStartTs, cropEndTs]);
+  }, [inlierGeo, cropStartTs, cropEndTs]);
 
   // Threshold for point removal: a fraction of the data's diagonal extent.
   const removeThreshold = useMemo(() => {
@@ -712,6 +749,7 @@ export function SessionEditorPage() {
                 setCropStartTs(s);
                 setCropEndTs(e);
               }}
+              markers={mode === "lap" ? excludedGeo.map((p) => p.ts) : undefined}
             />
           )}
           <div className="text-xs text-neutral-400">{status}</div>
@@ -759,6 +797,13 @@ export function SessionEditorPage() {
                     setNormMode(n.normMode);
                   }}
                 />
+                <div className="mt-4">
+                  <OutlierControls
+                    config={outlierCfg}
+                    onChange={setOutlierCfg}
+                    excluded={excludedGeo}
+                  />
+                </div>
               </div>
 
               <div>

--- a/dashboard/src/pages/sessions/editor/OutlierControls.tsx
+++ b/dashboard/src/pages/sessions/editor/OutlierControls.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { GeoPoint } from "@/models/session";
+import { OutlierConfig } from "@/lib/sessions/outliers";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface OutlierControlsProps {
+  config: OutlierConfig;
+  onChange: (next: OutlierConfig) => void;
+  excluded: GeoPoint[];
+}
+
+const MAX_LISTED = 50;
+
+function fmtTime(ts: number): string {
+  return new Date(ts * 1000).toLocaleTimeString();
+}
+
+export default function OutlierControls({
+  config,
+  onChange,
+  excluded,
+}: OutlierControlsProps) {
+  const [listOpen, setListOpen] = useState(false);
+
+  const apply = (patch: Partial<OutlierConfig>) =>
+    onChange({ ...config, ...patch });
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Label className="text-xs font-semibold uppercase text-neutral-500">
+        Outlier removal
+      </Label>
+
+      <label className="flex items-center gap-2 text-xs text-neutral-300">
+        <input
+          type="checkbox"
+          checked={config.sigmaOn}
+          onChange={(e) => apply({ sigmaOn: e.target.checked })}
+          className="h-3.5 w-3.5 rounded border-input accent-gr-purple"
+        />
+        <span>Remove GPS outliers</span>
+      </label>
+
+      {config.sigmaOn ? (
+        <div className="flex items-center gap-2 pl-6 text-xs text-neutral-400">
+          <span>beyond</span>
+          <Input
+            type="number"
+            value={config.sigmaN}
+            onChange={(e) => apply({ sigmaN: Number(e.target.value) || 0 })}
+            className="h-7 w-16 font-mono text-xs"
+          />
+          <span>σ</span>
+        </div>
+      ) : null}
+
+      <div className="flex items-center gap-2 text-xs text-neutral-400">
+        <span className="flex-shrink-0">Max distance</span>
+        <Input
+          type="number"
+          placeholder="off"
+          value={config.maxDistanceM ?? ""}
+          onChange={(e) => {
+            const v = e.target.value.trim();
+            apply({ maxDistanceM: v === "" ? null : Number(v) });
+          }}
+          className="h-7 w-20 font-mono text-xs"
+        />
+        <span>m</span>
+      </div>
+
+      {excluded.length > 0 ? (
+        <div className="flex flex-col gap-1">
+          <button
+            type="button"
+            onClick={() => setListOpen((o) => !o)}
+            className="flex items-center gap-1 text-xs text-neutral-300 hover:text-white"
+          >
+            {listOpen ? (
+              <ChevronDown className="h-3 w-3" />
+            ) : (
+              <ChevronRight className="h-3 w-3" />
+            )}
+            {excluded.length} point{excluded.length === 1 ? "" : "s"} excluded
+          </button>
+          {listOpen ? (
+            <div className="max-h-40 overflow-auto rounded-md bg-neutral-900 p-2 font-mono text-[11px] text-neutral-400">
+              {excluded.slice(0, MAX_LISTED).map((p, i) => (
+                <div key={i} className="flex justify-between gap-2">
+                  <span>{fmtTime(p.ts)}</span>
+                  <span>
+                    {p.lat.toFixed(5)}, {p.lon.toFixed(5)}
+                  </span>
+                </div>
+              ))}
+              {excluded.length > MAX_LISTED ? (
+                <div className="pt-1 text-neutral-500">
+                  +{excluded.length - MAX_LISTED} more
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/src/pages/sessions/editor/TimelineCrop.tsx
+++ b/dashboard/src/pages/sessions/editor/TimelineCrop.tsx
@@ -4,6 +4,8 @@ interface TimelineCropProps {
   cropStartTs: number;
   cropEndTs: number;
   onChange: (cropStartTs: number, cropEndTs: number) => void;
+  // Epoch-second timestamps of excluded outliers, drawn as red ticks.
+  markers?: number[];
 }
 
 function fmt(ts: number): string {
@@ -19,6 +21,7 @@ export default function TimelineCrop({
   cropStartTs,
   cropEndTs,
   onChange,
+  markers,
 }: TimelineCropProps) {
   const span = extentEndTs - extentStartTs || 1;
   const toFrac = (ts: number) => ((ts - extentStartTs) / span) * 1000;
@@ -33,6 +36,17 @@ export default function TimelineCrop({
         <span>Crop: {fmt(cropStartTs)}</span>
         <span>{fmt(cropEndTs)}</span>
       </div>
+      {markers && markers.length > 0 ? (
+        <div className="relative h-2" title={`${markers.length} excluded outliers`}>
+          {markers.map((ts, i) => (
+            <span
+              key={i}
+              className="absolute top-0 h-2 w-px bg-red-500"
+              style={{ left: `${(toFrac(ts) / 1000) * 100}%` }}
+            />
+          ))}
+        </div>
+      ) : null}
       <div className="flex flex-col gap-1">
         <input
           type="range"


### PR DESCRIPTION
## Changes

- Add client-side GPS outlier detection (`lib/sessions/outliers.ts`): per-axis population z-score (default 3σ) plus an optional max-distance-from-median limit, mirroring the signals page's rejection model
- Run outlier removal before normalization in the session editor so a far-off "bus noise" point can no longer collapse the track into a dot with a stray line
- Surface excluded points three ways: a count, an expandable list (timestamp + lat/lon, capped at 50), and red ticks on the timeline at each excluded timestamp
- Add `OutlierControls` component (toggle, σ input, max-distance input) under the signal picker; outlier removal defaults to on and is not persisted
- Autofill the lat/lon pickers from the first `*latitude*` / `*longitude*` signal when a session has no saved analysis; analyzed sessions keep their stored fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)