### PR TITLE
feat(gr26/ingest): register DCDC status message decoder

### DIFF
--- a/gr26/model/message.go
+++ b/gr26/model/message.go
@@ -24,6 +24,8 @@ var messageMap = map[int]mp.Message{
 	0x00F: BCUCellData3,
 	0x010: BCUCellData4,
 	0x011: BCUCellData5,
+	// DCDC (GRCAN node 0x2A, frame 0x2A01202 → msgID 0x012)
+	0x012: DCDCStatus,
 	// GR Inverter
 	0x013: InverterStatus1,
 	0x014: InverterStatus2,


### PR DESCRIPTION
- Register `0x012: DCDCStatus` in `gr26/model/message.go` so DCDC frames are decoded
- DCDC publishes GRCAN node `0x2A`, frame `0x2A01202` → msgID `0x012` (the value Mapache routes on)
- Without this, DCDC frames hit the `unknown_can_id` path and no `dcdc_*` signals are produced
- Pairs with Gaucho-Racing/TCM-26 change adding `0x2A: "dcdc"` to the publisher's nodeIDMap