### PR TITLE
chore(deploy): fetch infra PR token from Vault, match sentinel PR format

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,12 @@ run-name: Open infrastructure PR for ${{ github.event.release.tag_name }}
 # bumps the mapache service image tags to the new version. Fires on the
 # release event (not tag push) so it only ever runs for real releases.
 #
-# Requires repo secret INFRA_PR_TOKEN: a PAT (or GitHub App token) with
-# contents:write + pull-requests:write on Gaucho-Racing/infrastructure. The
-# default GITHUB_TOKEN can't write to another repo.
+# The infra PR token is stored in Vault (app-secret `infrastructure`,
+# field `pr_token`) and fetched at runtime by vault-pull-secrets using
+# the workflow's GitHub OIDC identity — no long-lived repo secret. The
+# token is a PAT with contents:write + pull-requests:write on
+# Gaucho-Racing/infrastructure. The default GITHUB_TOKEN can't write to
+# another repo.
 on:
   release:
     types: [published]
@@ -27,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write        # for Vault OIDC auth via vault-pull-secrets
     steps:
       - name: Checkout mapache (full history + tags)
         uses: actions/checkout@v4
@@ -34,11 +38,17 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Pull secrets
+        id: vault
+        uses: Gaucho-Racing/vault-pull-secrets@v1
+        with:
+          secrets: infrastructure.pr_token
+
       - name: Checkout infrastructure
         uses: actions/checkout@v4
         with:
           repository: ${{ env.INFRA_REPO }}
-          token: ${{ secrets.INFRA_PR_TOKEN }}
+          token: ${{ fromJSON(steps.vault.outputs.secrets_json).PR_TOKEN }}
           path: infra
 
       - name: Resolve versions
@@ -116,6 +126,8 @@ jobs:
               emit_commits -20 "$NEW_TAG"
             fi
             echo
+            echo "**[Click here to view all changes →](https://github.com/${MAPACHE_REPO}/compare/${OLD_TAG}...${NEW_TAG})**"
+            echo
             echo "---"
             echo "_Opened automatically by the \`deploy\` workflow on release ${NEW_TAG}._"
           } > "$RUNNER_TEMP/pr-body.md"
@@ -125,15 +137,20 @@ jobs:
         if: steps.versions.outputs.skip == 'false'
         working-directory: infra
         env:
-          GH_TOKEN: ${{ secrets.INFRA_PR_TOKEN }}
+          GH_TOKEN: ${{ fromJSON(steps.vault.outputs.secrets_json).PR_TOKEN }}
           NEW: ${{ steps.versions.outputs.new }}
           NEW_TAG: ${{ steps.versions.outputs.new_tag }}
           SHORT_SHA: ${{ steps.versions.outputs.short_sha }}
           RELEASE_AUTHOR: ${{ github.event.release.author.login }}
         run: |
           BRANCH="bot/bump-mapache-${NEW}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Attribute the commit to the gauchoracing service account (matches
+          # the PAT this job uses) so both the commit and the PR opener show
+          # as @gauchoracing in the infra repo, not github-actions[bot].
+          # team@gauchoracing.com is verified on the account, so GitHub
+          # links the commit to @gauchoracing automatically.
+          git config user.name "GR Admin"
+          git config user.email "team@gauchoracing.com"
           git switch -C "$BRANCH"
           git commit -am "Deploy: mapache to ${NEW_TAG} (${SHORT_SHA})"
           git push -f -u origin "$BRANCH"


### PR DESCRIPTION
- Fetch the infrastructure PR token from Vault at runtime via `Gaucho-Racing/vault-pull-secrets@v1` instead of the `INFRA_PR_TOKEN` repo secret
- Add the `Click here to view all changes` compare link to the generated PR body
- Attribute the deploy commit to @gauchoracing rather than github-actions[bot]

Brings `deploy.yml` in line with Sentinel's, which already made all three changes (Sentinel #100, #101).

**Why now**

The v3.9.7 deploy run failed at `Checkout infrastructure` with `Input required and not supplied: token` — `INFRA_PR_TOKEN` does not exist as a repo secret or an org secret. It existed for v3.9.6 in June, so the PAT most likely expired and the secret was removed. Sourcing from Vault removes the recurring expiry problem rather than re-adding a secret that will lapse again.

**Requires a Vault rule before this works**

vault-pull-secrets authorizes on repository, Git ref, and requested selector. A GitHub Actions rule in Vault settings has to allow `Gaucho-Racing/Mapache` to read `infrastructure.pr_token` — the Sentinel rule does not cover this repo. Without it the `Pull secrets` step fails and the run stops there, same as it does today.

**Notes**

- Selector `infrastructure.pr_token` maps to `PR_TOKEN` per the action's naming (app prefix dropped, field uppercased), read via `fromJSON(steps.vault.outputs.secrets_json).PR_TOKEN`.
- `id-token: write` added to the job so the runner can mint the OIDC token.
- `KUSTOMIZATION` keeps the repo-relative form from the previous PR rather than Sentinel's `infra/`-prefixed variable. Sentinel still hardcodes the bare path a second time in its diff step, which is how its two copies drifted apart; keeping one source avoids that.