### PR TITLE
fix(sessions): use cropped window for session start/end times

### DIFF
--- a/dashboard/src/pages/sessions/SessionEditorPage.tsx
+++ b/dashboard/src/pages/sessions/SessionEditorPage.tsx
@@ -554,7 +554,17 @@ export function SessionEditorPage() {
   const persistAndNavigate = async (session: Session) => {
     setSaving(true);
     try {
-      const updated = await saveSessionAnalysis(session, buildPayload());
+      // Keep the session window in sync with the current crop so the stored
+      // start/end reflect the trimmed range, not the full data cluster.
+      const windowed =
+        cropStartTs && cropEndTs
+          ? {
+              ...session,
+              start_time: tsToIso(cropStartTs),
+              end_time: tsToIso(cropEndTs),
+            }
+          : session;
+      const updated = await saveSessionAnalysis(windowed, buildPayload());
       if (lapResult && lapResult.lapCount > 0) {
         const laps = deriveLapInputs(lapResult, croppedPoints);
         await saveSessionLaps(updated.id, laps);
@@ -588,8 +598,8 @@ export function SessionEditorPage() {
         vehicle_id: vehicleId,
         name: newSessionName,
         description: "",
-        start_time: windowStart,
-        end_time: windowEnd,
+        start_time: tsToIso(cropStartTs),
+        end_time: tsToIso(cropEndTs),
       });
       setSelectedSession(created);
       setSelectedLabel(`ssn:${created.id}`);


### PR DESCRIPTION
- Session create (lap/GPS) now sets start/end from the crop timestamps instead of the full data-cluster window
- Edit-mode save (`persistAndNavigate`) now syncs the session window to the current crop, so re-cropping an existing session updates its start/end
- Fixes the bug where a session's End time defaulted to the end of the raw data cluster rather than the trimmed/cropped range

Note: sessions saved before this fix retain their old (full-cluster) end times until re-saved through the editor.