### PR TITLE
feat(auth,dashboard): migrate to Sentinel v5

### DIFF
--- a/auth/api/api.go
+++ b/auth/api/api.go
@@ -51,31 +51,35 @@ func AuthChecker() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if config.SkipAuthCheck {
 			c.Set("Auth-Token", "mock-token")
+			c.Set("Auth-EntityID", "mock-entity")
 			c.Set("Auth-UserID", "mock-user")
 			c.Set("Auth-Audience", "mock-audience")
-			c.Set("Auth-Scope", "openid profile email")
+			c.Set("Auth-Scope", "openid profile email user:read groups:read")
 			c.Next()
 			return
 		}
-		if c.GetHeader("Authorization") != "" {
-			authHeader := c.GetHeader("Authorization")
-			if strings.HasPrefix(authHeader, "Bearer ") {
-				claims, err := service.ValidateJWT(strings.Split(c.GetHeader("Authorization"), "Bearer ")[1])
-				if err != nil {
-					logger.SugarLogger.Errorln("Failed to validate token: " + err.Error())
-					c.AbortWithStatusJSON(401, gin.H{"message": err.Error()})
-				} else {
-					logger.SugarLogger.Infof("Decoded token: %s", claims.Subject)
-					logger.SugarLogger.Infof("↳ Client ID: %s", claims.Audience[0])
-					logger.SugarLogger.Infof("↳ Scope: %s", claims.Scope)
-					logger.SugarLogger.Infof("↳ Issued at: %s", claims.IssuedAt.String())
-					logger.SugarLogger.Infof("↳ Expires at: %s", claims.ExpiresAt.String())
-					c.Set("Auth-Token", strings.Split(c.GetHeader("Authorization"), "Bearer ")[1])
-					c.Set("Auth-UserID", claims.Subject)
-					c.Set("Auth-Audience", claims.Audience[0])
-					c.Set("Auth-Scope", claims.Scope)
-				}
+		authHeader := c.GetHeader("Authorization")
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			token := strings.TrimPrefix(authHeader, "Bearer ")
+			claims, err := service.ValidateJWT(token)
+			if err != nil {
+				logger.SugarLogger.Errorln("Failed to validate token: " + err.Error())
+				c.AbortWithStatusJSON(401, gin.H{"message": err.Error()})
+				return
 			}
+			// Sentinel v5: `sub` is the entity_id (users and service
+			// accounts are both entities); `user_id` is a custom claim
+			// stamped only when the token represents a logged-in user.
+			// Downstream user lookups key off Auth-UserID.
+			logger.SugarLogger.Infof("Decoded token: entity=%s user=%s", claims.Subject, claims.UserID)
+			logger.SugarLogger.Infof("↳ Client ID: %s", claims.Audience[0])
+			logger.SugarLogger.Infof("↳ Scope: %s", claims.Scope)
+			logger.SugarLogger.Infof("↳ Expires at: %s", claims.ExpiresAt.String())
+			c.Set("Auth-Token", token)
+			c.Set("Auth-EntityID", claims.Subject)
+			c.Set("Auth-UserID", claims.UserID)
+			c.Set("Auth-Audience", claims.Audience[0])
+			c.Set("Auth-Scope", claims.Scope)
 		}
 		c.Next()
 	}
@@ -129,12 +133,15 @@ func RequestUserHasEmail(c *gin.Context, email string) bool {
 	return GetRequestUserEmail(c) == email
 }
 
