### PR TITLE
ci: list p987 in the deploy PR changelog

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ env:
   # Path within the infrastructure repo, which is checked out into ./infra —
   # prefix with infra/ for filesystem access, use bare for `git -C infra`.
   KUSTOMIZATION: kubernetes/gr-foundry/manifests/mapache/kustomization.yaml
-  SERVICES: "auth vehicle gr26 live query dashboard"
+  SERVICES: "auth vehicle gr26 p987 live query dashboard"
 
 jobs:
   infra-pr:


### PR DESCRIPTION
Follow-up to #227. `SERVICES` drives the bullet list in the auto-opened infra PR body and is separate from the awk allowlist that does the actual tag rewrite — so p987 would have been bumped without being listed.

Cosmetic only; no effect on which images get bumped.