### PR TITLE
ci: wire p987 into the build, release, and deploy automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: build
 run-name: Check Mapache service builds
 
-# Aggregates the six per-service image builds into one check so branch
+# Aggregates the per-service image builds into one check so branch
 # protection has a single required status to gate on.
 #
 # Only the image builds are waited on. mapache-go / mapache-py run on
@@ -95,4 +95,5 @@ jobs:
           wait_for_workflow "gr26" "gr26.yml"
           wait_for_workflow "live" "live.yml"
           wait_for_workflow "query" "query.yml"
+          wait_for_workflow "p987" "p987.yml"
           wait_for_workflow "dashboard" "dashboard.yml"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
           # Surgically rewrite the newTag of each mapache/* image only, leaving
           # kerbecs and all comments/formatting untouched for a clean diff.
           awk -v new="$NEW" '
-            $0 ~ "- name: ghcr.io/gaucho-racing/mapache/(auth|vehicle|gr26|live|query|dashboard)$" { inmap=1; print; next }
+            $0 ~ "- name: ghcr.io/gaucho-racing/mapache/(auth|vehicle|gr26|p987|live|query|dashboard)$" { inmap=1; print; next }
             inmap==1 && $1=="newTag:" { sub(/newTag:[[:space:]]*.*/, "newTag: " new); inmap=0 }
             { print }
           ' "infra/$KUSTOMIZATION" > "infra/$KUSTOMIZATION.tmp" && mv "infra/$KUSTOMIZATION.tmp" "infra/$KUSTOMIZATION"

--- a/auth/config/config.go
+++ b/auth/config/config.go
@@ -21,7 +21,7 @@ func (s ServiceInfo) PathPrefix() string {
 
 var Service = ServiceInfo{
 	Name:    "Auth",
-	Version:     "3.9.9",
+	Version: "3.9.9",
 }
 
 var SkipAuthCheck = os.Getenv("SKIP_AUTH_CHECK") == "true"

--- a/gr26/config/config.go
+++ b/gr26/config/config.go
@@ -21,7 +21,7 @@ func (s ServiceInfo) PathPrefix() string {
 
 var Service = ServiceInfo{
 	Name:    "GR26",
-	Version:     "3.9.9",
+	Version: "3.9.9",
 }
 
 var SkipAuthCheck = os.Getenv("SKIP_AUTH_CHECK") == "true"

--- a/live/config/config.go
+++ b/live/config/config.go
@@ -21,7 +21,7 @@ func (s ServiceInfo) PathPrefix() string {
 
 var Service = ServiceInfo{
 	Name:    "Live",
-	Version:     "3.9.9",
+	Version: "3.9.9",
 }
 
 var Env = os.Getenv("ENV")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -331,7 +331,7 @@ case "$TARGET" in
         fi
 
         for svc in "${GO_CONFIG_SERVICES[@]}"; do
-            sed -i '' "s/Version:.*\".*\"/Version:     \"${SEMVER}\"/" "${REPO_ROOT}/${svc}/config/config.go"
+            sed -i '' "s/Version:.*\".*\"/Version: \"${SEMVER}\"/" "${REPO_ROOT}/${svc}/config/config.go"
         done
         for svc in "${PY_SERVICES[@]}"; do
             sed -i '' "s/^version = \".*\"/version = \"${SEMVER}\"/" "${REPO_ROOT}/${svc}/pyproject.toml"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 #       every dependent Go service and pushes a chore commit.
 #
 #   ./scripts/release.sh 3.1.0                  (default -t mapache)
-#       Cuts the services release (auth/gr26/live/vehicle/query). Bumps each
+#       Cuts the services release (auth/gr26/p987/live/vehicle/query). Bumps each
 #       service's Version constant or pyproject.toml, commits, tags v3.1.0,
 #       and lets the per-service workflows publish images.
 #
@@ -27,7 +27,7 @@ usage() {
 Usage: $0 [-t target] <version>
 
 Targets:
-  mapache       services (auth, gr26, live, vehicle, query) — default
+  mapache       services (auth, gr26, p987, live, vehicle, query) — default
   mapache-py    Python library; also bumps lockfiles in dependent services
   mapache-go    Go library; also bumps go.mod in dependent services
 
@@ -227,7 +227,7 @@ case "$TARGET" in
             exit 1
         fi
 
-        GO_DEPENDENTS=("gr26" "live" "vehicle")
+        GO_DEPENDENTS=("gr26" "p987" "live" "vehicle")
 
         echo ""
         echo "=== Release Summary ==="
@@ -295,7 +295,7 @@ case "$TARGET" in
             exit 1
         fi
 
-        GO_CONFIG_SERVICES=("auth" "gr26" "live" "vehicle")
+        GO_CONFIG_SERVICES=("auth" "gr26" "p987" "live" "vehicle")
         PY_SERVICES=("query")
         NODE_SERVICES=("dashboard")
         ALL_SERVICES=("${GO_CONFIG_SERVICES[@]}" "${PY_SERVICES[@]}" "${NODE_SERVICES[@]}")

--- a/vehicle/config/config.go
+++ b/vehicle/config/config.go
@@ -21,7 +21,7 @@ func (s ServiceInfo) PathPrefix() string {
 
 var Service = ServiceInfo{
 	Name:    "Vehicle",
-	Version:     "3.9.9",
+	Version: "3.9.9",
 }
 
 var Env = os.Getenv("ENV")


### PR DESCRIPTION
p987 merged but wasn't hooked into any of the release machinery, so it would have been skipped by every automated step.

- `build.yml` — add `p987` to the aggregate build check, which waited on six services and would not have caught a p987 image failure
- `deploy.yml` — add `p987` to the release tag-bump allowlist. That awk matches an explicit image list rather than `mapache/*`, so without this its pin in the infra kustomization would never move while every other service advanced
- `scripts/release.sh` — add `p987` to `GO_CONFIG_SERVICES` so a services release bumps its `Version` constant and tags its image, and to `GO_DEPENDENTS` so a mapache-go release bumps its dependency too

Last commit is separable cleanup: the release sed rewrote the `Version` line with a hardcoded five-space gap that gofmt collapses to one, so every release left all four Go service configs unformatted. Fixed the replacement and reformatted the already-affected files. Drop that commit if you'd rather keep the diff to p987 alone.

Verified the sed against p987's config (its field alignment differs from the others) — it matches and bumps correctly, and all five services still build.

Pairs with Gaucho-Racing/infrastructure#166, which pins p987 at `:latest` until the next release gives it a real version.