-func RequestUserHasRole(c *gin.Context, role string) bool {
+// RequestUserInGroup reports whether the bearer's user is a member of
+// the named Sentinel group. Looked up against Sentinel each call —
+// there's no in-process cache, so don't call this in a tight loop.
+func RequestUserInGroup(c *gin.Context, name string) bool {
 	user, err := service.GetUser(GetRequestUserID(c))
 	if err != nil {
 		return false
 	}
-	return user.HasRole(role)
+	return user.HasGroup(name)
 }
 
 func GetRequestUserID(c *gin.Context) string {

--- a/auth/api/user.go
+++ b/auth/api/user.go
@@ -26,7 +26,7 @@ func GetUser(c *gin.Context) {
 }
 
 func GetCurrentUser(c *gin.Context) {
-	user, err := service.GetCurrentUser(c.GetString("Auth-Token"))
+	user, err := service.GetCurrentUser(c.GetString("Auth-Token"), c.GetString("Auth-UserID"))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
 		return

--- a/auth/config/config.go
+++ b/auth/config/config.go
@@ -39,21 +39,34 @@ var KerbecsEndpoint = os.Getenv("KERBECS_ENDPOINT")
 var KerbecsUser = os.Getenv("KERBECS_USER")
 var KerbecsPassword = os.Getenv("KERBECS_PASSWORD")
 
+// Sentinel v5 configuration. All endpoints live under SENTINEL_URL with the
+// /api/ prefix the kerbecs gateway strips before reaching core/oauth.
+//
+//   - ClientID / ClientSecret: this app's OAuth client registration in
+//     Sentinel. Used for the authorization-code exchange.
+//   - SAToken: a pre-issued service-account JWT for backend-only calls
+//     (GetAllUsers, GetUserByID) that don't have a logged-in user's
+//     bearer. Replaces the v4 SENTINEL_TOKEN static API key.
+//   - RedirectURI: must byte-match a registered redirect_uri on the
+//     client; the dashboard sends users to this exact URL.
 var Sentinel = struct {
 	Url          string
-	JwksUrl      string
 	ClientID     string
 	ClientSecret string
-	Token        string
+	SAToken      string
 	RedirectURI  string
 }{
 	Url:          os.Getenv("SENTINEL_URL"),
-	JwksUrl:      os.Getenv("SENTINEL_JWKS_URL"),
 	ClientID:     os.Getenv("SENTINEL_CLIENT_ID"),
 	ClientSecret: os.Getenv("SENTINEL_CLIENT_SECRET"),
-	Token:        os.Getenv("SENTINEL_TOKEN"),
+	SAToken:      os.Getenv("SENTINEL_SA_TOKEN"),
 	RedirectURI:  os.Getenv("SENTINEL_REDIRECT_URI"),
 }
+
+// SentinelIssuer is the iss claim Sentinel v5 stamps into every signed
+// token. Must byte-match SENTINEL_URL — the issuer is fixed in v5 to
+// the public base URL.
+const SentinelIssuer = "https://sentinel-v5.gauchoracing.com"
 
 func IsProduction() bool {
 	return Env == "PROD"

--- a/auth/model/auth.go
+++ b/auth/model/auth.go
@@ -7,8 +7,12 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
+// AuthClaims is the Sentinel v5 JWT payload we care about. sub is the
+// signer's entity id; user_id is a custom claim Sentinel stamps when the
+// token represents a logged-in user (absent for service-account tokens).
 type AuthClaims struct {
-	Scope string `json:"scope"`
+	Scope  string `json:"scope"`
+	UserID string `json:"user_id"`
 	jwt.RegisteredClaims
 }
 
@@ -27,7 +31,7 @@ func (c AuthClaims) Valid() error {
 		vErr.Errors |= jwt.ValidationErrorIssuedAt
 	}
 
-	if !c.VerifyIssuer("https://sso.gauchoracing.com", true) {
+	if !c.VerifyIssuer(config.SentinelIssuer, true) {
 		vErr.Inner = jwt.ErrTokenInvalidIssuer
 		vErr.Errors |= jwt.ValidationErrorIssuer
 	}

--- a/auth/model/user.go
+++ b/auth/model/user.go
@@ -2,6 +2,9 @@ package model
 
 import "time"
 
+// User mirrors the profile fields Sentinel v5 exposes for a logged-in
+// user. Groups is the source of truth for role-based gating in v5 —
+// callers check membership with HasGroup against a Sentinel group name.
 type User struct {
 	ID                    string    `gorm:"primaryKey" json:"id"`
 	Username              string    `json:"username"`
@@ -19,8 +22,7 @@ type User struct {
 	SAERegistrationNumber string    `json:"sae_registration_number"`
 	AvatarURL             string    `json:"avatar_url"`
 	Verified              bool      `json:"verified"`
-	Subteams              []Subteam `gorm:"-" json:"subteams"`
-	Roles                 []string  `gorm:"-" json:"roles"`
+	Groups                []string  `gorm:"-" json:"groups"`
 	UpdatedAt             time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 	CreatedAt             time.Time `gorm:"autoCreateTime" json:"created_at"`
 }
@@ -29,42 +31,14 @@ func (user User) String() string {
 	return "(" + user.ID + ")" + " " + user.FirstName + " " + user.LastName + " [" + user.Email + "]"
 }
 
-func (user User) HasRole(role string) bool {
-	for _, r := range user.Roles {
-		if r == role {
+// HasGroup reports whether the user is a member of the named Sentinel
+// group. Names are case-sensitive and match what the Sentinel UI
+// displays (e.g. "Admins", "Officers", "Leads").
+func (user User) HasGroup(name string) bool {
+	for _, g := range user.Groups {
+		if g == name {
 			return true
 		}
 	}
 	return false
-}
-
-func (user User) HasSubteam(subteam string) bool {
-	for _, s := range user.Subteams {
-		if s.Name == subteam {
-			return true
-		}
-	}
-	return false
-}
-
-func (user User) IsAdmin() bool {
-	return user.HasRole("d_admin")
-}
-
-func (user User) IsOfficer() bool {
-	return user.HasRole("d_officer")
-}
-
-func (user User) IsLead() bool {
-	return user.HasRole("d_lead")
-}
-
-func (user User) IsInnerCircle() bool {
-	return user.IsAdmin() || user.IsOfficer() || user.IsLead()
-}
-
-type Subteam struct {
-	ID        string    `gorm:"primaryKey" json:"id"`
-	Name      string    `json:"name"`
-	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
 }

--- a/auth/service/auth.go
+++ b/auth/service/auth.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gaucho-racing/mapache/auth/config"
 	"github.com/gaucho-racing/mapache/auth/model"
@@ -10,31 +11,55 @@ import (
 	"github.com/lestrrat-go/jwx/jwk"
 )
 
-var publicKey interface{}
+// jwksKeySet caches the JWKS document fetched from Sentinel at boot.
+// Loaded once on Init; the per-request validation path looks up the
+// signing key by the token's `kid` header. Multiple active keys is
+// the normal state in Sentinel v5 (key rotation), so we can't just
+// pin the first one like the v4 client did.
+var jwksKeySet jwk.Set
 
 func InitializeKeys() {
-	set, err := jwk.Fetch(context.Background(), config.Sentinel.JwksUrl)
+	set, err := jwk.Fetch(context.Background(), config.Sentinel.Url+"/api/core/keys")
 	if err != nil {
 		logger.SugarLogger.Errorln("Failed to fetch JWKS:", err)
 		return
 	}
-
-	key, ok := set.Get(0)
-	if !ok {
+	if set.Len() == 0 {
 		logger.SugarLogger.Errorln("No keys found in JWKS")
 		return
 	}
-
-	if err := key.Raw(&publicKey); err != nil {
-		logger.SugarLogger.Errorln("Failed to get public key:", err)
-		return
-	}
+	jwksKeySet = set
+	logger.SugarLogger.Infof("Loaded %d signing key(s) from Sentinel JWKS", set.Len())
 }
 
 func ValidateJWT(token string) (*model.AuthClaims, error) {
 	claims := &model.AuthClaims{}
-	_, err := jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (interface{}, error) {
-		return publicKey, nil
+	_, err := jwt.ParseWithClaims(token, claims, func(t *jwt.Token) (interface{}, error) {
+		if jwksKeySet == nil {
+			return nil, fmt.Errorf("JWKS not initialized")
+		}
+		kid, _ := t.Header["kid"].(string)
+		var key jwk.Key
+		if kid != "" {
+			if k, ok := jwksKeySet.LookupKeyID(kid); ok {
+				key = k
+			}
+		}
+		// Token without a kid (or kid not in the set) — fall back to the
+		// first key. Sentinel v5 currently issues a single active key, so
+		// this keeps validation working while we wait for real rotation.
+		if key == nil {
+			k, ok := jwksKeySet.Get(0)
+			if !ok {
+				return nil, fmt.Errorf("no keys available")
+			}
+			key = k
+		}
+		var raw interface{}
+		if err := key.Raw(&raw); err != nil {
+			return nil, fmt.Errorf("decode signing key: %w", err)
+		}
+		return raw, nil
 	})
 	if err != nil {
 		logger.SugarLogger.Errorln(err.Error())

--- a/auth/service/sentinel.go
+++ b/auth/service/sentinel.go
@@ -12,9 +12,12 @@ import (
 	"github.com/gaucho-racing/mapache/auth/pkg/logger"
 )
 
+// SentinelError captures the {"error": "..."} envelope Sentinel v5
+// services return on non-2xx responses. The struct's Message field is
+// populated from the wire's `error` key (v5 doesn't use `message`).
 type SentinelError struct {
 	Code    int
-	Message string `json:"message"`
+	Message string `json:"error"`
 }
 
 type SentinelTokenResponse struct {
@@ -33,12 +36,12 @@ func mockUser(id string) model.User {
 		LastName:  "User",
 		Email:     "mock@gauchoracing.com",
 		Verified:  true,
-		Roles:     []string{"d_admin"},
+		Groups:    []string{"Admins"},
 	}
 }
 
 func PingSentinel() bool {
-	resp, err := http.Get(config.Sentinel.Url + "/ping")
+	resp, err := http.Get(config.Sentinel.Url + "/api/core/ping")
 	if err != nil {
 		logger.SugarLogger.Errorln("Failed to ping sentinel:", err)
 		return false
@@ -60,7 +63,7 @@ func ExchangeCodeForToken(code string) (SentinelTokenResponse, error) {
 			Scope:        "openid profile email",
 		}, nil
 	}
-	resp, err := http.PostForm(config.Sentinel.Url+"/oauth/token", url.Values{
+	resp, err := http.PostForm(config.Sentinel.Url+"/api/oauth/token", url.Values{
 		"grant_type":    {"authorization_code"},
 		"client_id":     {config.Sentinel.ClientID},
 		"client_secret": {config.Sentinel.ClientSecret},
@@ -102,12 +105,12 @@ func GetAllUsers() ([]model.User, error) {
 	if config.SkipAuthCheck {
 		return []model.User{mockUser("mock-user")}, nil
 	}
-	req, err := http.NewRequest("GET", config.Sentinel.Url+"/users", nil)
+	req, err := http.NewRequest("GET", config.Sentinel.Url+"/api/users", nil)
 	if err != nil {
 		logger.SugarLogger.Errorln("Failed to create request for users:", err)
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Bearer "+config.Sentinel.Token)
+	req.Header.Set("Authorization", "Bearer "+config.Sentinel.SAToken)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -147,12 +150,12 @@ func GetUser(id string) (model.User, error) {
 	if config.SkipAuthCheck {
 		return mockUser(id), nil
 	}
-	req, err := http.NewRequest("GET", config.Sentinel.Url+"/users/"+id, nil)
+	req, err := http.NewRequest("GET", config.Sentinel.Url+"/api/users/"+id, nil)
 	if err != nil {
 		logger.SugarLogger.Errorln("Failed to create request for user:", err)
 		return model.User{}, err
 	}
-	req.Header.Set("Authorization", "Bearer "+config.Sentinel.Token)
+	req.Header.Set("Authorization", "Bearer "+config.Sentinel.SAToken)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -188,11 +191,16 @@ func GetUser(id string) (model.User, error) {
 	return user, nil
 }
 
-func GetCurrentUser(accessToken string) (model.User, error) {
+// GetCurrentUser fetches the logged-in user's profile using their own
+// access token. Sentinel v5 has no /users/@me — instead we look up
+// /api/users/:userID, which the user's bearer satisfies via the
+// "user_id matches the token's user_id claim" branch of the gate.
+// userID is the user_id claim already extracted by AuthChecker.
+func GetCurrentUser(accessToken string, userID string) (model.User, error) {
 	if config.SkipAuthCheck {
 		return mockUser("mock-user"), nil
 	}
-	req, err := http.NewRequest("GET", config.Sentinel.Url+"/users/@me", nil)
+	req, err := http.NewRequest("GET", config.Sentinel.Url+"/api/users/"+userID, nil)
 	if err != nil {
 		logger.SugarLogger.Errorln("Failed to create request for user:", err)
 		return model.User{}, err

--- a/dashboard/src/components/Header.tsx
+++ b/dashboard/src/components/Header.tsx
@@ -53,7 +53,7 @@ const Header = (props: HeaderProps) => {
               <DropdownMenuItem
                 onClick={() =>
                   window.open(
-                    `https://sso.gauchoracing.com/users/${currentUser.id}/edit`,
+                    "https://sentinel-v5.gauchoracing.com/settings",
                     "_blank",
                   )
                 }

--- a/dashboard/src/consts/config.tsx
+++ b/dashboard/src/consts/config.tsx
@@ -5,9 +5,9 @@ export const BACKEND_WS_URL =
   import.meta.env.VITE_BACKEND_WS_URL ?? "wss://mapache.gauchoracing.com/api";
 
 export const SENTINEL_OAUTH_BASE_URL =
-  "https://sso.gauchoracing.com/oauth/authorize";
+  "https://sentinel-v5.gauchoracing.com/oauth/authorize";
 export const SENTINEL_CLIENT_ID =
-  import.meta.env.VITE_SENTINEL_CLIENT_ID ?? "z6V9NREjMFhf";
+  import.meta.env.VITE_SENTINEL_CLIENT_ID ?? "";
 
 export const MAPBOX_ACCESS_TOKEN =
   import.meta.env.VITE_MAPBOX_ACCESS_TOKEN ?? "";

--- a/dashboard/src/models/user.tsx
+++ b/dashboard/src/models/user.tsx
@@ -15,15 +15,8 @@ export interface User {
   sae_registration_number: string;
   avatar_url: string;
   verified: boolean;
-  subteams: Subteam[];
-  roles: string[];
+  groups: string[];
   updated_at: string;
-  created_at: string;
-}
-
-export interface Subteam {
-  id: string;
-  name: string;
   created_at: string;
 }
 
@@ -44,8 +37,7 @@ export const initUser: User = {
   sae_registration_number: "",
   avatar_url: "",
   verified: false,
-  subteams: [],
-  roles: [],
+  groups: [],
   updated_at: "",
   created_at: "",
 };
@@ -67,8 +59,7 @@ export const mockUser: User = {
   sae_registration_number: "",
   avatar_url: "",
   verified: true,
-  subteams: [],
-  roles: ["admin"],
+  groups: ["Admins"],
   updated_at: "",
   created_at: "",
 };

--- a/dashboard/src/pages/auth/LoginPage.tsx
+++ b/dashboard/src/pages/auth/LoginPage.tsx
@@ -42,12 +42,12 @@ function LoginPage() {
 
   const loginSentinel = async () => {
     const redirect_url = window.location.origin + "/auth/login";
-    // Sentinel v5: openid for the canonical OIDC ID-token contract,
-    // profile/email so userinfo can echo standard claims (we still
-    // pull the full profile from /api/users/:id), and user:read so
-    // /api/users/:id self-lookups pass when the user later navigates
-    // to other admin-gated views.
-    const scope = "openid profile email user:read";
+    // Sentinel v5: user:read covers the /api/users/:id self-lookup,
+    // groups:read covers /api/users/:id/groups if a future flow needs
+    // it separately. We don't request openid/profile/email — Mapache
+    // doesn't call /api/oauth/userinfo, it fetches the full profile
+    // (groups inline) straight from /api/users/:id.
+    const scope = "user:read groups:read";
     let oauthUrl = `${SENTINEL_OAUTH_BASE_URL}?client_id=${SENTINEL_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirect_url)}&scope=${encodeURIComponent(scope)}&prompt=none`;
     const route = queryParameters.get("route");
     if (route) {

--- a/dashboard/src/pages/auth/LoginPage.tsx
+++ b/dashboard/src/pages/auth/LoginPage.tsx
@@ -42,7 +42,12 @@ function LoginPage() {
 
   const loginSentinel = async () => {
     const redirect_url = window.location.origin + "/auth/login";
-    const scope = "user:read";
+    // Sentinel v5: openid for the canonical OIDC ID-token contract,
+    // profile/email so userinfo can echo standard claims (we still
+    // pull the full profile from /api/users/:id), and user:read so
+    // /api/users/:id self-lookups pass when the user later navigates
+    // to other admin-gated views.
+    const scope = "openid profile email user:read";
     let oauthUrl = `${SENTINEL_OAUTH_BASE_URL}?client_id=${SENTINEL_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirect_url)}&scope=${encodeURIComponent(scope)}&prompt=none`;
     const route = queryParameters.get("route");
     if (route) {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,12 +47,10 @@ services:
       KERBECS_USER: "admin"
       KERBECS_PASSWORD: "admin"
       SENTINEL_URL: ${SENTINEL_URL}
-      SENTINEL_JWKS_URL: ${SENTINEL_JWKS_URL}
       SENTINEL_CLIENT_ID: ${SENTINEL_CLIENT_ID}
       SENTINEL_CLIENT_SECRET: ${SENTINEL_CLIENT_SECRET}
-      SENTINEL_TOKEN: ${SENTINEL_TOKEN}
+      SENTINEL_SA_TOKEN: ${SENTINEL_SA_TOKEN}
       SENTINEL_REDIRECT_URI: ${SENTINEL_REDIRECT_URI}
-      SKIP_AUTH_CHECK: "true"
 
   vehicle:
     container_name: mapache-vehicle
@@ -170,9 +168,7 @@ services:
       KERBECS_USER: "admin"
       KERBECS_PASSWORD: "admin"
       SENTINEL_URL: ${SENTINEL_URL}
-      SENTINEL_JWKS_URL: ${SENTINEL_JWKS_URL}
       SENTINEL_CLIENT_ID: ${SENTINEL_CLIENT_ID}
-      SKIP_AUTH_CHECK: "true"
 
   foreman:
     container_name: mapache-foreman
@@ -209,7 +205,6 @@ services:
       VITE_BACKEND_WS_URL: "ws://localhost:10310/api"
       VITE_SENTINEL_CLIENT_ID: ${SENTINEL_CLIENT_ID}
       VITE_MAPBOX_ACCESS_TOKEN: ${MAPBOX_ACCESS_TOKEN}
-      VITE_SKIP_AUTH_CHECK: "true"
 
   nanomq:
     container_name: mapache-nanomq

--- a/example.env
+++ b/example.env
@@ -14,11 +14,15 @@ CLICKHOUSE_USER="default"
 CLICKHOUSE_PASSWORD=""
 CLICKHOUSE_DATABASE="mapache"
 
-SENTINEL_URL="https://sentinel-api.gauchoracing.com"
-SENTINEL_JWKS_URL="https://sso.gauchoracing.com/.well-known/jwks.json"
-SENTINEL_CLIENT_ID="z6V9NREjMFhf"
+# Sentinel v5. Local dev validates tokens against prod Sentinel; the
+# client_id/secret below come from the "Mapache" application's page on
+# https://sentinel-v5.gauchoracing.com/applications, and the SA token
+# from a service account on that same application. The redirect_uri
+# must be registered on the client (Sentinel rejects mismatched URIs).
+SENTINEL_URL="https://sentinel-v5.gauchoracing.com"
+SENTINEL_CLIENT_ID=""
 SENTINEL_CLIENT_SECRET=""
-SENTINEL_TOKEN=""
+SENTINEL_SA_TOKEN=""
 SENTINEL_REDIRECT_URI="http://localhost:5173/auth/login"
 
 MAPBOX_ACCESS_TOKEN=""

--- a/example.env
+++ b/example.env
@@ -23,7 +23,7 @@ SENTINEL_URL="https://sentinel-v5.gauchoracing.com"
 SENTINEL_CLIENT_ID=""
 SENTINEL_CLIENT_SECRET=""
 SENTINEL_SA_TOKEN=""
-SENTINEL_REDIRECT_URI="http://localhost:5173/auth/login"
+SENTINEL_REDIRECT_URI="http://localhost:10310/auth/login"
 
 MAPBOX_ACCESS_TOKEN=""
 

--- a/query/query/config/config.py
+++ b/query/query/config/config.py
@@ -29,11 +29,13 @@ class Config:
     KERBECS_USER: str = os.getenv('KERBECS_USER')
     KERBECS_PASSWORD: str = os.getenv('KERBECS_PASSWORD')
 
-    # Auth settings
+    # Auth settings. Sentinel v5 hosts JWKS at /api/core/keys under
+    # SENTINEL_URL, so the separate JWKS env var is gone — main.py derives
+    # the path. The issuer is fixed in v5; see SENTINEL_ISSUER below.
     SKIP_AUTH_CHECK: bool = os.getenv('SKIP_AUTH_CHECK', 'false').lower() == 'true'
     SENTINEL_URL: str = os.getenv('SENTINEL_URL')
-    SENTINEL_JWKS_URL: str = os.getenv('SENTINEL_JWKS_URL')
     SENTINEL_CLIENT_ID: str = os.getenv('SENTINEL_CLIENT_ID')
+    SENTINEL_ISSUER: str = 'https://sentinel-v5.gauchoracing.com'
 
     @staticmethod
     def get_database_url() -> URL:

--- a/query/query/main.py
+++ b/query/query/main.py
@@ -30,8 +30,8 @@ async def lifespan(app: FastAPI):
         logger.warning("SKIP_AUTH_CHECK is enabled, skipping Sentinel initialization")
     else:
         AuthService.configure(
-            jwks_url=Config.SENTINEL_JWKS_URL,
-            issuer="https://sso.gauchoracing.com",
+            jwks_url=f"{Config.SENTINEL_URL}/api/core/keys",
+            issuer=Config.SENTINEL_ISSUER,
             audience=Config.SENTINEL_CLIENT_ID,
         )
     yield

--- a/query/query/service/auth_guard.py
+++ b/query/query/service/auth_guard.py
@@ -20,6 +20,15 @@ def require_user(authorization: str | None = Header(None)) -> str:
             detail="you are not authorized to access this resource",
         )
     token = authorization.split("Bearer ")[1]
-    user_id = AuthService.get_user_id_from_token(token)
+    try:
+        user_id = AuthService.get_user_id_from_token(token)
+    except Exception as e:
+        # AuthService raises bare Exception for expired / malformed /
+        # bad-issuer tokens. Surface those as 401 so the dashboard's
+        # checkCredentials() can catch them and bounce to login —
+        # bare Exception otherwise becomes a 500 via FastAPI's default
+        # handler, which looks like a server bug.
+        logger.warning(f"Token verification failed: {e}")
+        raise HTTPException(status_code=401, detail=str(e))
     logger.info(f"Successfully authenticated user: {user_id}")
     return user_id


### PR DESCRIPTION
- Backend `auth/` and the dashboard now talk to Sentinel v5 (new base URL, /api/ prefixed paths, OIDC-canonical scopes, entity/user model, group-based gating).
- Token validation supports JWKS rotation (lookup by `kid`), pulls the v5 `user_id` custom claim, and switches the issuer to `https://sentinel-v5.gauchoracing.com`.
- v5 has no `/users/@me`; `GetCurrentUser` now hits `/api/users/:user_id` with the user's own bearer (the self-id branch of the gate satisfies it).
- Backend admin lookups (`GetAllUsers`, `GetUser`) use a new `SENTINEL_SA_TOKEN` — a pre-issued service account JWT — replacing the v4 static `SENTINEL_TOKEN`.
- Sentinel v5 returns errors as `{"error": "..."}` (not v4's `{"message": "..."}`); `SentinelError`'s JSON tag updated to match so error messages actually surface.
- Dropped v4-only dead code: `User.Roles[]`, `User.Subteams[]`, `Subteam`, `IsAdmin/IsOfficer/IsLead/IsInnerCircle/HasRole/HasSubteam/RequestUserHasRole`. Zero callers in the repo.
- Added `User.Groups: []string` and a single `HasGroup(name)` helper. Group names match exactly what the Sentinel v5 UI displays (e.g. `Admins`).
- Dashboard login scope expanded from `user:read` to `openid profile email user:read`. Profile link in the header points at v5's `/settings` (no per-user edit page exists in v5).

## Required env at deploy

\`\`\`
SENTINEL_URL=https://sentinel-v5.gauchoracing.com
SENTINEL_CLIENT_ID=<v5 OAuth client id>
SENTINEL_CLIENT_SECRET=<v5 OAuth client secret>
SENTINEL_REDIRECT_URI=https://mapache.gauchoracing.com/auth/login
SENTINEL_SA_TOKEN=<service account JWT issued to Mapache's v5 app>
VITE_SENTINEL_CLIENT_ID=<same as SENTINEL_CLIENT_ID, baked into dashboard at build time>
\`\`\`

`SENTINEL_JWKS_URL` and `SENTINEL_TOKEN` env vars go away; rip them out of infra at deploy time.

## Pre-merge checklist (your side)

- [ ] Register Mapache as an application in Sentinel v5 (client_id + secret + the redirect_uri above)
- [ ] Create a service account on that application and grab its single JWT for `SENTINEL_SA_TOKEN`
- [ ] Patch the prod Mapache secrets with the four `SENTINEL_*` values + `VITE_SENTINEL_CLIENT_ID`
- [ ] Smoke-test the login round-trip on a deploy preview (or a v5 dev login against staging)

## Out of scope

- Refresh-token flow (Mapache doesn't refresh today either)
- Access-gate enforcement (gating who can log in at all — would require linking Mapache to a Sentinel group)
- Any in-cluster wiring; this PR is code-only, infra/secrets land separately