### PR TITLE
fix(sessions): repair dashboard build in session editor

### DIFF
--- a/dashboard/src/pages/sessions/SessionEditorPage.tsx
+++ b/dashboard/src/pages/sessions/SessionEditorPage.tsx
@@ -556,11 +556,15 @@ export function SessionEditorPage() {
               end_time: tsToIso(cropEndTs),
             }
           : session;
-      const updated = await saveSessionAnalysis(windowed, buildPayload());
-      if (lapResult && lapResult.lapCount > 0) {
-        const laps = deriveLapInputs(lapResult, croppedPoints);
-        await saveSessionLaps(updated.id, laps);
-      }
+      const laps =
+        lapResult && lapResult.lapCount > 0
+          ? deriveLapInputs(lapResult, croppedPoints)
+          : [];
+      const updated = await saveSessionAnalysisWithLaps(
+        windowed,
+        buildPayload(),
+        laps,
+      );
       notify.success(`Saved analysis for ${updated.name}`);
       navigate(`/sessions/${updated.id}`);
     } catch (e) {


### PR DESCRIPTION
- `persistAndNavigate` in `SessionEditorPage.tsx` still called the removed `saveSessionAnalysis` / `saveSessionLaps` helpers, breaking `tsc` (TS2304/TS2552) and the unused import (TS6133) — main does not build
- Collapse the two-step save into the single transactional `saveSessionAnalysisWithLaps` call the import already references
- Verified `npm run build` passes clean off `origin/main`